### PR TITLE
linux-nilrt: Update SRC_URI, branches

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-debug_3.14.bb
+++ b/recipes-kernel/linux/linux-nilrt-debug_3.14.bb
@@ -6,7 +6,7 @@ require linux-nilrt-squashfs.inc
 NI_RELEASE_VERSION = "15.0"
 LINUX_VERSION = "3.14"
 LINUX_VERSION_EXTENSION = "-nilrt-debug"
-KBRANCH = "nilrt/${NI_RELEASE_VERSION}/${LINUX_VERSION}"
+KBRANCH = "nilrt_pub/${NI_RELEASE_VERSION}/${LINUX_VERSION}"
 
 KERNEL_MODULES_META_PACKAGE = "kernel-modules-debug"
 KERNEL_MODULE_PACKAGE_NAME_PREPEND = "kernel-module-debug"

--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -5,7 +5,7 @@ require recipes-kernel/linux/linux-yocto.inc
 # link against the gcc provided runtime
 do_kernel_configme[depends] += "libgcc:do_populate_sysroot"
 
-SRC_URI = "git://git.amer.corp.natinst.com/linux.git;protocol=git;nocheckout=1;branch=${KBRANCH}"
+SRC_URI = "git://github.com/ni/linux.git;protocol=git;nocheckout=1;branch=${KBRANCH}"
 SRCREV="${AUTOREV}"
 PV = "${LINUX_VERSION}+git${SRCPV}"
 

--- a/recipes-kernel/linux/linux-nilrt_3.14.bb
+++ b/recipes-kernel/linux/linux-nilrt_3.14.bb
@@ -5,7 +5,7 @@ require linux-nilrt.inc
 NI_RELEASE_VERSION = "15.0"
 LINUX_VERSION = "3.14"
 LINUX_VERSION_EXTENSION = "-nilrt"
-KBRANCH = "nilrt/${NI_RELEASE_VERSION}/${LINUX_VERSION}"
+KBRANCH = "nilrt_pub/${NI_RELEASE_VERSION}/${LINUX_VERSION}"
 
 # Subfolder of the same name will be added to FILESEXTRAPATHS and also
 # used for nilrt-specific defconfig manipulation during build. Provide


### PR DESCRIPTION
Now that the 2015 kernel source is hosted in github, update the
SRC_URI as well as the branches to reflect the new location.

Signed-off-by: Brad Mouring brad.mouring@ni.com
