### PR TITLE
Nilrt pub/17.0/krogoth

### DIFF
--- a/recipes-connectivity/python-salttesting/python-salttesting_%.bbappend
+++ b/recipes-connectivity/python-salttesting/python-salttesting_%.bbappend
@@ -1,0 +1,7 @@
+SRC_URI = "${NILRT_GIT}/python-salttesting.git;protocol=git;branch=nilrt/cardassia/develop \
+           file://0001-Add-ptest-output-option-to-test-suite.patch \
+           "
+
+SRCREV = "${AUTOREV}"
+PV = "2016.7.22+git${SRCPV}"
+S = "${WORKDIR}/git"

--- a/recipes-connectivity/python-salttesting/python-salttesting_%.bbappend
+++ b/recipes-connectivity/python-salttesting/python-salttesting_%.bbappend
@@ -1,7 +1,7 @@
-SRC_URI = "${NILRT_GIT}/python-salttesting.git;protocol=git;branch=nilrt/cardassia/develop \
+SRC_URI = "git://github.com/saltstack/salt-testing;protocol=git;branch=develop \
            file://0001-Add-ptest-output-option-to-test-suite.patch \
            "
 
-SRCREV = "${AUTOREV}"
+SRCREV = "095e9020b033c63b21fceba5bae9fa013dc52789"
 PV = "2016.7.22+git${SRCPV}"
 S = "${WORKDIR}/git"

--- a/recipes-connectivity/salt/files/run-ptest
+++ b/recipes-connectivity/salt/files/run-ptest
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+python /usr/lib/python2.7/site-packages/salt-tests/tests/runtests.py \
+    --ptest-out \
+    --transport=tcp \
+    --run-destructive \
+    -n integration.modules.system \
+    -n integration.modules.timezone \
+    -n integration.modules.shadow \
+    -n integration.states.user \
+    -n integration.modules.groupadd \
+
+

--- a/recipes-connectivity/salt/files/salt-common.logrotate
+++ b/recipes-connectivity/salt/files/salt-common.logrotate
@@ -1,0 +1,8 @@
+/var/log/salt/master
+/var/log/salt/minion
+/var/log/salt/*.log
+{
+	daily
+	size 50k
+	notifempty
+}

--- a/recipes-connectivity/salt/salt_2016.11.%.bbappend
+++ b/recipes-connectivity/salt/salt_2016.11.%.bbappend
@@ -1,0 +1,44 @@
+LIC_FILES_CHKSUM = "file://LICENSE;md5=fb92f464675f6b5df90f540d60237915"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI = "${NILRT_GIT}/salt.git;protocol=git;branch=nilrt/cardassia/2016.11 \
+           file://set_python_location_hashbang.patch \
+           file://minion \
+           file://salt-minion \
+           file://salt-common.bash_completion \
+           file://salt-common.logrotate \
+           file://salt-api \
+           file://salt-master \
+           file://master \
+           file://salt-syndic \
+           file://cloud \
+           file://roster \
+           file://run-ptest \
+"
+
+SRCREV = "${AUTOREV}"
+PV = "2016.11+git${SRCPV}"
+
+S="${WORKDIR}/git"
+
+PACKAGECONFIG = "tcp"
+
+RDEPENDS_${PN}-minion = "python ${PN}-common (= ${EXTENDPKGV}) python-msgpack python-avahi python-pyinotify python-pyroute2 python-pycrypto python-pika"
+RDEPENDS_${PN}-common = "python python-jinja2 python-pyyaml python-tornado (>= 4.2.1)"
+RDEPENDS_${PN}-ssh = "python ${PN}-common (= ${EXTENDPKGV}) python-msgpack"
+RDEPENDS_${PN}-api = "python ${PN}-master"
+RDEPENDS_${PN}-master = "python ${PN}-common (= ${EXTENDPKGV}) python-msgpack python-pycrypto"
+RDEPENDS_${PN}-syndic = "python ${PN}-master (= ${EXTENDPKGV})"
+RDEPENDS_${PN}-cloud = "python ${PN}-common (= ${EXTENDPKGV})"
+RDEPENDS_${PN}-tests += "python-pyzmq python-six python-image"
+RDEPENDS_${PN}-ptest += "salt-tests"
+# Note that the salt test suite (salt-tests) require python-pyzmq to run
+# properly even though we run them in tcp mode
+
+inherit update-rc.d ptest
+INITSCRIPT_PARAMS_${PN}-minion = "defaults 25 25"
+
+do_install_ptest_append() {
+    install -m 0755 ${WORKDIR}/run-ptest ${D}${PTEST_PATH}
+}

--- a/recipes-devtools/python/python-requests_2%.bbappend
+++ b/recipes-devtools/python/python-requests_2%.bbappend
@@ -1,0 +1,1 @@
+SRC_URI = "https://pypi.python.org/packages/source/r/requests/${SRCNAME}-${PV}.tar.gz"


### PR DESCRIPTION
While testing this out, I stumbled across something that will need to be fixed upstream as well (exists at least in pyro as well), namely the http:// URIs for pypi sources.

When fixed, we can revert 83efda5  (python-requests: bbappend for http->https SRC_URI ) and cherry-pick fixes as appropriate in other layers.