### PR TITLE
NILRT_GIT isn't publicly available for librtpi

### DIFF
--- a/recipes-rt/librtpi/librtpi_0.0.1.bb
+++ b/recipes-rt/librtpi/librtpi_0.0.1.bb
@@ -5,10 +5,10 @@ DEPENDS = ""
 LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1803fa9c2c3ce8cb06b4861d75310742"
 
-SRC_URI = "${NILRT_GIT}/librtpi.git;branch=gratian/latest"
+SRC_URI = "git://github.com/dvhart/librtpi.git"
 
 PV = "0.0.1+git${SRCPV}"
-SRCREV="558653f9fd48ec755d8feca7bce3cd7824018d9b"
+SRCREV="37a96aa7da7d9873b982e84d57b150423c0a0e60"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
The git repository pointed at by meta-nilrt/recipes-rt/librtpi/librtpi_0.0.1.bb does not appear to exist or is not publicly available.  This changes allows builds to complete.