### PR TITLE
Updated /var/cache to a non-volatile storage location.

### DIFF
--- a/recipes-core/base-files/base-files_3.0.14.bbappend
+++ b/recipes-core/base-files/base-files_3.0.14.bbappend
@@ -35,11 +35,6 @@ do_install_append () {
 	install ${WORKDIR}/safemode-ps1.sh ${D}${sysconfdir}/profile.d/
 
 	install -d ${D}${sysconfdir}/default/volatiles/
-	echo "d root root 0755 /var/volatile/cache none" \
-		>> ${D}${sysconfdir}/default/volatiles/10_varcache
-	echo "l root root 0755 /var/cache /var/volatile/cache" \
-		>> ${D}${sysconfdir}/default/volatiles/10_varcache
-
 	echo "d ${LVRT_USER} ${LVRT_GROUP} 0775 /run/natinst none" \
 		>> ${D}${sysconfdir}/default/volatiles/20_run_natinst
 }

--- a/recipes-ni/initscripts-nilrt/files/cleanvarcache
+++ b/recipes-ni/initscripts-nilrt/files/cleanvarcache
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+CACHE_DIR=/var/cache
+
+if [ -d $CACHE_DIR ]; then
+	echo Cleaning up the /var/cache directory
+	rm -rf $CACHE_DIR
+fi

--- a/recipes-ni/initscripts-nilrt/initscripts-nilrt_1.0.bb
+++ b/recipes-ni/initscripts-nilrt/initscripts-nilrt_1.0.bb
@@ -32,6 +32,7 @@ SRC_URI = "file://nisetbootmode \
            file://nisetupirqpriority \
            file://nipopulateconfigdir \
            file://run-ptest \
+           file://cleanvarcache \
 "
 
 SRC_URI_append_x64 = "file://nidisablecstates \
@@ -70,6 +71,7 @@ do_install () {
 	install -m 0755 ${WORKDIR}/nisetupkernelconfig   ${D}${sysconfdir}/init.d
 	install -m 0755 ${WORKDIR}/nisetcommitratio      ${D}${sysconfdir}/init.d
 	install -m 0755 ${WORKDIR}/wirelesssetdomain     ${D}${sysconfdir}/init.d
+	install -m 0755 ${WORKDIR}/cleanvarcache         ${D}${sysconfdir}/init.d
 	install -m 0755 ${S}/nisetupirqpriority          ${D}${sysconfdir}/init.d
 
 	install -d ${D}${sysconfdir}/natinst
@@ -85,6 +87,7 @@ do_install () {
 	update-rc.d -r ${D} nisetupkernelconfig   start 3  4 5 .
 	update-rc.d -r ${D} nisetcommitratio      start 99 S .
 	update-rc.d -r ${D} wirelesssetdomain     start 36 S .
+	update-rc.d -r ${D} cleanvarcache         start 38 0 6 S .
 
 	# only for nilrt-nxg, on older nilrt it's installed via p4
 	if ${@oe.utils.conditional('DISTRO', 'nilrt-nxg', 'true', 'false', d)}; then


### PR DESCRIPTION
AzDo work item [US1023816](https://ni.visualstudio.com/DevCentral/_workitems/edit/1023816).

Tested changes on a cRIO-9068 and cRIO-9037:
1. /var/cache was mounted on the root filesystem.
2. opkg was able to install software
2. /var/cache directory was cleaned up on shutdown and initialization during a reboot

@ni/rtos 