### PR TITLE
Remove DISTRO_FEATURES_LIBC

### DIFF
--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -4,9 +4,6 @@ TARGET_VENDOR = "-nilrt"
 
 GRUB_BRANCH = "nilrt/19.0"
 
-# Inherit the default LIBC features superset from OE-core
-DISTRO_FEATURES += "${DISTRO_FEATURES_LIBC}"
-
 # Common features enabled on all NILRT flavours
 DISTRO_FEATURES += "\
         argp \


### PR DESCRIPTION
> The DISTRO_FEATURES_LIBC variable is no longer used. Remove it from meta-nilrt/conf/distro/nilrt.inc
> 
> https://www.yoctoproject.org/docs/3.0.2/ref-manual/ref-manual.html


Requires verification be done later as discussed. I did not build dunfell.