### PR TITLE
Use kernel-devsrc to support building modules on target

### DIFF
--- a/recipes-core/packagegroups/packagegroup-kernel-module-build.bb
+++ b/recipes-core/packagegroups/packagegroup-kernel-module-build.bb
@@ -8,5 +8,6 @@ RDEPENDS_${PN} = "\
 	gcc \
 	gcc-symlinks \
 	kernel-dev \
+	kernel-devsrc \
 	make \
 	"

--- a/recipes-kernel/dkms/dkms_%.bbappend
+++ b/recipes-kernel/dkms/dkms_%.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS_${PN} += "kernel-devsrc"

--- a/recipes-kernel/linux/kernel-devsrc.bbappend
+++ b/recipes-kernel/linux/kernel-devsrc.bbappend
@@ -1,0 +1,5 @@
+pkg_postinst_ontarget_kernel-devsrc () {
+   cd /lib/modules/${KERNEL_VERSION}/build/scripts/mod
+   make prepare
+   make modules_prepare
+}

--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -77,9 +77,6 @@ FILES_${PN}-module-versioning-headers = "/kernel"
 do_install_append() {
 	export CROSS_COMPILE=${CROSS_COMPILE} ARCH=${ARCH} KBUILD_OUTPUT=${KBUILD_OUTPUT}
 
-	# for NXG NILRT install under /lib/modules/ to be included in kernel-dev pkg
-	${WORKDIR}/export-kernel-headers.sh ${S} ${D}${base_libdir}/modules/${KERNEL_VERSION}/build
-
 	# for older NILRT install under /kernel for inclusion in squashfs for backwards
 	# compatibility with non-standard Linux installs (non-dkms). This should go away
 	# and older NILRT should be migrated to kernel-dev + dkms in the future.
@@ -92,10 +89,4 @@ do_install_append() {
 				${D}/${KERNEL_IMAGEDEST}/${type}
 		done
 	fi
-}
-
-pkg_postinst_ontarget_kernel-dev () {
-	cd /lib/modules/${KERNEL_VERSION}/build/scripts/mod
-	mv ${HOST_PREFIX}elfconfig.h elfconfig.h
-	gcc -o modpost modpost.h modpost.c file2alias.c sumversion.c
 }


### PR DESCRIPTION
kernel-dev doesn't contain everything needed to build modules on target.
Notably, files needed for building tools/objtool aren't present preventing modules from getting built when elfutils-dev is installed.
kernel-devsrc already provides all files needed to build module on target but it can't be installed as there are conflicts
with kernel-dev.

The changes
1. Removes /lib/modules/<kernel>/build from kernel-dev.
2. Add kernel-devsrc to the distribution.
3. Add a postinst script to kernel-devsrc that prepares /lib/modules/<kernel>/build so external modules can be built.
4. Add kernel-devsrc as dependency to dkms.