### PR TITLE
kernel-tests: Add kernel performance ptests

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/common.cfg
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/common.cfg
@@ -4,3 +4,6 @@ TEST_DURATION=8h
 # Maximum expected latency in useconds.
 # The test will fail if cyclictest latency goes beyond this value.
 MAX_LATENCY=300
+
+# Location for benchmark logs and test results
+LOG_DIR="/var/local/ptest-results/kernel-performance-tests"

--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/common.cfg
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/common.cfg
@@ -1,0 +1,6 @@
+# Common configuration for all kernel performance tests
+TEST_DURATION=8h
+
+# Maximum expected latency in useconds.
+# The test will fail if cyclictest latency goes beyond this value.
+MAX_LATENCY=300

--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/fio.cfg
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/fio.cfg
@@ -1,5 +1,5 @@
 [global]
-directory=./.fio
+directory=/var/cache/fio
 numjobs=1
 size=100M
 nrfiles=20

--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/fio.cfg
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/fio.cfg
@@ -1,0 +1,15 @@
+[global]
+directory=./.fio
+numjobs=1
+size=100M
+nrfiles=20
+openfiles=10
+direct=0
+verify=sha256
+do_verify=1
+time_based
+clocksource=clock_gettime
+bs=5k
+
+[random_rw]
+rw=randrw

--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/iperf.cfg
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/iperf.cfg
@@ -1,0 +1,4 @@
+# Server configuration for iperf test
+#
+# IPERF_SERVER=foo
+# IPERF_PORT=5201

--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/run-cyclictest
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/run-cyclictest
@@ -1,0 +1,72 @@
+#!/bin/sh
+source ./common.cfg
+
+function add_system_info()
+{
+    {
+	DESC=$(fw_printenv DeviceDesc)
+	DEVICE=${DESC#*=}
+	echo "# Device: $DEVICE"
+
+	echo -n "# Kernel: "
+	uname -a
+
+	echo -n "# Kernel parameters: "
+	cat /proc/cmdline
+
+	# save info on the current security mitigations
+	echo "# Security vulnerabilities settings: "
+	if [ -d "/sys/devices/system/cpu/vulnerabilities" ]; then
+	    for f in  /sys/devices/system/cpu/vulnerabilities/*; do
+		VULN=$(basename "$f")
+		if [ -f "$f" ]; then
+		    echo -n -e "#     $VULN:\t"
+		    cat "$f"
+		fi
+	    done
+	else
+	    echo "#     vulnerability information not published"
+	fi
+
+	# save info on the current C state settings
+	echo "# C-states settings: "
+	for CPU in /sys/devices/system/cpu/cpu[0-9]; do
+	    NCPU=$(basename "$CPU")
+	    echo "#     [$NCPU]"
+	    for CSTATE in $CPU/cpuidle/state[0-9]; do
+		NSTATE=$(basename "$CSTATE")
+		if [ -f "$CSTATE/name" ] && [ -f "$CSTATE/disable" ]; then
+                    NAME=$(cat "$CSTATE/name" 2>/dev/null)
+                    STATUS=$(cat "$CSTATE/disable" 2>/dev/null)
+
+                    echo -n "#     $NSTATE: $NAME: "
+                    if [ "$STATUS" = "0" ]; then
+                        echo "enabled"
+                    else
+                        echo "disabled"
+                    fi
+		else
+                    echo "#     information not available"
+		fi
+	    done
+	done
+    } >> "$1"
+}
+
+function run_cyclictest()
+{
+    LOG="results/cyclictest-$1-`date +'%Y_%m_%d-%H_%M_%S'`.log"
+    cyclictest --smp --priority=98 --mlockall --notrace --interval=997 --quiet --duration="$TEST_DURATION" --histofall=1000 --histfile="$LOG" > /dev/null
+    add_system_info "$LOG"
+
+    LATENCY=$(grep -sw "# Max Latencies:" "$LOG" | awk '{max=$4; for(i=4; i<=NF; i++) if ($i>max) max=$i; gsub("^0*", "", max); print max}')
+    if [ "$LATENCY" -le "$MAX_LATENCY" ]; then
+	echo "PASS: cyclictest with $1 load, latency: $LATENCY (usec) is less than max latency: $MAX_LATENCY (usec)"
+	CYCLICTEST_RESULT=0
+    else
+	echo "FAIL: cyclictest with $1 load, latency: $LATENCY (usec) is above the expected max latency: $MAX_LATENCY (usec)"
+	CYCLICTEST_RESULT=1
+    fi
+}
+
+mkdir -p results

--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/run-cyclictest
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/run-cyclictest
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 source ./common.cfg
 
 function add_system_info()
@@ -55,18 +55,22 @@ function add_system_info()
 
 function run_cyclictest()
 {
-    LOG="results/cyclictest-$1-`date +'%Y_%m_%d-%H_%M_%S'`.log"
+    LOG="$LOG_DIR/cyclictest-$1-`date +'%Y_%m_%d-%H_%M_%S'`.log"
     cyclictest --smp --priority=98 --mlockall --notrace --interval=997 --quiet --duration="$TEST_DURATION" --histofall=1000 --histfile="$LOG" > /dev/null
     add_system_info "$LOG"
 
     LATENCY=$(grep -sw "# Max Latencies:" "$LOG" | awk '{max=$4; for(i=4; i<=NF; i++) if ($i>max) max=$i; gsub("^0*", "", max); print max}')
     if [ "$LATENCY" -le "$MAX_LATENCY" ]; then
-	echo "PASS: cyclictest with $1 load, latency: $LATENCY (usec) is less than max latency: $MAX_LATENCY (usec)"
+	echo "cyclictest with $1 load latency: $LATENCY (usec) is less than max latency: $MAX_LATENCY (usec)"
+	echo "histogram log file: $LOG"
+	echo "PASS: test_kernel_cyclictest_$1"
 	CYCLICTEST_RESULT=0
     else
-	echo "FAIL: cyclictest with $1 load, latency: $LATENCY (usec) is above the expected max latency: $MAX_LATENCY (usec)"
+	echo "cyclictest with $1 load latency: $LATENCY (usec) is above the expected max latency: $MAX_LATENCY (usec)"
+	echo "histogram log file: $LOG"
+	echo "FAIL: test_kernel_cyclictest_$1"
 	CYCLICTEST_RESULT=1
     fi
 }
 
-mkdir -p results
+mkdir -p "$LOG_DIR"

--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/run-ptest
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/run-ptest
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+./test_kernel_cyclictest_idle.sh
+./test_kernel_cyclictest_hackbench.sh
+./test_kernel_cyclictest_fio.sh
+./test_kernel_cyclictest_iperf.sh
+exit 0

--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/run-ptest
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/run-ptest
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ./test_kernel_cyclictest_idle.sh
 ./test_kernel_cyclictest_hackbench.sh

--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/test_kernel_cyclictest_fio.sh
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/test_kernel_cyclictest_fio.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+source ./run-cyclictest
+
+# start background disk I/O load
+mkdir -p .fio
+fio fio.cfg --ioengine="sync" --runtime="$TEST_DURATION" --ramp_time=1m --output="results/fio-sync-`date +'%Y_%m_%d-%H_%M_%S'`.log" > /dev/null &
+
+# measure the system latency under disk load
+run_cyclictest "fio"
+
+# clean-up
+killall -INT fio > /dev/null 2>&1
+rm -rf .fio
+
+exit $CYCLICTEST_RESULT

--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/test_kernel_cyclictest_fio.sh
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/test_kernel_cyclictest_fio.sh
@@ -1,15 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 source ./run-cyclictest
 
 # start background disk I/O load
-mkdir -p .fio
-fio fio.cfg --ioengine="sync" --runtime="$TEST_DURATION" --ramp_time=1m --output="results/fio-sync-`date +'%Y_%m_%d-%H_%M_%S'`.log" > /dev/null &
+mkdir -p /var/cache/fio
+fio fio.cfg --ioengine="sync" --runtime="$TEST_DURATION" --ramp_time=1m --output="$LOG_DIR/fio-sync-`date +'%Y_%m_%d-%H_%M_%S'`.log" > /dev/null &
 
 # measure the system latency under disk load
 run_cyclictest "fio"
 
 # clean-up
 killall -INT fio > /dev/null 2>&1
-rm -rf .fio
+rm -rf /var/cache/fio
 
 exit $CYCLICTEST_RESULT

--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/test_kernel_cyclictest_hackbench.sh
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/test_kernel_cyclictest_hackbench.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+source ./run-cyclictest
+
+# start background scheduler load
+hackbench -l 36000000 -g 10 2>/dev/null >"results/hackbench-`date +'%Y_%m_%d-%H_%M_%S'`.log" &
+
+# measure the system latency under scheduler load
+run_cyclictest "hackbench"
+
+# clean-up
+killall -INT hackbench > /dev/null 2>&1
+
+exit $CYCLICTEST_RESULT

--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/test_kernel_cyclictest_hackbench.sh
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/test_kernel_cyclictest_hackbench.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 source ./run-cyclictest
 
 # start background scheduler load
-hackbench -l 36000000 -g 10 2>/dev/null >"results/hackbench-`date +'%Y_%m_%d-%H_%M_%S'`.log" &
+hackbench -l 36000000 -g 10 2>/dev/null >"$LOG_DIR/hackbench-`date +'%Y_%m_%d-%H_%M_%S'`.log" &
 
 # measure the system latency under scheduler load
 run_cyclictest "hackbench"

--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/test_kernel_cyclictest_idle.sh
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/test_kernel_cyclictest_idle.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 source ./run-cyclictest
 
 # measure the system latency with just background noise (i.e. idle system with no explicit load)

--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/test_kernel_cyclictest_idle.sh
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/test_kernel_cyclictest_idle.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+source ./run-cyclictest
+
+# measure the system latency with just background noise (i.e. idle system with no explicit load)
+run_cyclictest "idle"
+
+exit $CYCLICTEST_RESULT

--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/test_kernel_cyclictest_iperf.sh
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/test_kernel_cyclictest_iperf.sh
@@ -1,18 +1,19 @@
-#!/bin/sh
+#!/bin/bash
 source ./run-cyclictest
 
 # start background network load
 source ./iperf.cfg
 if [ -z "$IPERF_SERVER" ]; then
-    echo "SKIP: iperf server not configured, skipping iperf based network load test."
+    echo "Warning: iperf server not configured; skipping iperf based network load test."
     echo "Edit `pwd`/iperf.cfg file to configure a server to connect to for this test."
+    echo "SKIP: test_kernel_cyclictest_iperf"
     exit 77
 fi
 
 if [ ! -z "$IPERF_PORT" ]; then
-	iperf3 -c "$IPERF_SERVER" -p "$IPERF_PORT" -t 36000 --logfile "results/iperf-`date +'%Y_%m_%d-%H_%M_%S'`.log" &
+	iperf3 -c "$IPERF_SERVER" -p "$IPERF_PORT" -t 36000 --logfile "$LOG_DIR/iperf-`date +'%Y_%m_%d-%H_%M_%S'`.log" &
     else
-	iperf3 -c "$IPERF_SERVER" -t 36000 --logfile "results/iperf-`date +'%Y_%m_%d-%H_%M_%S'`.log" &
+	iperf3 -c "$IPERF_SERVER" -t 36000 --logfile "$LOG_DIR/iperf-`date +'%Y_%m_%d-%H_%M_%S'`.log" &
 fi
 
 # measure the system latency under network load

--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/test_kernel_cyclictest_iperf.sh
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/test_kernel_cyclictest_iperf.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+source ./run-cyclictest
+
+# start background network load
+source ./iperf.cfg
+if [ -z "$IPERF_SERVER" ]; then
+    echo "SKIP: iperf server not configured, skipping iperf based network load test."
+    echo "Edit `pwd`/iperf.cfg file to configure a server to connect to for this test."
+    exit 77
+fi
+
+if [ ! -z "$IPERF_PORT" ]; then
+	iperf3 -c "$IPERF_SERVER" -p "$IPERF_PORT" -t 36000 --logfile "results/iperf-`date +'%Y_%m_%d-%H_%M_%S'`.log" &
+    else
+	iperf3 -c "$IPERF_SERVER" -t 36000 --logfile "results/iperf-`date +'%Y_%m_%d-%H_%M_%S'`.log" &
+fi
+
+# measure the system latency under network load
+run_cyclictest "iperf"
+
+# clean-up
+killall -INT iperf3 > /dev/null 2>&1
+
+exit $CYCLICTEST_RESULT

--- a/recipes-kernel/kernel-tests/kernel-performance-tests.bb
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests.bb
@@ -2,7 +2,7 @@ SUMMARY = "Linux kernel-specific performance tests"
 HOMEPAGE = "https://kernel.org"
 SECTION = "tests"
 LICENSE = "GPLv2 & GPLv2+"
-LIC_FILES_CHKSUM = "file://run-ptest;md5=905781abd96c0213c8b5bfa6c0681dd3"
+LIC_FILES_CHKSUM = "file://run-ptest;md5=e6b9dbe04e1c3de85402b8167a279f76"
 
 inherit ptest
 
@@ -11,7 +11,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-files:"
 S = "${WORKDIR}"
 
 DEPENDS = "virtual/kernel"
-RDEPENDS_${PN}-ptest += "bash rt-tests fio iperf3"
+RDEPENDS_${PN}-ptest += "bash rt-tests fio iperf3 fw-printenv"
 
 ALLOW_EMPTY_${PN} = "1"
 

--- a/recipes-kernel/kernel-tests/kernel-performance-tests.bb
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests.bb
@@ -1,0 +1,42 @@
+SUMMARY = "Linux kernel-specific performance tests"
+HOMEPAGE = "https://kernel.org"
+SECTION = "tests"
+LICENSE = "GPLv2 & GPLv2+"
+LIC_FILES_CHKSUM = "file://run-ptest;md5=905781abd96c0213c8b5bfa6c0681dd3"
+
+inherit ptest
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-files:"
+
+S = "${WORKDIR}"
+
+DEPENDS = "virtual/kernel"
+RDEPENDS_${PN}-ptest += "bash rt-tests fio iperf3"
+
+ALLOW_EMPTY_${PN} = "1"
+
+SRC_URI += "\
+    file://run-ptest \
+    file://run-cyclictest \
+    file://common.cfg \
+    file://fio.cfg \
+    file://iperf.cfg \
+    file://test_kernel_cyclictest_idle.sh \
+    file://test_kernel_cyclictest_hackbench.sh \
+    file://test_kernel_cyclictest_fio.sh \
+    file://test_kernel_cyclictest_iperf.sh \
+"
+
+do_install_ptest_append() {
+    install -m 0755 ${S}/run-ptest ${D}${PTEST_PATH}
+    install -m 0755 ${S}/run-cyclictest ${D}${PTEST_PATH}
+    install -m 0644 ${S}/common.cfg ${D}${PTEST_PATH}
+    install -m 0644 ${S}/fio.cfg ${D}${PTEST_PATH}
+    install -m 0644 ${S}/iperf.cfg ${D}${PTEST_PATH}
+    install -m 0755 ${S}/test_kernel_cyclictest_idle.sh ${D}${PTEST_PATH}
+    install -m 0755 ${S}/test_kernel_cyclictest_hackbench.sh ${D}${PTEST_PATH}
+    install -m 0755 ${S}/test_kernel_cyclictest_fio.sh ${D}${PTEST_PATH}
+    install -m 0755 ${S}/test_kernel_cyclictest_iperf.sh ${D}${PTEST_PATH}
+}
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
Add cyclictest performance tests with various loads: idle, hackbench
scheduler load, fio based disk I/O load, and iperf based network load.

Signed-off-by: Gratian Crisan <gratian.crisan@ni.com>