### PR TITLE
Add support for installing the 'next' kernel from package feeds

### DIFF
--- a/recipes-core/images/nilrt-dkms-bundle-image.bb
+++ b/recipes-core/images/nilrt-dkms-bundle-image.bb
@@ -37,9 +37,9 @@ bootimg_fixup() {
 	echo >>"${IMAGE_ROOTFS}/boot/readme.txt" " - baserootfs.squashfs: ${BASEROOTFS_IMAGE}-${MACHINE}.tar.bz2 root file system image"
 
 	# Move /boot/runmode/bzImage to /boot/bzImage
-	mv "${IMAGE_ROOTFS}/boot/runmode/bzImage" "${IMAGE_ROOTFS}/boot/bzImage"
+	mv "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/$(readlink "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/bzImage")" "${IMAGE_ROOTFS}/boot/bzImage"
 	# Remove /boot/runmode
-	rmdir "${IMAGE_ROOTFS}/boot/runmode"
+	rm -rf "${IMAGE_ROOTFS}/boot/runmode"
 
 	# Bitbake insists on installing glibc which is not needed on
 	#  EFI system partition. Cleanup all non-boot related files.

--- a/recipes-core/images/nilrt-image-common.inc
+++ b/recipes-core/images/nilrt-image-common.inc
@@ -11,12 +11,9 @@ IMAGE_PREPROCESS_COMMAND += "rootfs_update_timestamp;"
 # Do not install license subpackages if they are only recommended.
 BAD_RECOMMENDATIONS_pn-${PN} += "*-lic"
 
-ROOTFS_POSTPROCESS_COMMAND += "\
-       ${@oe.utils.conditional('DISTRO', 'nilrt-nxg', '', 'move_kernel;', d)} \
-"
-
-# Older NILRT distro flavors expect the kernel is an actual image file
+# NILRT images expect the default kernel is an actual file
 # (e.g. bzImage) and not a symbolic link; fix it up here.
+ROOTFS_POSTPROCESS_COMMAND += "move_kernel;"
 move_kernel() {
 	for type in ${KERNEL_IMAGETYPES} ; do
 		if [ -L "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/${type}" ]; then

--- a/recipes-core/images/nilrt-image-common.inc
+++ b/recipes-core/images/nilrt-image-common.inc
@@ -11,4 +11,19 @@ IMAGE_PREPROCESS_COMMAND += "rootfs_update_timestamp;"
 # Do not install license subpackages if they are only recommended.
 BAD_RECOMMENDATIONS_pn-${PN} += "*-lic"
 
+ROOTFS_POSTPROCESS_COMMAND += "\
+       ${@oe.utils.conditional('DISTRO', 'nilrt-nxg', '', 'move_kernel;', d)} \
+"
+
+# Older NILRT distro flavors expect the kernel is an actual image file
+# (e.g. bzImage) and not a symbolic link; fix it up here.
+move_kernel() {
+	for type in ${KERNEL_IMAGETYPES} ; do
+		if [ -L "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/${type}" ]; then
+			mv "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/$(readlink "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/${type}")" \
+			   "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/${type}"
+		fi
+	done
+}
+
 inherit core-image

--- a/recipes-core/packagegroups/packagegroup-ni-desirable.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-desirable.bb
@@ -13,6 +13,7 @@ RDEPENDS_${PN} += "\
 "
 
 RDEPENDS_${PN}_append_x64 = "\
+	packagegroup-ni-next-kernel \
 	packagegroup-ni-mono-extra \
 	florence \
 "

--- a/recipes-core/packagegroups/packagegroup-ni-next-kernel.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-next-kernel.bb
@@ -1,0 +1,10 @@
+SUMMARY = "Kernel packages for 'next' kernel under test for the NI Linux Real-Time distribution"
+LICENSE = "MIT"
+
+inherit packagegroup
+
+RDEPENDS_${PN} = "\
+	kernel-next \
+	kernel-next-dev \
+	kernel-next-modules \
+"

--- a/recipes-kernel/linux/linux-nilrt-current.inc
+++ b/recipes-kernel/linux/linux-nilrt-current.inc
@@ -4,3 +4,4 @@ KBRANCH = "nilrt/${NI_RELEASE_VERSION}/${LINUX_VERSION}"
 GIT_KERNEL_REPO = "linux.git"
 
 require linux-nilrt.inc
+

--- a/recipes-kernel/linux/linux-nilrt-current.inc
+++ b/recipes-kernel/linux/linux-nilrt-current.inc
@@ -1,0 +1,6 @@
+NI_RELEASE_VERSION = "master"
+LINUX_VERSION = "4.14"
+KBRANCH = "nilrt/${NI_RELEASE_VERSION}/${LINUX_VERSION}"
+GIT_KERNEL_REPO = "linux.git"
+
+require linux-nilrt.inc

--- a/recipes-kernel/linux/linux-nilrt-debug_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-debug_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NILRT linux kernel debug build"
 
-require linux-nilrt.inc
+require linux-nilrt-current.inc
 
 SRC_URI += "\
 	file://debug.cfg \

--- a/recipes-kernel/linux/linux-nilrt-next.inc
+++ b/recipes-kernel/linux/linux-nilrt-next.inc
@@ -1,0 +1,8 @@
+NI_RELEASE_VERSION = "master"
+LINUX_VERSION = "5.6"
+KBRANCH = "nilrt/${NI_RELEASE_VERSION}/${LINUX_VERSION}"
+GIT_KERNEL_REPO = "linux.git"
+
+require linux-nilrt.inc
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"

--- a/recipes-kernel/linux/linux-nilrt-next_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-next_git.bb
@@ -1,0 +1,14 @@
+DESCRIPTION = "NILRT linux kernel next development build"
+
+require linux-nilrt-next.inc
+
+LINUX_VERSION_EXTENSION = "-next"
+KERNEL_PACKAGE_NAME = "kernel${LINUX_VERSION_EXTENSION}"
+
+# Subfolder of the same name will be added to FILESEXTRAPATHS and also
+# used for nilrt-specific config fragment manipulation during build.
+# Provide a unique name for each recipe saved in the same source folder.
+KBUILD_FRAGMENTS_LOCATION := "nilrt-next"
+
+# Force creation of symlink to target file at a relative path
+KERNEL_IMAGE_SYMLINK_DEST = "."

--- a/recipes-kernel/linux/linux-nilrt-next_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-next_git.bb
@@ -2,8 +2,7 @@ DESCRIPTION = "NILRT linux kernel next development build"
 
 require linux-nilrt-next.inc
 
-LINUX_VERSION_EXTENSION = "-next"
-KERNEL_PACKAGE_NAME = "kernel${LINUX_VERSION_EXTENSION}"
+KERNEL_PACKAGE_NAME = "kernel-next"
 
 # Subfolder of the same name will be added to FILESEXTRAPATHS and also
 # used for nilrt-specific config fragment manipulation during build.

--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -78,6 +78,35 @@ do_install_append() {
 	# compatibility with non-standard Linux installs (non-dkms). This should go away
 	# and older NILRT should be migrated to kernel-dev + dkms in the future.
 	${WORKDIR}/export-kernel-headers.sh ${S} ${D}/kernel
+}
+
+pkg_postinst_ontarget_${KERNEL_PACKAGE_NAME}-base_append_x64 () {
+	cd "$D/${KERNEL_IMAGEDEST}"
+
+	if [ -f "${KERNEL_IMAGETYPE}" ]; then
+		if [ -L "${KERNEL_IMAGETYPE}" ]; then
+			# If the current kernel image file (e.g. bzImage) is a symlink check
+			# if the kernel version is stored in the 'kernel-versions' file (for uninstall)
+			kpath=`readlink -f ${KERNEL_IMAGETYPE} 2>/dev/null`
+			if [ -f "$kpath" ]; then
+				kimage=`basename $kpath 2>/dev/null`
+				if ! grep -xqs "$kimage" kernel-versions; then
+					echo "$kimage" >> kernel-versions
+				fi
+			fi
+		else
+			# If we have an actual kernel image file (e.g. bzImage) and it's not
+			# a symlink then it must be the kernel currently booted; rename it
+			# and store its version for uninstall.
+			if mv "${KERNEL_IMAGETYPE}" "${KERNEL_IMAGETYPE}-`uname -r`" 2>/dev/null; then
+				echo "${KERNEL_IMAGETYPE}-`uname -r`" >> kernel-versions
+			else
+				echo "WARNING: could not move existing $D/${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE} file"
+			fi
+		fi
+	fi
+
+	echo "${KERNEL_IMAGETYPE}-${KERNEL_VERSION}" >> kernel-versions
 
 	# on older NILRT, the kernel is not symlinked for backwards compatibility
 	if [ "${DISTRO}" != nilrt-nxg ]; then
@@ -85,8 +114,81 @@ do_install_append() {
 			mv ${D}/${KERNEL_IMAGEDEST}/${type}-${KERNEL_VERSION} \
 				${D}/${KERNEL_IMAGEDEST}/${type}
 		done
+	if [ -L "${KERNEL_IMAGETYPE}" -o ! -f "${KERNEL_IMAGETYPE}" ]; then
+		ln -f -s "${KERNEL_IMAGETYPE}-${KERNEL_VERSION}" "${KERNEL_IMAGETYPE}"
+	else
+		echo "ERROR: $D/${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE} file is not a symbolic link"
+		echo "ERROR: cannot switch to the new kernel image $D/${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}-${KERNEL_VERSION}"
+		exit 1
 	fi
 }
+
+pkg_prerm_${KERNEL_PACKAGE_NAME}-base_append_x64 () {
+	cd "$D/${KERNEL_IMAGEDEST}"
+
+	# Check that the current kernel image file (e.g. bzImage) is a
+	# symlink and make sure is listed in the 'kernel-versions'
+	# file. This will also create the 'kernel-versions' file if it
+	# doesn't exist.
+	if [ -L "${KERNEL_IMAGETYPE}" ]; then
+		kpath=`readlink -f ${KERNEL_IMAGETYPE} 2>/dev/null`
+		if [ -f "$kpath" ]; then
+			kimage=`basename $kpath 2>/dev/null`
+			if ! grep -xqs "$kimage" kernel-versions; then
+				echo "$kimage" >> kernel-versions
+			fi
+		fi
+	else
+		echo "Error: $D/${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE} is not a symlink."
+		echo "Refusing to uninstall default kernel"
+		exit 1;
+	fi
+
+	# Also make sure the kernel being uninstalled is listed in
+	# 'kernel-versions'. This simplifies error checking later.
+	if ! grep -xqs "${KERNEL_IMAGETYPE}-${KERNEL_VERSION}" kernel-versions; then
+		echo "${KERNEL_IMAGETYPE}-${KERNEL_VERSION}" >> kernel-versions
+	fi
+
+	# Sanity check the kernels listed in 'kernel-versions' are
+        # present on disk.
+	while read line; do
+		if [ -f "$line" ]; then
+			echo "$line"
+		fi
+	done <kernel-versions >kernel-versions.tmp
+	mv -f kernel-versions.tmp kernel-versions
+
+	# Make sure this is not the last kernel available before proceeding.
+	if [ $(wc -l <kernel-versions) -le 1 ]; then
+		echo "Error: Refusing to uninstall last available kernel."
+		exit 1
+	fi
+}
+
+pkg_postrm_${KERNEL_PACKAGE_NAME}-base_append_x64 () {
+	cd "$D/${KERNEL_IMAGEDEST}"
+
+	# Remove kernel name from 'kernel-versions' file. We're
+	# relying on the prerm script for sanity checks (e.g. bzImage
+	# is a symlink we have another kernel to fall back to etc.)
+	while read line; do
+		if [ ! "$line" = "${KERNEL_IMAGETYPE}-${KERNEL_VERSION}" ]; then
+			echo "$line"
+		fi
+	done <kernel-versions >kernel-versions.tmp
+	mv -f kernel-versions.tmp kernel-versions
+
+	# If the symlink points to this kernel; update it.
+	kpath=`readlink -f ${KERNEL_IMAGETYPE} 2>/dev/null`
+	if [ -f "$kpath" ]; then
+		kimage=`basename $kpath 2>/dev/null`
+		if [ "$kimage" = "${KERNEL_IMAGETYPE}-${KERNEL_VERSION}" ]; then
+			ln -f -s `tail -1 kernel-versions` "${KERNEL_IMAGETYPE}"
+		fi
+	fi
+}
+
 
 pkg_postinst_ontarget_kernel-dev () {
 	cd /lib/modules/${KERNEL_VERSION}/build/scripts/mod

--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -108,12 +108,6 @@ pkg_postinst_ontarget_${KERNEL_PACKAGE_NAME}-base_append_x64 () {
 
 	echo "${KERNEL_IMAGETYPE}-${KERNEL_VERSION}" >> kernel-versions
 
-	# on older NILRT, the kernel is not symlinked for backwards compatibility
-	if [ "${DISTRO}" != nilrt-nxg ]; then
-		for type in ${KERNEL_IMAGETYPES} ; do
-			mv ${D}/${KERNEL_IMAGEDEST}/${type}-${KERNEL_VERSION} \
-				${D}/${KERNEL_IMAGEDEST}/${type}
-		done
 	if [ -L "${KERNEL_IMAGETYPE}" -o ! -f "${KERNEL_IMAGETYPE}" ]; then
 		ln -f -s "${KERNEL_IMAGETYPE}-${KERNEL_VERSION}" "${KERNEL_IMAGETYPE}"
 	else

--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -30,12 +30,6 @@ INHIBIT_PACKAGE_DEBUG_SPLIT="1"
 # link against the gcc provided runtime
 do_kernel_configme[depends] += "libgcc:do_populate_sysroot"
 
-NI_RELEASE_VERSION = "master"
-LINUX_VERSION = "4.14"
-
-KBRANCH = "nilrt/${NI_RELEASE_VERSION}/${LINUX_VERSION}"
-
-GIT_KERNEL_REPO = "linux.git"
 SRC_URI = "\
 	${NILRT_GIT}/${GIT_KERNEL_REPO};protocol=git;nocheckout=1;branch=${KBRANCH} \
 	file://export-kernel-headers.sh \

--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -145,10 +145,12 @@ pkg_prerm_${KERNEL_PACKAGE_NAME}-base_append_x64 () {
 	fi
 
 	# Sanity check the kernels listed in 'kernel-versions' are
-        # present on disk.
+	# present on disk.
 	while read line; do
 		if [ -f "$line" ]; then
 			echo "$line"
+		else
+			echo "WARNING: kernel '$line' listed in '$D/${KERNEL_IMAGEDEST}/kernel-versions' not found on disk" 1>&2
 		fi
 	done <kernel-versions >kernel-versions.tmp
 	mv -f kernel-versions.tmp kernel-versions

--- a/recipes-kernel/linux/linux-nilrt_git.bb
+++ b/recipes-kernel/linux/linux-nilrt_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Linux kernel based on nilrt branch"
 
-require linux-nilrt.inc
+require linux-nilrt-current.inc
 
 # Subfolder of the same name will be added to FILESEXTRAPATHS and also
 # used for nilrt-specific config fragment manipulation during build.


### PR DESCRIPTION
This patch series adds support for building and installing a 'next' kernel on a NILRT distro via package feeds.

New kernels are installed as versioned image files (e.g. /boot/runmode/bzImage-5.6.17-rt9-next) and switching to the new kernel is accomplished by changing the '/boot/runmode/bzImage' symlink. A list of available kernel images is generated and kept for uninstall use cases. This patch series does not cover updating the initramfs images on kernel installs from feed.

Testing done:

- built packages for the 'next' kernel;

- verified that: 'opkg install packagegroup-ni-next-kernel' and 'opkg remove --autoremove packagegroup-ni-next-kernel' work correctly;

- verified that a full NI OE build succeeds and the output can be consumed w/o errors by the os-common component; 

- verified that the layout of the exported images has not changed.