### PR TITLE
Add nsswitch.conf that queries the ldap database.

### DIFF
--- a/recipes-core/base-files/base-files/nsswitch.conf
+++ b/recipes-core/base-files/base-files/nsswitch.conf
@@ -1,0 +1,19 @@
+# /etc/nsswitch.conf
+#
+# Example configuration of GNU Name Service Switch functionality.
+# If you have the `glibc-doc' and `info' packages installed, try:
+# `info libc "Name Service Switch"' for information about this file.
+
+passwd:         compat ldap
+group:          compat ldap
+shadow:         compat ldap
+
+hosts:          files dns
+networks:       files
+
+protocols:      db files
+services:       db files
+ethers:         db files
+rpc:            db files
+
+netgroup:       nis

--- a/recipes-core/base-files/base-files_3.0.14.bbappend
+++ b/recipes-core/base-files/base-files_3.0.14.bbappend
@@ -37,4 +37,6 @@ do_install_append () {
 	install -d ${D}${sysconfdir}/default/volatiles/
 	echo "d ${LVRT_USER} ${LVRT_GROUP} 0775 /run/natinst none" \
 		>> ${D}${sysconfdir}/default/volatiles/20_run_natinst
+
+	install -m 0644 ${WORKDIR}/nsswitch.conf ${D}${sysconfdir}/nsswitch.conf
 }


### PR DESCRIPTION
This updated nsswitch.conf file was originally provided by the
meta-cloud-services layer. The layer had a bug that enabled
installation of this file even when OpenLDAP was not enabled as a
DISTRO_FEATURE. This bug was fixed in the Dunfell branch and the file
is no longer added to the image because we do not enable OpenLDAP.
We still want to keep this version of the file to avoid breaking
customers who might expect this behavior after installing ldap
libraries.

I had intended to push a review for this before, but forgot about it. The os-common component expect this version of the file and that's how I caught it.
Made sure I could build the recipe. Haven't built an image with the change yet.

@ni/rtos 