### PR TITLE
Fix issue where update did not work for uncompressed feeds

### DIFF
--- a/recipes-devtools/opkg/files/0002-fix-issue-where-update-did-not-work-for-uncompressed.patch
+++ b/recipes-devtools/opkg/files/0002-fix-issue-where-update-did-not-work-for-uncompressed.patch
@@ -1,0 +1,26 @@
+From bab8d6f1e74d52c53bb0600bbe5afd8943b65bce Mon Sep 17 00:00:00 2001
+From: Andrei Zene <andrei.zene@ni.com>
+Date: Tue, 8 Sep 2020 22:07:25 +0300
+Subject: [PATCH] Fix issue where update did not work for uncompressed feeds
+
+---
+ libopkg/opkg_download_curl.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/libopkg/opkg_download_curl.c b/libopkg/opkg_download_curl.c
+index d572070..8d6ca6a 100644
+--- a/libopkg/opkg_download_curl.c
++++ b/libopkg/opkg_download_curl.c
+@@ -245,6 +245,12 @@ static int opkg_validate_cached_file(const char *src, const char *cache_location
+         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &error_code);
+         opkg_msg(ERROR, "Failed to download %s headers: %s.\n", src,
+                  curl_easy_strerror(res));
++        free(etag);
++        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, NULL);
++        curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, NULL);
++        curl_easy_setopt(curl, CURLOPT_WRITEHEADER, NULL);
++        curl_easy_setopt(curl, CURLOPT_HEADER, 0);
++        curl_easy_setopt(curl, CURLOPT_NOBODY, 0);
+         return -1;
+     }
+     curl_easy_getinfo(curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &src_size);

--- a/recipes-devtools/opkg/opkg_%.bbappend
+++ b/recipes-devtools/opkg/opkg_%.bbappend
@@ -8,6 +8,7 @@ SRC_URI += " \
             file://gpg.conf \
             file://run-ptest \
             file://0001-opkg-key-add-keys-even-if-creation-date-is-in-the-fu.patch \
+            file://0002-fix-issue-where-update-did-not-work-for-uncompressed.patch \
 "
 
 SRC_URI_append_armv7a = " \


### PR DESCRIPTION
There was a case in which opkg update did not work for uncompressed feeds. 
Steps to reproduce are:
1. add an unexisting compressed feed URL
2. add an existing uncompressed feed URL (they have to be in this order and they have to be URLs so that the opkg download curl backend is used)
3. make sure volatile cache is enabled
4. run opkg update
5. try to install something fom the uncompressed feed

Although opkg says that the uncompressed feed was updated, the uncompressed feed lists file is not downloaded and therefore no packages from that feed can be installed.

The issue was that after an unexisting compressed feed download failure, the opkg options were not reset and therefore a subsequent uncompressed feed download attempt failed.

**Testing**
- built recipe
- installed generated libopkg ipk on a x64 target where the issue was reproducing. Checked that after upgrading libopkg the issue doesn't reproduce anymore.