### PR TITLE
initrdscripts: increase RAUC partition to 400MB

### DIFF
--- a/recipes-core/initrdscripts/files/disk_config_x64
+++ b/recipes-core/initrdscripts/files/disk_config_x64
@@ -21,9 +21,9 @@ disk_partition()
 
     parted -s "$disk" --align optimal      \
         mklabel "gpt"                      \
-        mkpart "niboota"       1MB  250MB  \
-        mkpart "nibootb"     250MB  500MB  \
-        mkpart "niuser"      500MB  100%
+        mkpart "niboota"       1MB  400MB  \
+        mkpart "nibootb"     400MB  800MB  \
+        mkpart "niuser"      800MB  100%
 
     # Per https://www.freedesktop.org/wiki/Specifications/DiscoverablePartitionsSpec/
     #  C12A7328-F81F-11D2-BA4B-00A0C93EC93B -- EFI System Partition


### PR DESCRIPTION
The RAUC partitions were sized at 250MB each, based on the estimated
8-year growth curve for the nilrt-nxg bundle. The newer OneRT Base
System Image bundles are expected to be significantly larger, and 400MB
each is a better estimate for their 8-year growth.

Increase the size of each `nibootX` partition to 400MB, to accommodate
OneRT bundles.

Natinst-AZDO-ID: 1041635
Signed-off-by: Alex Stewart <alex.stewart@ni.com>

@ni/rtos @jpautler 