### PR TITLE
opkg: add patch fix for uncompressed feed downloads

### DIFF
--- a/recipes-devtools/opkg/files/0002-libopkg-clear-curl-properties-on-download-error-to-p.patch
+++ b/recipes-devtools/opkg/files/0002-libopkg-clear-curl-properties-on-download-error-to-p.patch
@@ -1,0 +1,110 @@
+From 8ad7c8bdc8a77f357a6ee929184647a98c5b69cb Mon Sep 17 00:00:00 2001
+From: Andrei Zene <andrei.zene@ni.com>
+Date: Fri, 11 Sep 2020 23:20:34 +0300
+Subject: [PATCH] libopkg: clear curl properties on download error to prevent
+ polluting next call
+To: opkg-devel@googlegroups.com
+
+The opkg_validate_cached_file method sets a dummy write function on
+the global curl session pointer that is used by opkg. It also sets
+CURL_NOBODY to 1 which will only download the header. It does this
+to check if the timestamp of the source has changed and if a
+redownload is needed.
+
+However, if that curl call for the header fails, it doesn't reset
+back the curl options. Because of this, if a subsequent call to
+opkg_download doesn't use cache (which is the case for uncompressed
+feeds list files) and therefore opkg_validate_cache is not called at
+all, the download will look as if it succeeded where in fact it
+didn't write anything to the disk.
+
+The opkg_validate_cached_file function already had some code to
+cleanup the curl options so that they are in the same state then
+before the call. However, that cleanup logic was not executed in
+case of an error. This change makes the cleanup logic to be executed
+also on error.
+
+This fixes an issue where an opkg update would look as if it
+successfully updated an uncompressed feed source but it didn't.
+The issue occured only under the following conditions:
+- before updating the uncompressed feed source, it tried to
+update a compressed feed source and it failed
+- volatile_cache is enabled.
+
+Signed-off-by: Andrei Zene <andrei.zene@ni.com>
+
+Upstream-Status: Accepted [opkg-devel@googlegroups.com]
+---
+ libopkg/opkg_download_curl.c | 30 ++++++++++++++++++------------
+ 1 file changed, 18 insertions(+), 12 deletions(-)
+
+diff --git a/libopkg/opkg_download_curl.c b/libopkg/opkg_download_curl.c
+index d572070..17ad3a4 100644
+--- a/libopkg/opkg_download_curl.c
++++ b/libopkg/opkg_download_curl.c
+@@ -232,6 +232,7 @@ static int opkg_validate_cached_file(const char *src, const char *cache_location
+     long resume_from = 0;
+     char *etag = NULL;
+     double src_size = -1;
++    int ret = 1;
+ 
+     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &dummy_write);
+     curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, &header_write);
+@@ -245,7 +246,8 @@ static int opkg_validate_cached_file(const char *src, const char *cache_location
+         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &error_code);
+         opkg_msg(ERROR, "Failed to download %s headers: %s.\n", src,
+                  curl_easy_strerror(res));
+-        return -1;
++        ret = -1;
++        goto cleanup;
+     }
+     curl_easy_getinfo(curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &src_size);
+ 
+@@ -261,18 +263,12 @@ static int opkg_validate_cached_file(const char *src, const char *cache_location
+         if (r != 0)
+             opkg_msg(ERROR, "Failed to create stamp for %s.\n", cache_location);
+     }
+-    free(etag);
+-
+-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, NULL);
+-    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, NULL);
+-    curl_easy_setopt(curl, CURLOPT_WRITEHEADER, NULL);
+-    curl_easy_setopt(curl, CURLOPT_HEADER, 0);
+-    curl_easy_setopt(curl, CURLOPT_NOBODY, 0);
+ 
+     file = fopen(cache_location, "ab");
+     if (!file) {
+         opkg_msg(ERROR, "Failed to open cache file %s\n", cache_location);
+-        return -1;
++        ret = -1;
++        goto cleanup;
+     }
+     fseek(file, 0, SEEK_END);
+     resume_from = ftell(file);
+@@ -280,10 +276,20 @@ static int opkg_validate_cached_file(const char *src, const char *cache_location
+ 
+     if (resume_from < src_size)
+         curl_easy_setopt(curl, CURLOPT_RESUME_FROM, resume_from);
+-    else
+-        return 0;
++    else {
++        ret = 0;
++        goto cleanup;
++    }
++
++cleanup:
++    free(etag);
+ 
+-    return 1;
++    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, NULL);
++    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, NULL);
++    curl_easy_setopt(curl, CURLOPT_WRITEHEADER, NULL);
++    curl_easy_setopt(curl, CURLOPT_HEADER, 0);
++    curl_easy_setopt(curl, CURLOPT_NOBODY, 0);
++    return ret;
+ }
+ 
+ /* Download using curl backend. */
+-- 
+2.25.1
+

--- a/recipes-devtools/opkg/opkg_%.bbappend
+++ b/recipes-devtools/opkg/opkg_%.bbappend
@@ -8,6 +8,7 @@ SRC_URI += " \
             file://gpg.conf \
             file://run-ptest \
             file://0001-opkg-key-add-keys-even-if-creation-date-is-in-the-fu.patch \
+            file://0002-libopkg-clear-curl-properties-on-download-error-to-p.patch \
 "
 
 SRC_URI_append_armv7a = " \


### PR DESCRIPTION
The opkg_validate_cached_file method sets a dummy write function on
the global curl session pointer that is used by opkg. It also sets
CURL_NOBODY to 1 which will only download the header. It does this
to check if the timestamp of the source has changed and if a
redownload is needed.

However, if that curl call for the header fails, it doesn't reset
back the curl options. Because of this, if a subsequent call to
opkg_download doesn't use cache (which is the case for uncompressed
feeds list files) and therefore opkg_validate_cache is not called at
all, the download will look as if it succeeded where in fact it
didn't write anything to the disk.

The opkg_validate_cached_file function already had some code to
cleanup the curl options so that they are in the same state then
before the call. However, that cleanup logic was not executed in
case of an error. This change makes the cleanup logic to be executed
also on error.

This fixes an issue where an opkg update would look as if it
successfully updated an uncompressed feed source but it didn't.
The issue occured only under the following conditions:
- before updating the uncompressed feed source, it tried to
update a compressed feed source and it failed
- volatile_cache is enabled.

Note: The patch was accepted upstream: https://git.yoctoproject.org/cgit/cgit.cgi/opkg/commit/?id=0485ad453fc5f582e4d289cb35b0c70dc17f7544

Signed-off-by: Andrei Zene <andrei.zene@ni.com>