### PR TITLE
packagegroup-ni-extra: add makedumpfile

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-extra.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-extra.bb
@@ -223,6 +223,7 @@ RDEPENDS_${PN} += "\
 	kexec-tools \
 	kmod \
 	linux-firmware \
+	makedumpfile \
 	oprofile \
 	perf \
 	powertop \


### PR DESCRIPTION
This package is used in conjunction with a dump-capture kernel for kdump.

Signed-off-by: Brandon Streiff <brandon.streiff@ni.com>