### PR TITLE
bblayers.conf.sample: fixup LCONF_VERSION

### DIFF
--- a/conf/bblayers.conf.sample
+++ b/conf/bblayers.conf.sample
@@ -1,6 +1,6 @@
-# LAYER_CONF_VERSION is increased each time build/conf/bblayers.conf
-# changes incompatibly
-LCONF_VERSION = "6"
+# The LCONF_VERSION number should align with the minimum LAYER_CONF_VERSION
+# defined in the oe-core:meta/conf/sanity.conf file.
+LCONF_VERSION = "7"
 
 BBPATH = "${TOPDIR}"
 BBFILES ?= ""

--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -43,7 +43,7 @@ SDK_VENDOR = "-nilrtsdk"
 SDK_VERSION := "${@'${DISTRO_VERSION}'}"
 
 LOCALCONF_VERSION = "1"
-LAYER_CONF_VERSION ?= "5"
+LAYER_CONF_VERSION ?= "7"
 
 VIRTUAL-RUNTIME_graphical_init_manager = "xserver-xfce-init"
 


### PR DESCRIPTION
The LCONF_VERSION should be '7', to align to the minimum required
version for upstream OE/dunfell's sanity checker.

Ref oe-core commit 933088c74870b8c3aa5077d57bc85fc66a652291.
https://github.com/ni/openembedded-core/commit/933088c74870b8c3aa5077d57bc85fc66a652291

Signed-off-by: Alex Stewart <alex.stewart@ni.com>