### PR TITLE
Clean up EFI variables left behind by efi-pstore

### DIFF
--- a/recipes-core/initrdscripts/files/ni_provisioning.common
+++ b/recipes-core/initrdscripts/files/ni_provisioning.common
@@ -289,10 +289,23 @@ elif [ "$ARCH" = "x86_64" ]; then
         ASK_BEFORE_REBOOT=1
     }
 
+    prune_efi_crash_vars()
+    {
+        # Previous kernels may have stored kernel crash information in EFI.
+        # Unfortunately if we have a backlog, this can prevent us from adding
+        # additional boot entries, since those are also EFI variables. Since
+        # we're (re)provisioning a target, we don't care about prior state,
+        # so just delete them.
+        LINUX_EFI_CRASH_GUID="cfc8fc79-be2e-4ddc-97f0-9f98bfe298a0"
+        find /sys/firmware/efi/efivars -name "*-${LINUX_EFI_CRASH_GUID}" -exec /bin/rm {} +
+    }
+
     provision_target()
     {
         echo "Partitioning $TARGET_DISK..."
         do_silent disk_setup "$TARGET_DISK"
+
+        prune_efi_crash_vars
 
         # XXX Find niboota and nibootb partlabels on TARGET_DISK and
         # link as needed by RAUC

--- a/recipes-core/initrdscripts/files/ni_provisioning.safemode
+++ b/recipes-core/initrdscripts/files/ni_provisioning.safemode
@@ -469,6 +469,7 @@ partitioning_disk
 wait_for_partitions $TARGET_DISK
 create_filesystems
 
+prune_efi_crash_vars
 install_grub
 install_safemode
 install_bootmode_file

--- a/recipes-ni/initscripts-nilrt/files/nicleanefivars
+++ b/recipes-ni/initscripts-nilrt/files/nicleanefivars
@@ -1,0 +1,46 @@
+#!/bin/bash
+### BEGIN INIT INFO
+# Provides:          nicleanefivars
+# Required-Start:    $mountvirtfs
+# Required-Stop:     
+# Default-Start:     S
+# Default-Stop:      
+# Short-Description: nicleanefivars
+# Description:       This is a script that cleans old efi-pstore information.
+### END INIT INFO
+
+# Previous kernels may have stored kernel crash information in EFI for
+# systemd to retrieve later. However, this version of NI Linux RT does
+# not use systemd and therefore does not have a way to meaningfully
+# utilize this information. In order to prevent future issues due to
+# exhaustion of EFI variable storage, erase all prior dump information.
+
+NAME=nicleanefivars
+SCRIPTNAME=/etc/init.d/$NAME
+
+EFI_CRASH_CLEANUP=y
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+# no-op if EFI_CRASH_CLEANUP=n is set in /etc/default/nicleanefivars
+case "$EFI_CRASH_CLEANUP" in
+    [Nn]*)
+        exit 0
+        ;;
+esac
+
+case "$1" in
+    start)
+        LINUX_EFI_CRASH_GUID="cfc8fc79-be2e-4ddc-97f0-9f98bfe298a0"
+        find /sys/firmware/efi/efivars -name "*-${LINUX_EFI_CRASH_GUID}" -exec /bin/rm {} +
+        ;;
+    stop|status|reload|restart|force-reload)
+        ;;
+    *)
+        echo "Usage: $SCRIPTNAME {start}" >&2
+        exit 3
+        ;;
+esac
+
+exit 0

--- a/recipes-ni/initscripts-nilrt/initscripts-nilrt_1.0.bb
+++ b/recipes-ni/initscripts-nilrt/initscripts-nilrt_1.0.bb
@@ -17,6 +17,7 @@ RDEPENDS_${PN}_append_x64 = " nilrtdiskcrypt "
 SRC_URI = "file://nisetbootmode \
            file://firewall \
            file://mountdebugfs \
+           file://nicleanefivars \
            file://nicleanstalelinks \
            file://nicreatecpusets \
            file://nicreatecpuacctgroups \
@@ -167,6 +168,9 @@ do_install_append_x64 () {
 
 	install -m 0755   ${WORKDIR}/niclosedisks  ${D}${sysconfdir}/init.d
 	update-rc.d -r ${D} niclosedisks start 41 0 . start 41 6 .
+
+	install -m 0755   ${WORKDIR}/nicleanefivars  ${D}${sysconfdir}/init.d
+	update-rc.d -r ${D} nicleanefivars start 10 S .
 }
 
 do_install_ptest () {


### PR DESCRIPTION
Our 4.14-kernel-based releases have had CONFIG_EFI_PSTORE enabled, but we're
not currently doing anything with the dump information that gets left behind
as efi variables, since we do not have systemd-pstore to come along and
retrieve this information. Therefore, dump information can accumulate to the
point that other operations to add or update EFI variables will fail for lack
of storage.

As the quick-fix for dealing with this, delete all EFI variables associated
with the Linux crash GUID on startup, since we're not currently making use of
that information anyway. (Ideally, a future version will be able to remove
this script and utilize this information.)

Also delete all crash-related EFI variables during provisioning; these are
even less important to keep around at the time of provisioning, because the
user is seeking to remove any prior system state.