### PR TITLE
base-files: revert removal of /var/volatile/cache

### DIFF
--- a/recipes-core/base-files/base-files_3.0.14.bbappend
+++ b/recipes-core/base-files/base-files_3.0.14.bbappend
@@ -35,6 +35,10 @@ do_install_append () {
 	install ${WORKDIR}/safemode-ps1.sh ${D}${sysconfdir}/profile.d/
 
 	install -d ${D}${sysconfdir}/default/volatiles/
+	# 10_var_vol_cache is only needed for post-8.5 safemodes to support
+	# chrooted opkg operations on pre-8.5 runmodes.
+	echo "d root root 0755 /var/volatile/cache none" \
+		>> ${D}${sysconfdir}/default/volatiles/10_var_vol_cache
 	echo "d ${LVRT_USER} ${LVRT_GROUP} 0775 /run/natinst none" \
 		>> ${D}${sysconfdir}/default/volatiles/20_run_natinst
 }


### PR DESCRIPTION
NILRT 8.5 safemodes do not create a /var/volatile/cache directory due to
commit 20ea59ab3e8938e8f45f5e073a315b75d4b7ec0f. This is a sane decision
for runmodes of the same version, since the opkg configuration was also
modified to not use that non-standard location for its cache.

However, some MAX workflows (AZDO 1153388) require opkg operations
performed from the safemode, via a chroot into runmode. In cases where
the runmode image predates the volatile cache change, operations will
fail with an OSError when opkg tries to create a subdirectory under the
nonexistant volatile cache.

Add the volatile cache directory back into the runtime-generated
volatile cache locations. With new runmodes, the empty directory will be
unused. On old runmodes, it will be used.

Natinst-AZDO-ID: 1159845
Signed-off-by: Alex Stewart <alex.stewart@ni.com>