### PR TITLE
pkgrp-ni-restoremode: Add vmware keyboard support

### DIFF
--- a/recipes-core/initrdscripts/files/init-restore-mode.sh
+++ b/recipes-core/initrdscripts/files/init-restore-mode.sh
@@ -99,6 +99,7 @@ if [[ $ARCH == "x86_64" ]]; then
     disable_x64_cstates
     # support VMWare image keyboard
     modprobe atkbd 2> /dev/null
+    modprobe i8042 2> /dev/null
     remove_bootmode 2> /dev/null
 fi
 

--- a/recipes-core/packagegroups/packagegroup-ni-restoremode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-restoremode.bb
@@ -51,5 +51,6 @@ RDEPENDS_${PN}_append_xilinx-zynqhf = "\
 
 RRECOMMENDS_${PN}_x64 = "\
     kernel-module-tpm-tis \
-    kernel-module-atkbd \
+    kernel-module-atkbd   \
+    kernel-module-i8042   \
 "


### PR DESCRIPTION
Added i8042 driver to restoremode and modprobed in init

Tested on vmware

@ni/rtos 