### PR TITLE
meta-nilrt: Changes to build image from feeds

### DIFF
--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -25,3 +25,4 @@ KERNEL_IMAGEDEST = "boot/runmode"
 ROOT_HOME = "/home/admin"
 
 IMAGE_LINGUAS ?= "en-us en-us.iso-8859-1"
+

--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -104,6 +104,9 @@ NILRT_FEEDS_URI_RELEASE            ?= "${NILRT_FEEDS_URI}/${NILRT_RELEASE_NAME}"
 NILRT_MACHINE_FEED_URI_x64         ?= "${NILRT_FEEDS_URI_RELEASE}/x64"
 NILRT_MACHINE_FEED_URI_xilinx-zynq ?= "${NILRT_FEEDS_URI_RELEASE}/arm"
 
+NILRT_MAIN_FEED_VERSION            ?= "2020.6"
+NILRT_MACHINE_FEED_URI_nimain      ?= "${NILRT_FEEDS_URI}/${NILRT_MAIN_FEED_VERSION}/ni-main"
+
 # OE Packages with TUNEARCHes
 PACKAGE_FEED_URIS       = "${NILRT_MACHINE_FEED_URI}"
 PACKAGE_FEED_BASE_PATHS = "extra main"
@@ -116,3 +119,19 @@ PACKAGE_FEED_URIS_ADDITIONAL = 'fake value for PACKAGE_FEED_URIS_ADDITIONAL'
 
 # NI distribution packages
 PACKAGE_FEED_URIS_ADDITIONAL[NI-dist] = "${NILRT_FEEDS_URI}/dist"
+
+# NI-main packages
+PACKAGE_FEED_URIS_ADDITIONAL[ni-main] = "${NILRT_MACHINE_FEED_URI_nimain}"
+
+BUILD_IMAGES_FROM_FEEDS = "1"
+
+# Get NIOE packages from local deploy feed and NI packages from web feed
+NILRT_LOCAL_FEED_URI ?= "file://${DEPLOY_DIR_IPK}"
+
+# Configure feed URIs for image builds
+IPK_FEED_URIS += "\
+    NIOE-all##${NILRT_LOCAL_FEED_URI}/all \
+    NIOE-${MACHINE}##${NILRT_LOCAL_FEED_URI}/${MACHINE} \
+    NIOE-${TUNE_PKGARCH}##${NILRT_LOCAL_FEED_URI}/${TUNE_PKGARCH} \
+    NI-software##${NILRT_MACHINE_FEED_URI_nimain} \
+"

--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -4,6 +4,7 @@ TARGET_VENDOR = "-nilrt"
 
 GRUB_BRANCH = "nilrt/19.0"
 
+DISTRO_FEATURES += "${DISTRO_FEATURES_DEFAULT}"
 # Common features enabled on all NILRT flavours
 DISTRO_FEATURES += "\
         argp \

--- a/recipes-core/images/include/licenses.inc
+++ b/recipes-core/images/include/licenses.inc
@@ -10,5 +10,7 @@ tar_licenses() {
 	[ ! -e "${IMAGE_ROOTFS}/usr/share/common-licenses" ]
 }
 
-ROOTFS_POSTPROCESS_COMMAND += "tar_licenses; "
+# tar_licenses() does not work when using BUILD_IMAGE_FROM_FEEDS,
+# because licenses are not available in the rootfs.
+#ROOTFS_POSTPROCESS_COMMAND += "tar_licenses; "
 

--- a/recipes-core/images/nilrt-dkms-image.bb
+++ b/recipes-core/images/nilrt-dkms-image.bb
@@ -10,5 +10,6 @@ require niconsole-image.inc
 require nilrt-xfce.inc
 require nilrt-initramfs.inc
 require include/licenses.inc
+require nilrt-proprietary.inc
 
 IMAGE_FSTYPES += "squashfs"

--- a/recipes-core/images/nilrt-proprietary.inc
+++ b/recipes-core/images/nilrt-proprietary.inc
@@ -1,0 +1,34 @@
+# NI infrastructure packages to be installed in the image
+IMAGE_INSTALL_NODEPS = "\
+        libnitargetcfg \
+        ni-auth \
+        ni-auth-webservice \
+        ni-avahi-client \
+        ni-ca-certs \
+        ni-rt-exec-webservice \
+        ni-service-locator \
+        ni-skyline-file-client \
+        ni-skyline-message-client \
+        ni-skyline-tag-client \
+        ni-software-action-services \
+        ni-software-installation-websvc \
+        ni-ssl-webserver-support \
+        ni-sysapi \
+        ni-sysapi-remote \
+        ni-sysapi-webservice \
+        ni-sysmgmt-auth-utils \
+        ni-sysmgmt-salt-minion-support \
+        ni-sysmgmt-sysapi-expert \
+        ni-system-webserver \
+        ni-traceengine \
+        ni-webdav-system-webserver-support \
+        ni-webserver-libs \
+        ni-webservices-webserver-support \
+        nicurl \
+        nirtcfg \
+        nirtmdnsd \
+        nissl \
+        python3-ni-systemlink-sdk \
+        sysconfig-settings \
+        sysconfig-settings-ui \
+"

--- a/recipes-core/images/nilrt-proprietary.inc
+++ b/recipes-core/images/nilrt-proprietary.inc
@@ -1,3 +1,10 @@
+# Disable running ldconfig at the end of the rootfs creation process.
+# Running ldconfig removes symlinks created by ni packages installed
+# to the rootfs, particularly the symlinks to libraries in
+# NIWebServer. This needs to be investigated before ldconfig can be
+# reenabled.
+LDCONFIGDEPEND = ""
+
 # NI infrastructure packages to be installed in the image
 IMAGE_INSTALL_NODEPS = "\
         libnitargetcfg \

--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -115,6 +115,7 @@ RDEPENDS_${PN} = "\
 	openssh-sftp-server \
 	openssh-ssh \
 	opkg \
+	opkg-utils \
 	opkg-keyrings \
 	os-release \
 	run-postinsts \

--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -92,12 +92,14 @@ RDEPENDS_${PN} = "\
 	daemonize \
 	dhcp-client \
 	dpkg-start-stop \
+	efibootmgr \
 	ethtool \
 	gptfdisk-sgdisk \
 	initscripts \
 	initscripts-nilrt \
 	iproute2 \
 	iptables \
+	jq \
 	kmod \
 	kernel-modules \
 	libavahi-client \
@@ -118,6 +120,7 @@ RDEPENDS_${PN} = "\
 	opkg-utils \
 	opkg-keyrings \
 	os-release \
+	rauc \
 	run-postinsts \
 	sudo \
 	syslog-ng \
@@ -139,4 +142,99 @@ RDEPENDS_${PN} = "\
 	${@oe.utils.conditional('DISTRO', 'nilrt-nxg', \
 		'${NILRT_NXG_PACKAGES}', \
 		'${NILRT_PACKAGES}', d)} \
+"
+
+# Packages required by SystemLink
+RDEPENDS_${PN} += "\
+	cpp \
+	cpp-symlinks \
+	libmpc \
+	libpython3 \
+	libyaml \
+	mpfr \
+	python3 \
+	python3-aiodns \
+	python3-aiohttp \
+	python3-asn1crypto \
+	python3-async-timeout \
+	python3-asyncio \
+	python3-attrs \
+	python3-avahi \
+	python3-certifi \
+	python3-cffi \
+	python3-chardet \
+	python3-codecs \
+	python3-compile \
+	python3-compression \
+	python3-configparser \
+	python3-core \
+	python3-crypt \
+	python3-cryptography \
+	python3-ctypes \
+	python3-datetime \
+	python3-dateutil \
+	python3-dbus \
+	python3-difflib \
+	python3-distutils \
+	python3-email \
+	python3-fcntl \
+	python3-html \
+	python3-idna \
+	python3-idna-ssl \
+	python3-io \
+	python3-jinja2 \
+	python3-json \
+	python3-logging \
+	python3-markupsafe \
+	python3-math \
+	python3-mime \
+	python3-misc \
+	python3-mmap \
+	python3-msgpack \
+	python3-multidict \
+	python3-multiprocessing \
+	python3-ndg-httpsclient \
+	python3-netclient \
+	python3-netserver \
+	python3-numbers \
+	python3-pickle \
+	python3-pika \
+	python3-pkgutil \
+	python3-plistlib \
+	python3-ply \
+	python3-pprint \
+	python3-profile \
+	python3-psutil \
+	python3-pyasn1 \
+	python3-pycares \
+	python3-pycparser \
+	python3-pycrypto \
+	python3-pyiface \
+	python3-pyinotify \
+	python3-pyopenssl \
+	python3-pyroute2 \
+	python3-pysocks \
+	python3-pyyaml \
+	python3-requests \
+	python3-resource \
+	python3-setuptools \
+	python3-shell \
+	python3-six \
+	python3-smtpd \
+	python3-stringold \
+	python3-terminal \
+	python3-threading \
+	python3-tornado \
+	python3-typing \
+	python3-typing-extensions \
+	python3-unittest \
+	python3-unixadmin \
+	python3-urllib3 \
+	python3-xml \
+	python3-xmlrpc \
+	python3-yarl \
+	salt-common \
+	salt-minion \
+	sysconfig-settings \
+	sysconfig-settings-ui \
 "

--- a/recipes-core/packagegroups/packagegroup-ni-extra.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-extra.bb
@@ -34,7 +34,6 @@ RDEPENDS_${PN}_append_x64 = "\
 		sessreg \
 		setxkbmap \
 		sip \
-		sysconfig-settings-ui \
 		t1lib \
 		toscoterm \
 		tk \
@@ -135,17 +134,12 @@ RDEPENDS_${PN} += "\
 	patchelf \
 	pax-utils \
 	prelink \
-	python3-dbus \
 	python3-distribute \
 	python3-imaging \
-	python3-setuptools \
 	python3-docutils \
 	python3-mako \
 	python3-nose \
 	python3-numpy \
-	python3-pyiface \
-	python3 \
-	python3-setuptools \
 	rpm \
 	rsync \
 	unfs3 \
@@ -300,7 +294,6 @@ RDEPENDS_${PN} += "\
 	dejagnu \
 	i2c-tools \
 	icon-slicer \
-	jq \
 	lemon \
 	libedit \
 	log4cplus \
@@ -603,32 +596,24 @@ RDEPENDS_${PN} += "\
 	python3-future \
 	python3-gsocketpool \
 	python3-mprpc \
-	python3-pycrypto \
 	python3-feedparser \
-	python3-requests \
 	python3-pyzmq \
 	python3-m2crypto \
 	python3-cheetah \
-	python3-configparser \
 	python3-lxml \
 	python3-numeric \
 	python3-matplotlib \
 	python3-pyudev \
 	python3-pyalsaaudio \
 	python3-pyusb \
-	python3-markupsafe \
-	python3-jinja2 \
 	python3-pexpect \
 	python3-webdav \
-	python3-dateutil \
 	python3-ldap \
 	python3-epydoc \
 	python3-gevent \
 	python3-cython \
 	python3-smbus \
 	python3-snakefood \
-	python3-psutil \
-	python3-msgpack \
 	python3-vobject \
 	python3-twisted \
 	python3-pyserial \
@@ -636,7 +621,6 @@ RDEPENDS_${PN} += "\
 	python3-gdata \
 	pyrtm \
 	python3-sqlalchemy \
-	python3-pyyaml \
 	python3-decorator \
 	python3-greenlet \
 	python3-pytz \
@@ -702,7 +686,6 @@ RDEPENDS_${PN} += "\
 	python3-httpretty \
 	python3-ipaddr \
 	python3-iso8601 \
-	python3-jinja2 \
 	python3-jsonpatch \
 	python3-jsonpath-rw \
 	python3-jsonpointer \
@@ -714,7 +697,6 @@ RDEPENDS_${PN} += "\
 	python3-logutils \
 	python3-lxml \
 	python3-mako \
-	python3-markupsafe \
 	python3-mccabe \
 	python3-memcache \
 	python3-memcached \
@@ -722,11 +704,9 @@ RDEPENDS_${PN} += "\
 	python3-mock \
 	python3-mox \
 	python3-mox3 \
-	python3-msgpack \
 	python3-netaddr \
 	python3-netifaces \
 	python3-networkx \
-	python3-requests \
 	python3-oauth2 \
 	python3-oauthlib \
 	python3-pam \
@@ -736,13 +716,10 @@ RDEPENDS_${PN} += "\
 	python3-pastedeploy \
 	python3-pbr \
 	python3-pep8 \
-	python3-ply \
 	python3-posix-ipc \
 	python3-prettytable \
 	python3-psycopg2 \
 	python3-py \
-	python3-pyasn1 \
-	python3-pycrypto \
 	python3-pyflakes \
 	python3-pymongo \
 	python3-pyparsing \
@@ -752,13 +729,11 @@ RDEPENDS_${PN} += "\
 	python3-pytest \
 	python3-pytz \
 	python3-pyudev \
-	python3-requests \
 	python3-rfc3986 \
 	python3-rtslib-fb \
 	python3-setuptools-git \
 	python3-simplegeneric \
 	python3-singledispatch \
-	python3-six \
 	python3-sqlalchemy \
 	python3-stevedore \
 	python3-subunit \
@@ -844,14 +819,12 @@ RDEPENDS_${PN} += "\
 RDEPENDS_${PN} += "\
 	clamav \
 	libhtp \
-	python3-pycrypto \
 	samhain-server \
 "
 
 # meta-nilrt/recipes-ni
 RDEPENDS_${PN} += "\
 	nirtcfg-tests \
-	sysconfig-settings \
 "
 
 # meta-qt5

--- a/recipes-kernel/linux/kernel-devsrc.bbappend
+++ b/recipes-kernel/linux/kernel-devsrc.bbappend
@@ -1,5 +1,5 @@
 pkg_postinst_ontarget_kernel-devsrc () {
-   cd /lib/modules/${KERNEL_VERSION}/build/scripts/mod
+   cd /lib/modules/${KERNEL_VERSION}/build
    make prepare
    make modules_prepare
 }


### PR DESCRIPTION
Preliminary PR for the changes to build image from feeds. The following are the outstanding workitems that will be addressed once the first set of changes are in:
	
- investigate ldconfig deletion of symlinks at the end of rootfs task
- replace NI_MAIN_FEED_URI with location to feed export derived from the package file when creating non-final builds within nibuild
- fix license copying, tar creation issue when building images from feed

@ni/rtos 
