### PR TITLE
Apply patches to make 'opkg install --noaction <package>' run faster

### DIFF
--- a/recipes-devtools/opkg/files/0003-opkg_solver_libsolv-Pass-opkg_config-noaction-as-noa.patch
+++ b/recipes-devtools/opkg/files/0003-opkg_solver_libsolv-Pass-opkg_config-noaction-as-noa.patch
@@ -1,0 +1,32 @@
+From 852b31b13de3ab739f889345b982a82970614cf7 Mon Sep 17 00:00:00 2001
+From: Zavaczki Raul <raul.zavaczki@ni.com>
+Date: Mon, 26 Oct 2020 05:57:41 -0700
+Subject: [PATCH] opkg_solver_libsolv: Pass opkg_config->noaction as 'noaction'
+ parameter to libsolv_solver_transaction_preamble
+
+Currently, if the option for 'download first' is true, opkg will download packages even when noaction is set to false
+Changing the function call to pass opkg_config->noaction instead of 0 will fix this behaviour
+
+Signed-off-by: Zavaczki Raul <raul.zavaczki@ni.com>
+
+Upstream-Status: Accepted [opkg-devel@googlegroups.com]
+---
+ libopkg/solvers/libsolv/opkg_solver_libsolv.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libopkg/solvers/libsolv/opkg_solver_libsolv.c b/libopkg/solvers/libsolv/opkg_solver_libsolv.c
+index 8e769b1..b625002 100644
+--- a/libopkg/solvers/libsolv/opkg_solver_libsolv.c
++++ b/libopkg/solvers/libsolv/opkg_solver_libsolv.c
+@@ -900,7 +900,7 @@ static int libsolv_solver_execute_transaction(libsolv_solver_t *libsolv_solver)
+     } else {
+         pkg_t *pkg;
+ 
+-        if (libsolv_solver_transaction_preamble(libsolv_solver, pkgs, transaction, 0)) {
++        if (libsolv_solver_transaction_preamble(libsolv_solver, pkgs, transaction, opkg_config->noaction)) {
+             err = -1;
+             goto CLEANUP;
+         }
+-- 
+2.25.1
+

--- a/recipes-devtools/opkg/files/0004-pkg_src_verify-Verify-feeds-signatures-only-once.patch
+++ b/recipes-devtools/opkg/files/0004-pkg_src_verify-Verify-feeds-signatures-only-once.patch
@@ -1,0 +1,106 @@
+From a00ab183da1559a7f6e411af4134b4ec1d911af4 Mon Sep 17 00:00:00 2001
+From: Zavaczki Raul <raul.zavaczki@ni.com>
+Date: Mon, 26 Oct 2020 04:36:23 -0700
+Subject: [PATCH] pkg_src_verify: Verify feeds signatures only once
+
+Rename pkg_src_t disable_sig_check to signature_verified to better
+reflect the field purpose
+
+Signed-off-by: Zavaczki Raul <raul.zavaczki@ni.com>
+
+Upstream-Status: Accepted [opkg-devel@googlegroups.com]
+---
+ libopkg/opkg_conf.c    | 6 +++---
+ libopkg/opkg_install.c | 2 +-
+ libopkg/pkg_src.c      | 8 +++++---
+ libopkg/pkg_src.h      | 2 +-
+ 4 files changed, 10 insertions(+), 8 deletions(-)
+
+diff --git a/libopkg/opkg_conf.c b/libopkg/opkg_conf.c
+index e9c59e7..a0189ff 100644
+--- a/libopkg/opkg_conf.c
++++ b/libopkg/opkg_conf.c
+@@ -182,7 +182,7 @@ static void parse_pkg_src_options_str(pkg_src_options_t *src_options,
+     char *token, *value, *src_option;
+ 
+     /* default value */
+-    src_options->disable_sig_check = 0;
++    src_options->signature_verified = 0;
+ 
+     token = strtok(options_str, " ");
+     while (token) {
+@@ -193,9 +193,9 @@ static void parse_pkg_src_options_str(pkg_src_options_t *src_options,
+             src_option = xstrndup(token, strlen(token) - (strlen(value) + 1));
+             if (strcasecmp(src_option, "trusted") == 0) {
+                 if (strcasecmp(value, "yes") == 0)
+-                    src_options->disable_sig_check = 1;
++                    src_options->signature_verified = 1;
+                 else
+-                    src_options->disable_sig_check = 0;
++                    src_options->signature_verified = 0;
+             }
+             free(src_option);
+         }
+diff --git a/libopkg/opkg_install.c b/libopkg/opkg_install.c
+index e7a9a24..f05d778 100644
+--- a/libopkg/opkg_install.c
++++ b/libopkg/opkg_install.c
+@@ -915,7 +915,7 @@ int opkg_install_pkg(pkg_t * pkg, pkg_t * old_pkg)
+         return -1;
+ 
+     /* check that the repository is valid */
+-    if (opkg_config->check_signature && pkg->src && !(pkg->src->options->disable_sig_check)) {
++    if (opkg_config->check_signature && pkg->src && !(pkg->src->options->signature_verified)) {
+         /* pkg_src_verify prints an error message so we don't have to. */
+         err = pkg_src_verify(pkg->src);
+         if (err)
+diff --git a/libopkg/pkg_src.c b/libopkg/pkg_src.c
+index edd19ad..f3bea59 100644
+--- a/libopkg/pkg_src.c
++++ b/libopkg/pkg_src.c
+@@ -41,9 +41,9 @@ int pkg_src_init(pkg_src_t * src, const char *name, const char *base_url,
+     src->value = xstrdup(base_url);
+     src->options = xmalloc(sizeof(pkg_src_options_t));
+     if (options)
+-       src->options->disable_sig_check = options->disable_sig_check;
++       src->options->signature_verified = options->signature_verified;
+     else
+-       src->options->disable_sig_check = 0;
++       src->options->signature_verified = 0;
+ 
+     if (extra_data)
+         src->extra_data = xstrdup(extra_data);
+@@ -186,6 +186,8 @@ int pkg_src_verify(pkg_src_t * src)
+ 
+     opkg_msg(DEBUG, "Signature verification passed for %s.\n", src->name);
+ 
++    src->options->signature_verified = 1;
++
+  cleanup:
+     if (err) {
+         /* Remove incorrect files. */
+@@ -205,7 +207,7 @@ int pkg_src_update(pkg_src_t * src)
+     if (err)
+         return err;
+ 
+-    if (opkg_config->check_signature && !(src->options->disable_sig_check)) {
++    if (opkg_config->check_signature && !(src->options->signature_verified)) {
+         err = pkg_src_download_signature(src);
+         if (err)
+             return err;
+diff --git a/libopkg/pkg_src.h b/libopkg/pkg_src.h
+index fa43a0a..4e7dd62 100644
+--- a/libopkg/pkg_src.h
++++ b/libopkg/pkg_src.h
+@@ -28,7 +28,7 @@ extern "C" {
+ #endif
+ 
+ typedef struct {
+-    int disable_sig_check;
++    int signature_verified;
+ } pkg_src_options_t;
+ 
+ typedef struct {
+-- 
+2.25.1
+

--- a/recipes-devtools/opkg/opkg_%.bbappend
+++ b/recipes-devtools/opkg/opkg_%.bbappend
@@ -9,6 +9,8 @@ SRC_URI += " \
             file://run-ptest \
             file://0001-opkg-key-add-keys-even-if-creation-date-is-in-the-fu.patch \
             file://0002-libopkg-clear-curl-properties-on-download-error-to-p.patch \
+            file://0003-opkg_solver_libsolv-Pass-opkg_config-noaction-as-noa.patch \
+            file://0004-pkg_src_verify-Verify-feeds-signatures-only-once.patch \
 "
 
 SRC_URI_append_armv7a = " \


### PR DESCRIPTION
Signed-off-by: Raul Zavaczki <raul.zavaczki@ni.com>

SystemsManagement added two new features that heavily rely on 'opkg install --noaction' to get a summary of packages that are going to be installed. Unfortunately, this operation takes extremely long (~90 seconds with 'opkg install --noaction ni-crio' on a freshly formatted target) and the expected behavior is that these operations take at most a few seconds.
After some investigations, we found that if the 'download_first' option is supplied, 'opkg install --noaction' will download the packages, and that a feed is verified for each package - even if it was verified before.
The patches optimize these two use-cases.