### PR TITLE
rauc: Fix safemode to rauc provisioning failures

### DIFF
--- a/recipes-core/dist-nilrt/dist-nilrt-efi-ab-gateway.bb
+++ b/recipes-core/dist-nilrt/dist-nilrt-efi-ab-gateway.bb
@@ -1,4 +1,4 @@
-SUMMARY = "Repartition a safemode based installation to an A/B EFI implementation"
+SUMMARY = "IPK to repartition a safemode based installation to an A/B EFI implementation"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
@@ -10,13 +10,15 @@ PV = "${DISTRO_VERSION}"
 RDEPENDS_${PN} += "bash"
 ALLOW_EMPTY_${PN}-dbg = "0"
 ALLOW_EMPTY_${PN}-dev = "0"
-do_install[depends] = "restore-mode-image:do_image_complete"
+
+ISO_NAME = "nilrt-restore-mode"
+IMAGE = "${ISO_NAME}-image"
+do_install[depends] = "${IMAGE}:do_image_complete"
 
 do_install_append_x64() {
-
     install -d ${D}/usr/share/nilrt
     install -m 0755 ${WORKDIR}/nilrt-gateway-install ${D}/usr/share/nilrt/nilrt-install
-    install -m 0755 ${DEPLOY_DIR_IMAGE}/restore-mode-image-${MACHINE}.wic ${D}/usr/share/nilrt/restore-mode-image-${MACHINE}.iso
+    install -m 0755 ${DEPLOY_DIR_IMAGE}/${ISO_NAME}-${MACHINE}.wic ${D}/usr/share/nilrt/restore-mode-image-${MACHINE}.iso
 }
 
 python do_package_ipk_prepend() {

--- a/recipes-core/dist-nilrt/dist-nilrt-efi-ab.bb
+++ b/recipes-core/dist-nilrt/dist-nilrt-efi-ab.bb
@@ -1,9 +1,9 @@
-SUMMARY = "IPK to install the current DISTRO_VERSION of the minimal image on an exising NXG target"
+SUMMARY = "IPK to install the current DISTRO_VERSION of base bundle"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 
 PV = "${DISTRO_VERSION}"
-BUNDLE = "minimal-nilrt-bundle"
+BUNDLE = "nilrt-base-bundle"
 DEPENDS = "${BUNDLE}"
 RDEPENDS_${PN} += "bash rauc"
 ALLOW_EMPTY_${PN}-dbg = "0"

--- a/recipes-core/dist-nilrt/files/nilrt-gateway-install
+++ b/recipes-core/dist-nilrt/files/nilrt-gateway-install
@@ -26,6 +26,7 @@ function cleanup() {
     # Restore boot partitions to previous states
     [ ! -z "${EFI_MOUNT_A-}" ] && mount -o remount,ro "$EFI_MOUNT_A" &>/dev/null
     [ ! -z "${EFI_MOUNT_B-}" ] && umount "$EFI_MOUNT_B" &>/dev/null
+    [ ! -z "${NIROOTFS_MOUNT-}" ] && umount "$NIROOTFS_MOUNT" &>/dev/null
 
     exit "$exitCode"
 }
@@ -36,6 +37,19 @@ function die() {
     echo "Error: $1"
     exit 1
 }
+
+# Download dist-nilrt-efi-ab.ipk into /payload of nirootfs partition
+NIROOTFS_MOUNT=$(mktemp -d "/var/volatile/niroot-XXXXXXX")
+mount -L nirootfs $NIROOTFS_MOUNT || die "Unable to mount nirootfs."
+
+rm -rf $NIROOTFS_MOUNT/payload
+mkdir $NIROOTFS_MOUNT/payload || die "Unable to create payload directory."
+
+pushd $NIROOTFS_MOUNT/payload > /dev/null
+opkg update > /dev/null
+opkg download dist-nilrt-efi-ab > /dev/null || (popd > /dev/null; die "Unable to download dist-nilrt-efi-ab. Check if disk has sufficient space.")
+test -e dist-nilrt-efi-ab*.ipk || (popd > /dev/null; die "Unable to download dist-nilrt-efi-ab. Check if feeds contain dist-nilrt-efi-ab package.")
+popd > /dev/null
 
 # Mount the ISO/wic file as a loopback device
 info "Mounting the ISO"

--- a/recipes-core/images/nilrt-recovery-media-image.bb
+++ b/recipes-core/images/nilrt-recovery-media-image.bb
@@ -1,0 +1,24 @@
+DESCRIPTION = "Tiny initramfs image with rauc bundle intended to run restore mode operations"
+NIBOOT_BUNDLE_IMAGE = "nilrt-base-bundle"
+IMAGE_DISPLAY_NAME = "NI LinuxRT Base System Image"
+
+IMAGE_BASENAME = "nilrt-recovery-media"
+WKS_FILE = "${IMAGE_BASENAME}.${MACHINE}.wks.in"
+
+IMAGE_FSTYPES_append_x64 = " wic"
+
+do_rootfs[depends] += "${NIBOOT_BUNDLE_IMAGE}:do_deploy"
+
+PAYLOAD_DIR = "${T}/payload"
+
+install_payload () {
+   rm -rf ${PAYLOAD_DIR}
+   install -d ${PAYLOAD_DIR}/payload
+   install -m 0644 ${DEPLOY_DIR_IMAGE}/${NIBOOT_BUNDLE_IMAGE}-${MACHINE}.raucb  ${PAYLOAD_DIR}/payload/niboot.raucb
+   echo "BUILD_IDENTIFIER=${BUILDNAME}" > ${PAYLOAD_DIR}/payload/imageinfo
+   echo "IMAGE_DISPLAY_NAME=${IMAGE_DISPLAY_NAME}" >> ${PAYLOAD_DIR}/payload/imageinfo
+}
+
+ROOTFS_POSTPROCESS_COMMAND += "install_payload;"
+
+require nilrt-restore-mode.inc

--- a/recipes-core/images/nilrt-restore-mode-image.bb
+++ b/recipes-core/images/nilrt-restore-mode-image.bb
@@ -1,6 +1,8 @@
 DESCRIPTION = "Tiny initramfs image intended to run restore mode operations"
-NIBOOT_BUNDLE_IMAGE = "nilrt-base-bundle"
 IMAGE_DISPLAY_NAME = "NI LinuxRT Base System Image"
+
+IMAGE_BASENAME = "nilrt-restore-mode"
+WKS_FILE = "${IMAGE_BASENAME}.${MACHINE}.wks"
 
 IMAGE_FSTYPES_append_x64 = " wic"
 

--- a/recipes-core/images/nilrt-restore-mode.inc
+++ b/recipes-core/images/nilrt-restore-mode.inc
@@ -17,24 +17,19 @@ VIRTUAL-RUNTIME_getopt = "util-linux-getopt"
 VIRTUAL-RUNTIME_base-utils = "util-linux"
 PREFERRED_PROVIDER_virtual/base-utils="util-linux"
 
-do_rootfs[depends] += "${NIBOOT_BUNDLE_IMAGE}:do_deploy"
-
 # If BUILDNAME is not already set in the build environment (common when doing a local dev build)
 # then set a default value that can be used only for display purposes. Setting the default value here
 # limits the scope of the default value to this file.
 BUILDNAME ?= "0.0.0"
 
-install_payload () {
-	install -d ${IMAGE_ROOTFS}/payload
-	install -m 0644 ${DEPLOY_DIR_IMAGE}/${NIBOOT_BUNDLE_IMAGE}-${MACHINE}.raucb  ${IMAGE_ROOTFS}/payload/niboot.raucb
-	echo "BUILD_IDENTIFIER=${BUILDNAME}" > ${IMAGE_ROOTFS}/payload/imageinfo
-	echo "IMAGE_DISPLAY_NAME=${IMAGE_DISPLAY_NAME}" >> ${IMAGE_ROOTFS}/payload/imageinfo
+create_payload_dir () {
+   install -d ${IMAGE_ROOTFS}/payload
 }
 
 symlink_iso () {
-        ln -sf ${PN}-${MACHINE}.wic ${DEPLOY_DIR_IMAGE}/${PN}-${MACHINE}.iso
+        ln -sf ${IMAGE_BASENAME}-${MACHINE}.wic ${DEPLOY_DIR_IMAGE}/${IMAGE_BASENAME}-${MACHINE}.iso
 }
 
-ROOTFS_POSTPROCESS_COMMAND += "symlink_iso;install_payload;"
+ROOTFS_POSTPROCESS_COMMAND += "create_payload_dir;symlink_iso;"
 
 require nilrt-image-common.inc

--- a/recipes-core/packagegroups/packagegroup-ni-restoremode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-restoremode.bb
@@ -31,6 +31,7 @@ RDEPENDS_${PN} += "\
     "
 
 RDEPENDS_${PN}_append_x64 = "\
+    binutils            \
     dmidecode           \
     efibootmgr          \
     efivar              \
@@ -41,6 +42,7 @@ RDEPENDS_${PN}_append_x64 = "\
     eudev               \
     ni-smbios-helper    \
     nilrtdiskcrypt      \
+    xz                  \
     "
 
 RDEPENDS_${PN}_append_xilinx-zynqhf = "\

--- a/scripts/lib/wic/canned-wks/grub.cfg
+++ b/scripts/lib/wic/canned-wks/grub.cfg
@@ -3,14 +3,15 @@ default='Default Provisioning'
 timeout=1
 
 search --set=root --label NIRECOVERY-CD
+probe --set bootmedia_uuid --fs-uuid ($root)
 
 menuentry 'Default Provisioning' {
-	linux /bzImage rootwait restore=provision quiet loglevel=1
+	linux /bzImage rootwait restore=provision bootmedia_uuid=$bootmedia_uuid quiet loglevel=1
 	initrd /initrd
 }
 
 menuentry 'Verbose Provisioning' {
-	linux /bzImage rootwait restore=provision verbose_mode=1
+	linux /bzImage rootwait restore=provision bootmedia_uuid=$bootmedia_uuid verbose_mode=1
 	initrd /initrd
 }
 

--- a/scripts/lib/wic/canned-wks/nilrt-recovery-media.x64.wks.in
+++ b/scripts/lib/wic/canned-wks/nilrt-recovery-media.x64.wks.in
@@ -2,7 +2,7 @@
 # long-description: Creates an EFI and legacy bootable hybrid ISO image
 # which can be used on optical media as well as USB media.
 
-part /boot --source isoimage-isohybrid --sourceparams="esp_label=NIRECOVERY,esp_extra_blocks=5000,loader=grub-efi,image_name=nilrt-restore-mode-image.x64" --ondisk cd --label NIRECOVERY-CD
+part /boot --source isoimage-isohybrid --sourceparams="esp_label=NIRECOVERY,esp_extra_blocks=5000,loader=grub-efi,image_name=nilrt-recovery-media.x64,payload_dir=${PAYLOAD_DIR}" --ondisk cd --label NIRECOVERY-CD
 
 # note that --append is ignored by grub when using a configfile
 # and only processed by syslinux as configured below

--- a/scripts/lib/wic/canned-wks/nilrt-restore-mode.x64.wks
+++ b/scripts/lib/wic/canned-wks/nilrt-restore-mode.x64.wks
@@ -1,0 +1,9 @@
+# short-description: Create a hybrid ISO image
+# long-description: Creates an EFI and legacy bootable hybrid ISO image
+# which can be used on optical media as well as USB media.
+
+part /boot --source isoimage-isohybrid --sourceparams="esp_label=NIRECOVERY,esp_extra_blocks=5000,loader=grub-efi,image_name=nilrt-restore-mode.x64" --ondisk cd --label NIRECOVERY-CD
+
+# note that --append is ignored by grub when using a configfile
+# and only processed by syslinux as configured below
+bootloader --configfile="grub.cfg" --append="restore=provision console=ttyS0"


### PR DESCRIPTION
On small memory targets, initrd containing payload doesn't
fit in RAM. These changes fix the issue.

There are now 2 iso images and 2 ipk images
  1. nilrt-restore-mode-image.iso - contains payload (rauc bundle),
     kernel, initrd, etc. Payload is outside initrd
     This is used for USB provisioning
  2. nilrt-restore-mode-boot-image.iso - same as (1) but without payload
     and is used in (4) below for IPK provisioning
  3. dist-nilrt-efi-ab.ipk - contains payload
  4. dist-nilrt-efi-ab-gateway.ipk - contains (2) and a scripts to
     set up target to boot into provisioning in next boot.

When provisioning from a USB formatted with nilrt-restore-mode-image.iso:
  1. Kernel, initrd are loaded from USB
  2. UUID of USB is passed from grub and is mounted
  3. Since root of USB contains payload, this is used for provisioning

For gateway ipk
  1. When gateway ipk is installed and its nilrt-install script is run,
     dist-nilrt-efi-ab.ipk is downloaded to nirootfs/payload
  2. If (1) is successful, nibootfs is overwritten with contents of
     nilrt-restore-mode-boot-image.iso
  3. After reboot, kernel and initrd are loaded from nibootfs
  4. UUID of nibootfs is passed down from grub and is mounted
  5. Since root of this partition does not contain payload, it is
     determined that this is ipk provisioning and payload is obtained
     from nirootfs partition

Testing:
  Verified USB, IPK provisioning works on a VM with same amount of memory
   as our smallest memory targets and on a cRIO-9030.

@ni/rtos 