### PR TITLE
openvpn: start initscript in rl 4 and 5

### DIFF
--- a/recipes-support/openvpn/openvpn_2.%.bbappend
+++ b/recipes-support/openvpn/openvpn_2.%.bbappend
@@ -12,7 +12,7 @@ RDEPENDS_{PN} += "niacctbase"
 inherit update-rc.d
 
 INITSCRIPT_NAME = "vpn"
-INITSCRIPT_PARAMS = "start 42 4 . stop 5 0 1 2 6 ."
+INITSCRIPT_PARAMS = "start 42 4 5 . stop 5 0 1 2 6 ."
 
 do_install_append () {
      install -d ${D}${sysconfdir}/default/volatiles/


### PR DESCRIPTION
The NILRT-specific openvpn-wrapping initscript: `vpn` is configured to start at `rc4.d/S42`. In a RAUC system, this means that the openvpn daemon will only start in the "safemode" equivalent runlevel.

Start it in both runlevels 4 and 5, so that users can configure openvpn to automatically start in both safemode and runmode.

Natinst-AZDO-ID: 1165918