### PR TITLE
linux-nilrt (and related): Use different pinned kernel versions

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-current.inc
+++ b/recipes-kernel/linux/linux-nilrt-current.inc
@@ -3,5 +3,6 @@ LINUX_VERSION = "4.14"
 KBRANCH = "nilrt/${NI_RELEASE_VERSION}/${LINUX_VERSION}"
 GIT_KERNEL_REPO = "linux.git"
 
+SRCREV="997fc3df5a3e740f585e6298cae9bd9d63832f7a"
 require linux-nilrt.inc
 

--- a/recipes-kernel/linux/linux-nilrt-next.inc
+++ b/recipes-kernel/linux/linux-nilrt-next.inc
@@ -3,6 +3,7 @@ LINUX_VERSION = "5.6"
 KBRANCH = "nilrt/${NI_RELEASE_VERSION}/${LINUX_VERSION}"
 GIT_KERNEL_REPO = "linux.git"
 
+SRCREV="4b4582056dc76290a36f8d9a2aab63dee2ce0808"
 require linux-nilrt.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"

--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -34,7 +34,6 @@ SRC_URI = "\
 	${NILRT_GIT}/${GIT_KERNEL_REPO};protocol=git;nocheckout=1;branch=${KBRANCH} \
 	file://export-kernel-headers.sh \
 "
-SRCREV="997fc3df5a3e740f585e6298cae9bd9d63832f7a"
 PV = "${LINUX_VERSION}+git${SRCPV}"
 
 # This checks ${PV} == version from kernel sources which our PV/AUTOREV breaks, so skip it.


### PR DESCRIPTION
This will pin the "current" version to the latest 4.14 and the
"next" version to the current 5.6 in development version.

Signed-off-by: James Minor <james.minor@ni.com>