### PR TITLE
packagegroup-ni-runmode: Add gdb

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -15,6 +15,7 @@ RDEPENDS_${PN} = "\
 	e2fsprogs-e2fsck \
 	e2fsprogs-mke2fs \
 	e2fsprogs-tune2fs \
+	gdb \
 	gdbserver \
 	glibc-gconv-cp932 \
 	glibc-gconv-cp936 \


### PR DESCRIPTION
Fix for this odd build [failure](https://dev.azure.com/ni/DevCentral/_build/results?buildId=565007&view=logs&j=7b573d1f-6776-53c2-0b0a-ff05672f5008&t=0a7242b1-32ca-59b5-a501-bcb76228df87&l=32484). When I added this dependency, it built alright locally, again, oddly.

Signed-off-by: Shruthi Ravichandran <shruthi.ravichandran@ni.com>