### PR TITLE
Replace globbing in file:// with list of files.

### DIFF
--- a/recipes-ni/nirtcfg-tests/nirtcfg-tests_1.0.bb
+++ b/recipes-ni/nirtcfg-tests/nirtcfg-tests_1.0.bb
@@ -15,7 +15,12 @@ SRC_URI = "\
     file://setup.sh \
     file://shared-functions.sh \
     file://teardown.sh \
-    file://test_* \
+    file://test_binary.sh \
+    file://test_clear.sh \
+    file://test_get.sh \
+    file://test_list.sh \
+    file://test_rm-if-empty.sh \
+    file://test_set.sh \
 "
 
 S = "${WORKDIR}"

--- a/recipes-ni/sysconfig-settings-ui/sysconfig-settings-ui_1.0.bb
+++ b/recipes-ni/sysconfig-settings-ui/sysconfig-settings-ui_1.0.bb
@@ -4,7 +4,23 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 SECTION = "base"
 
-SRC_URI = "file://uixml/* \
+SRC_URI = " \
+	   file://uixml/nilinuxrt.System.binding.xml \
+	   file://uixml/nilinuxrt.System.const.xml \
+	   file://uixml/nilinuxrt.System.const.de.xml \
+	   file://uixml/nilinuxrt.System.const.fr.xml \
+	   file://uixml/nilinuxrt.System.const.ja.xml \
+	   file://uixml/nilinuxrt.System.const.ko.xml \
+	   file://uixml/nilinuxrt.System.const.zh-CN.xml \
+	   file://uixml/nilinuxrt.System.def.xml \
+	   file://uixml/nilinuxrt.ui_enable.binding.xml \
+	   file://uixml/nilinuxrt.ui_enable.const.xml \
+	   file://uixml/nilinuxrt.ui_enable.const.de.xml \
+	   file://uixml/nilinuxrt.ui_enable.const.fr.xml \
+	   file://uixml/nilinuxrt.ui_enable.const.ja.xml \
+	   file://uixml/nilinuxrt.ui_enable.const.ko.xml \
+	   file://uixml/nilinuxrt.ui_enable.const.zh-CN.xml \
+	   file://uixml/nilinuxrt.ui_enable.def.xml \
 	   file://systemsettings/ui_enable.ini \
 "
 

--- a/recipes-ni/sysconfig-settings/sysconfig-settings_1.0.bb
+++ b/recipes-ni/sysconfig-settings/sysconfig-settings_1.0.bb
@@ -5,8 +5,33 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 SECTION = "base"
 
 SRC_URI = "file://niselectsystemsettings \
-	   file://uixml/* \
-	   file://systemsettings/* \
+           file://systemsettings/fpga_target.ini \
+           file://systemsettings/rt_target.ini \
+           file://systemsettings/target_common.ini \
+           file://uixml/nilinuxrt.rtprotocol_enable.binding.xml \
+           file://uixml/nilinuxrt.rtprotocol_enable.const.xml \
+           file://uixml/nilinuxrt.rtprotocol_enable.const.de.xml \
+           file://uixml/nilinuxrt.rtprotocol_enable.const.fr.xml \
+           file://uixml/nilinuxrt.rtprotocol_enable.const.ja.xml \
+           file://uixml/nilinuxrt.rtprotocol_enable.const.ko.xml \
+           file://uixml/nilinuxrt.rtprotocol_enable.const.zh-CN.xml \
+           file://uixml/nilinuxrt.rtprotocol_enable.def.xml \
+           file://uixml/nilinuxrt.soft_dip_switch.binding.xml \
+           file://uixml/nilinuxrt.soft_dip_switch.const.xml \
+           file://uixml/nilinuxrt.soft_dip_switch.const.de.xml \
+           file://uixml/nilinuxrt.soft_dip_switch.const.fr.xml \
+           file://uixml/nilinuxrt.soft_dip_switch.const.ja.xml \
+           file://uixml/nilinuxrt.soft_dip_switch.const.ko.xml \
+           file://uixml/nilinuxrt.soft_dip_switch.const.zh-CN.xml \
+           file://uixml/nilinuxrt.soft_dip_switch.def.xml \
+           file://uixml/nirio.soft_dip_switch.binding.xml \
+           file://uixml/nirio.soft_dip_switch.const.xml \
+           file://uixml/nirio.soft_dip_switch.const.de.xml \
+           file://uixml/nirio.soft_dip_switch.const.fr.xml \
+           file://uixml/nirio.soft_dip_switch.const.ja.xml \
+           file://uixml/nirio.soft_dip_switch.const.ko.xml \
+           file://uixml/nirio.soft_dip_switch.const.zh-CN.xml \
+           file://uixml/nirio.soft_dip_switch.def.xml \
 "
 
 FILES_${PN} += "/usr/local/natinst/share/uixml/sysconfig/* \


### PR DESCRIPTION
The upstream bitbake parser no longer supports globbing in file://
urls. Replace those instances with the complete list of files to be
included.

Built locally.