### PR TITLE
kernel-devsrc-next: Add recipe

### DIFF
--- a/recipes-core/packagegroups/packagegroup-kernel-module-build.bb
+++ b/recipes-core/packagegroups/packagegroup-kernel-module-build.bb
@@ -8,5 +8,6 @@ RDEPENDS_${PN} = "\
 	gcc \
 	gcc-symlinks \
 	kernel-dev \
+	kernel-devsrc \
 	make \
 	"

--- a/recipes-kernel/dkms/dkms_%.bbappend
+++ b/recipes-kernel/dkms/dkms_%.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS_${PN} += "kernel-devsrc"

--- a/recipes-kernel/linux/kernel-devsrc-next.bb
+++ b/recipes-kernel/linux/kernel-devsrc-next.bb
@@ -1,0 +1,5 @@
+KERNEL_DEPENDENCY = "linux-nilrt-next"
+KERNEL_DIRECTORY = "${DEPLOY_DIR_IMAGE}/kernel-next/staging_kernel_dir"
+KERNEL_BUILD_DIRECTORY = "${DEPLOY_DIR_IMAGE}/kernel-next/staging_kernel_builddir"
+
+require recipes-kernel/linux/kernel-devsrc.inc

--- a/recipes-kernel/linux/kernel-devsrc.bbappend
+++ b/recipes-kernel/linux/kernel-devsrc.bbappend
@@ -1,5 +1,5 @@
 pkg_postinst_ontarget_kernel-devsrc () {
-   cd /lib/modules/${KERNEL_VERSION}/build/scripts/mod
+   cd /lib/modules/${KERNEL_VERSION}/build
    make prepare
    make modules_prepare
 }

--- a/recipes-kernel/linux/kernel-devsrc.bbappend
+++ b/recipes-kernel/linux/kernel-devsrc.bbappend
@@ -1,0 +1,5 @@
+pkg_postinst_ontarget_kernel-devsrc () {
+   cd /lib/modules/${KERNEL_VERSION}/build/scripts/mod
+   make prepare
+   make modules_prepare
+}

--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -71,9 +71,6 @@ FILES_${PN}-module-versioning-headers = "/kernel"
 do_install_append() {
 	export CROSS_COMPILE=${CROSS_COMPILE} ARCH=${ARCH} KBUILD_OUTPUT=${KBUILD_OUTPUT}
 
-	# for NXG NILRT install under /lib/modules/ to be included in kernel-dev pkg
-	${WORKDIR}/export-kernel-headers.sh ${S} ${D}${base_libdir}/modules/${KERNEL_VERSION}/build
-
 	# for older NILRT install under /kernel for inclusion in squashfs for backwards
 	# compatibility with non-standard Linux installs (non-dkms). This should go away
 	# and older NILRT should be migrated to kernel-dev + dkms in the future.
@@ -183,11 +180,4 @@ pkg_postrm_${KERNEL_PACKAGE_NAME}-base_append_x64 () {
 			ln -f -s `tail -1 kernel-versions` "${KERNEL_IMAGETYPE}"
 		fi
 	fi
-}
-
-
-pkg_postinst_ontarget_kernel-dev () {
-	cd /lib/modules/${KERNEL_VERSION}/build/scripts/mod
-	mv ${HOST_PREFIX}elfconfig.h elfconfig.h
-	gcc -o modpost modpost.h modpost.c file2alias.c sumversion.c
 }


### PR DESCRIPTION
Backported commits from dunfell for kernel-dev and kernel-devsrc

Add recipe to build kernel-devsrc for kernel-next

@ni/rtos 