### PR TITLE
Revert "packagegroup-ni-runmode: Add gdb"

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -15,7 +15,6 @@ RDEPENDS_${PN} = "\
 	e2fsprogs-e2fsck \
 	e2fsprogs-mke2fs \
 	e2fsprogs-tune2fs \
-	gdb \
 	gdbserver \
 	glibc-gconv-cp932 \
 	glibc-gconv-cp936 \


### PR DESCRIPTION
This reverts commit b4cb254631fe798e2db00390a3fa3bff76c37c2c.

This change is unnecessary and did nothing to resolve the build failures I was running into. It was added in this [PR](https://github.com/ni/meta-nilrt/pull/59).