### PR TITLE
pkggrp-ni-safemode: Add e2fsprogs utilities to support formatting ext4 filesystem

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-safemode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-safemode.bb
@@ -11,4 +11,8 @@ inherit packagegroup
 
 RDEPENDS_${PN} = " \
 	initscripts-nilrt-safemode \
+	e2fsprogs \
+	e2fsprogs-e2fsck \
+	e2fsprogs-mke2fs \
+	e2fsprogs-tune2fs \
 "


### PR DESCRIPTION
The Artemis project introduces the use of SD card as the main disk in a zynq target.
In order to allow NIMAX to format the disk (which is in ext4 filesystem format), the
e2fsprogs utilities are required.
@ni/rtos 

Signed-off-by: wkoe <wilson.koe@ni.com>