### PR TITLE
Support for building versioned kernel-devsrc packages

### DIFF
--- a/recipes-kernel/linux/kernel-devsrc-next.bb
+++ b/recipes-kernel/linux/kernel-devsrc-next.bb
@@ -3,3 +3,15 @@ KERNEL_DIRECTORY = "${DEPLOY_DIR_IMAGE}/kernel-next/staging_kernel_dir"
 KERNEL_BUILD_DIRECTORY = "${DEPLOY_DIR_IMAGE}/kernel-next/staging_kernel_builddir"
 
 require recipes-kernel/linux/kernel-devsrc.inc
+
+do_install_append() {
+   # Remove the symlink so it doesn't conflict with other
+   # kernel-devsrc packages
+   rm -f ${D}/usr/src/kernel
+}
+
+pkg_postinst_ontarget_${PN} () {
+   cd /lib/modules/${KERNEL_VERSION}/build
+   make prepare
+   make modules_prepare
+}

--- a/recipes-kernel/linux/linux-nilrt-next.inc
+++ b/recipes-kernel/linux/linux-nilrt-next.inc
@@ -5,4 +5,10 @@ GIT_KERNEL_REPO = "linux.git"
 
 require linux-nilrt.inc
 
+kernel_do_deploy_append() {
+    cp -rf ${STAGING_KERNEL_DIR} $deployDir/staging_kernel_dir
+    cp -rf ${B} $deployDir/staging_kernel_builddir
+    rm -f $deployDir/staging_kernel_builddir/source
+}
+
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"


### PR DESCRIPTION
Moved some changes from https://github.com/ni/openembedded-core/pull/14 to here as per review feedback

@ni/rtos 