### PR TITLE
Fix driver build issue

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-next.inc
+++ b/recipes-kernel/linux/linux-nilrt-next.inc
@@ -7,7 +7,7 @@ require linux-nilrt.inc
 
 kernel_do_deploy_append() {
     cp -rf ${STAGING_KERNEL_DIR} $deployDir/staging_kernel_dir
-    cp -rf ${B} $deployDir/staging_kernel_builddir
+    cp -rf ${STAGING_KERNEL_BUILDDIR} $deployDir/staging_kernel_builddir
     rm -f $deployDir/staging_kernel_builddir/source
 }
 

--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -77,6 +77,10 @@ do_install_append() {
 	${WORKDIR}/export-kernel-headers.sh ${S} ${D}/kernel
 }
 
+do_shared_workdir_append() {
+	cp -rf ./* ${STAGING_KERNEL_BUILDDIR}
+}
+
 pkg_postinst_ontarget_${KERNEL_PACKAGE_NAME}-base_append_x64 () {
 	cd "$D/${KERNEL_IMAGEDEST}"
 


### PR DESCRIPTION
Fixes driver build issue on "current kernel".

Tested by installing kernel-devsrc on sumo and installing ni-kal without issues.
Installed kernel*next packages and installed ni-kal without issues.

@ni/rtos 