### PR TITLE
nilrt-base-image: Include nilrt proprietary packages

### DIFF
--- a/recipes-core/images/nilrt-base-image.bb
+++ b/recipes-core/images/nilrt-base-image.bb
@@ -1,6 +1,7 @@
 DESCRIPTION = "NI LinuxRT Base System Image for x64 Targets"
 
 require nilrt-base.inc
+require nilrt-proprietary.inc
 require nilrt-initramfs.inc
 require include/licenses.inc
 


### PR DESCRIPTION
I think this should make the rauc image comparable to the runmode image. 
Built the [nilrt-base-bundle](https://ni.visualstudio.com/DevCentral/_build/results?buildId=604835&view=logs&j=7b573d1f-6776-53c2-0b0a-ff05672f5008&t=0a7242b1-32ca-59b5-a501-bcb76228df87) with this change (ignore the feed_dunfell failure).

Signed-off-by: Shruthi Ravichandran <shruthi.ravichandran@ni.com>