### PR TITLE
kernel-devsrc-next: Notify dkms of new kernel

### DIFF
--- a/recipes-kernel/linux/kernel-devsrc-next.bb
+++ b/recipes-kernel/linux/kernel-devsrc-next.bb
@@ -14,4 +14,14 @@ pkg_postinst_ontarget_${PN} () {
    cd /lib/modules/${KERNEL_VERSION}/build
    make prepare
    make modules_prepare
+
+   if [ -e /etc/kernel/postinst.d ]; then
+      run-parts /etc/kernel/postinst.d -a ${KERNEL_VERSION}
+   fi
+}
+
+pkg_prerm_${PN} () {
+   if [ -e /etc/kernel/prerm.d ]; then
+      run-parts /etc/kernel/prerm.d -a ${KERNEL_VERSION}
+   fi
 }


### PR DESCRIPTION
Tested on a VM

@ni/rtos 