### PR TITLE
Enable empty root password login in images.

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -139,6 +139,7 @@ PACKAGE_CLASSES ?= "package_ipk"
 #                     e.g. ssh root access has a blank password
 # There are other application targets that can be used here too, see
 # meta/classes/image.bbclass and meta/classes/core-image.bbclass for more details.
+EXTRA_IMAGE_FEATURES += "empty-root-password allow-empty-password"
 
 #
 # Additional image features


### PR DESCRIPTION
Bill was not able to login to the images generated by the OE build. He validated that this change now allows him to login as root.

 @ni/rtos 