### PR TITLE
recipe-ni: add nisdbootconfig-safe and nisdbootconfig to configure boot from sd card

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -23,6 +23,7 @@ RDEPENDS_${PN} = "\
 	libfmi-dev \
 	librtpi \
 	lldpd \
+	nisdbootconfig \
 	niwatchdogpet \
 	parted \
 	rtctl \

--- a/recipes-core/packagegroups/packagegroup-ni-safemode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-safemode.bb
@@ -15,4 +15,5 @@ RDEPENDS_${PN} = " \
 	e2fsprogs-e2fsck \
 	e2fsprogs-mke2fs \
 	e2fsprogs-tune2fs \
+	nisdbootconfig \
 "

--- a/recipes-ni/nisdbootconfig/files/nisdbootconfig
+++ b/recipes-ni/nisdbootconfig/files/nisdbootconfig
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+
+# check if target is NOT using ubifs (mtd)
+if ! cat /proc/mtd | grep -qs mtd ; then
+
+    # configure the partitions to mount by label in fstab
+    sed -i '/ubifs/d' /etc/fstab
+    echo LABEL=nibootfs         /boot                ext4       sync           0  0 >>/etc/fstab
+    echo LABEL=niconfig         /etc/natinst/share   ext4       sync           0  0 >>/etc/fstab
+    mkdir -p /etc/natinst/share
+
+    # configure the nirootfs partition if we are in safemode
+    if [ -f /etc/natinst/safemode ]; then
+        echo LABEL=nirootfs         /mnt/userfs          ext4       defaults       0  0 >>/etc/fstab
+        mkdir -p /mnt/userfs
+    fi
+
+    # configure the path for fw_printenv to read environmental variables from u-boot
+    # replace /dev/mtd4 and /dev/mtd5 with /boot/uboot/uboot.env
+    sed -i '/mtd/d' /etc/fw_env.config
+    echo /boot/uboot/uboot.env         0x0000         0x20000 >>/etc/fw_env.config
+fi
+
+# we don't need this to run all the time, remove after first boot
+update-rc.d -f nisdbootconfig remove

--- a/recipes-ni/nisdbootconfig/nisdbootconfig.bb
+++ b/recipes-ni/nisdbootconfig/nisdbootconfig.bb
@@ -1,0 +1,26 @@
+SUMMARY = "NI SDboot Config"
+DESCRIPTION = "Configuration script for arm target booting from SD Card"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+SECTION = "base"
+
+inherit update-rc.d
+
+SRC_URI = "file://nisdbootconfig \
+"
+
+INITSCRIPT_NAME = "nisdbootconfig"
+INITSCRIPT_PARAMS = "start 00 S ."
+
+S = "${WORKDIR}"
+
+do_install () {
+	install -d ${D}${sysconfdir}/init.d/
+
+	# from artemis onwards, using sd card as main disk for arm target is introduced
+	# install nisdbootconfig to configure sd card booting requirement
+	if [ "${TARGET_ARCH}" = "arm" ]; then
+		install -m 0755 ${WORKDIR}/nisdbootconfig ${D}${sysconfdir}/init.d
+	fi
+
+}


### PR DESCRIPTION
Artemis uses sd card as its main disk instead of NAND disk (ubifs). Some configurations are required for it to boot properly. These configurations are mount points and fw_printenv configuration. The implementation for both safemode and runmode is similar, which is to install the script and invoke it earlier than mountall.sh so that the SD card partitions can be mounted properly and fw_printenv can function correctly with the right path to u-boot's environmental variable.

We can assume the arm target uses an sd card by checking the absence of mtd partition. Since this configuration is only needed on first boot, the script will remove its link once it has been executed.
@ni/rtos 