### PR TITLE
packagegroup-ni-extra: Add the kernel performance tests to the extra feed

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-desirable.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-desirable.bb
@@ -31,6 +31,7 @@ RDEPENDS_${PN} += "\
 	htop \
 	iperf2 \
 	iperf3 \
+	kernel-performance-tests \
 	ldd \
 	ltrace \
 	ntpdate \


### PR DESCRIPTION
Build and publish the kernel performance tests in the extra feed for
wider consumption.

Signed-off-by: Gratian Crisan <gratian.crisan@ni.com>