### PR TITLE
packagegroup-ni-extra: Add the kernel performance tests to the extra feed

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-extra.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-extra.bb
@@ -78,6 +78,7 @@ RDEPENDS_${PN} += "\
 # kernel regression tests
 RDEPENDS_${PN} += "\
 	kernel-test-fbomb \
+	kernel-performance-tests \
 "
 
 RDEPENDS_${PN} += "\


### PR DESCRIPTION
Build and publish the kernel performance tests in the extra feed for
wider consumption.

Signed-off-by: Gratian Crisan <gratian.crisan@ni.com>