### PR TITLE
initscripts-nilrt: Move nisetembeddeduixml into OE

### DIFF
--- a/recipes-ni/initscripts-nilrt/files/nisetembeddeduixml
+++ b/recipes-ni/initscripts-nilrt/files/nisetembeddeduixml
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+system_has_display_driver() {
+	[ -d /sys/class/drm ]
+}
+
+check_and_remove() {
+	if system_has_display_driver; then
+		return
+	fi
+	rm -f /var/local/natinst/systemsettings/ui_enable.ini
+	sed -i '/^.*embedded UI/,/^[ \t]*$/d' /etc/issue.template
+}
+
+case $1 in
+	start)
+		check_and_remove
+		;;
+	*)
+		;;
+esac
+

--- a/recipes-ni/initscripts-nilrt/initscripts-nilrt_1.0.bb
+++ b/recipes-ni/initscripts-nilrt/initscripts-nilrt_1.0.bb
@@ -37,6 +37,7 @@ SRC_URI = "file://nisetbootmode \
 "
 
 SRC_URI_append_x64 = "file://nidisablecstates \
+                      file://nisetembeddeduixml \
                       file://nicheckbiosconfig \
                       file://niopendisks \
                       file://niclosedisks \
@@ -65,6 +66,7 @@ do_install () {
 	fi
 
 	install -m 0755 ${WORKDIR}/mountdebugfs          ${D}${sysconfdir}/init.d
+	install -m 0755 ${WORKDIR}/nisetembeddeduixml    ${D}${sysconfdir}/init.d
 	install -m 0755 ${WORKDIR}/nicleanstalelinks     ${D}${sysconfdir}/init.d
 	install -m 0755 ${WORKDIR}/nicreatecpusets       ${D}${sysconfdir}/init.d
 	install -m 0755 ${WORKDIR}/nicreatecpuacctgroups ${D}${sysconfdir}/init.d
@@ -81,6 +83,7 @@ do_install () {
 	update-rc.d -r ${D} nisetbootmode         start 80 S . stop 0 0 6 .
 	update-rc.d -r ${D} firewall              start 39 S .
 	update-rc.d -r ${D} mountdebugfs          start 82 S .
+	update-rc.d -r ${D} nisetembeddeduixml    start 20 5 .
 	update-rc.d -r ${D} nicleanstalelinks     start 5  S .
 	update-rc.d -r ${D} nicreatecpusets       start 1  4 5 .
 	update-rc.d -r ${D} nicreatecpuacctgroups start 2  4 5 .


### PR DESCRIPTION
Move nisetembeddeduixml from os-common into OE

I wasn't sure if this should instead go here or into xserver-xfce-init.

The script was originally intended to work on both safemode and runmode so adding it here where it'd end up in rauc bundle makes sense if we want MAX experience to be same - xserver-xfce-init wouldn't presumably in rauc bundle so adding it there would change MAX experience.
But there are other scripts like this on os-common (e.g., niselectsystemsettings) which can have a better home than initscripts if MAX experience need not be exactly same. Thoughts?

@ni/rtos 