### PR TITLE
nisdbootconfig: Fixup commit 801d331 breaking x64 images.

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -39,6 +39,7 @@ NILRT_NXG_x64_PACKAGES = "\
 NILRT_ARM_PACKAGES = "\
 	jitterentropy-rngd \
 	mtd-utils-ubifs \
+	nisdbootconfig \
 "
 
 NILRT_x64_PACKAGES = "\

--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -23,7 +23,6 @@ RDEPENDS_${PN} = "\
 	libfmi-dev \
 	librtpi \
 	lldpd \
-	nisdbootconfig \
 	niwatchdogpet \
 	parted \
 	rtctl \

--- a/recipes-core/packagegroups/packagegroup-ni-safemode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-safemode.bb
@@ -15,5 +15,4 @@ RDEPENDS_${PN} = " \
 	e2fsprogs-e2fsck \
 	e2fsprogs-mke2fs \
 	e2fsprogs-tune2fs \
-	nisdbootconfig \
 "

--- a/recipes-ni/nisdbootconfig/nisdbootconfig.bb
+++ b/recipes-ni/nisdbootconfig/nisdbootconfig.bb
@@ -19,8 +19,5 @@ do_install () {
 
 	# from artemis onwards, using sd card as main disk for arm target is introduced
 	# install nisdbootconfig to configure sd card booting requirement
-	if [ "${TARGET_ARCH}" = "arm" ]; then
-		install -m 0755 ${WORKDIR}/nisdbootconfig ${D}${sysconfdir}/init.d
-	fi
-
+	install -m 0755 ${WORKDIR}/nisdbootconfig ${D}${sysconfdir}/init.d
 }

--- a/recipes-ni/nisdbootconfig/nisdbootconfig.bb
+++ b/recipes-ni/nisdbootconfig/nisdbootconfig.bb
@@ -4,6 +4,8 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 SECTION = "base"
 
+COMPATIBLE_MACHINE = "xilinx-zynq"
+
 inherit update-rc.d
 
 SRC_URI = "file://nisdbootconfig \


### PR DESCRIPTION
Commit 801d331 added nisdbootconfig to x64 images too. The recipe
inherits from update-rc.d but does not install any file to
/etc/init.d on x64 targets. This causes the post-inst of the package
to fail on x64 targets when the following command is run:
update-rc.d $OPT nisdbootconfig start 00 S .
because the nisdbootconfig file does not exist on that image.

To fix this, add the package to only ARM images in
packagegroup-ni-base since the package is common to both safemode and
runmode.

Testing: Still building the packagegroup-ni-base recipe. Will update when it is done.

@ni/rtos, fyi @NIwkoe 