### PR TITLE
packagegroup-ni-desirable: Fixup commit 8221f77, breaks ARM builds

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-desirable.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-desirable.bb
@@ -16,6 +16,7 @@ RDEPENDS_${PN}_append_x64 = "\
 	packagegroup-ni-next-kernel \
 	packagegroup-ni-mono-extra \
 	florence \
+	kernel-performance-tests \
 "
 
 RDEPENDS_${PN} += "\
@@ -32,7 +33,6 @@ RDEPENDS_${PN} += "\
 	htop \
 	iperf2 \
 	iperf3 \
-	kernel-performance-tests \
 	ldd \
 	ltrace \
 	mysql-python \


### PR DESCRIPTION
The kernel-performance-tests package depends on the fw-printenv
package that is marked [compatible](https://github.com/ni/meta-nilrt/blob/nilrt/master/sumo/recipes-ni/ni-utils/fw-printenv_1.0.bb#L14) only for x64 builds, thus breaking
ARM builds. As a quick workaround, set RDEPENDS on the tests package
only during x64 builds.
@gratian I'm not sure if this is the right change at all. I don't know if these
tests were intended to run on ARM targets. The alternative is to change the 
fw-printenv dependency for ARM builds. This is blocking a good SystemImage
build, so I thought I'll get a quick change out to start the conversation. Lmk
what you think.