### PR TITLE
kernel-performance-tests: Fix runtime dependency on fw-printenv

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-performance-tests.bb
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests.bb
@@ -11,7 +11,9 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-files:"
 S = "${WORKDIR}"
 
 DEPENDS = "virtual/kernel"
-RDEPENDS_${PN}-ptest += "bash rt-tests fio iperf3 fw-printenv"
+RDEPENDS_${PN}-ptest += "bash rt-tests fio iperf3"
+RDEPENDS_${PN}-ptest_append_x64 += "fw-printenv"
+RDEPENDS_${PN}-ptest_append_armv7a += "u-boot-fw-utils"
 
 ALLOW_EMPTY_${PN} = "1"
 


### PR DESCRIPTION
The 'fw_printenv' binary is provided by different packages on
different architectures:

  * 'fw-printenv' package on x86_x64 targets.

  * 'u-boot-fw-utils' on 32-bit ARM targets.

Make this runtime dependency machine specific.

Fixes: c2e2ecbdcd91 ("kernel-tests: Add kernel performance ptests")
Signed-off-by: Gratian Crisan <gratian.crisan@ni.com>