### PR TITLE
wpa-supplicant: Migrate dbus conf and service files from os-common

### DIFF
--- a/recipes-connectivity/wpa-supplicant/files/dbus-wpa_supplicant.conf
+++ b/recipes-connectivity/wpa-supplicant/files/dbus-wpa_supplicant.conf
@@ -1,0 +1,51 @@
+<!DOCTYPE busconfig PUBLIC
+ "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+        <policy user="webserv">
+                <allow own="fi.epitest.hostap.WPASupplicant"/>
+
+                <allow send_destination="fi.epitest.hostap.WPASupplicant"/>
+                <allow send_interface="fi.epitest.hostap.WPASupplicant"/>
+
+                <allow own="fi.w1.wpa_supplicant1"/>
+
+                <allow send_destination="fi.w1.wpa_supplicant1"/>
+                <allow send_interface="fi.w1.wpa_supplicant1"/>
+                <allow receive_sender="fi.w1.wpa_supplicant1" receive_type="signal"/>
+        </policy>
+        <policy user="root">
+                <allow own="fi.epitest.hostap.WPASupplicant"/>
+
+                <allow send_destination="fi.epitest.hostap.WPASupplicant"/>
+                <allow send_interface="fi.epitest.hostap.WPASupplicant"/>
+
+                <allow own="fi.w1.wpa_supplicant1"/>
+
+                <allow send_destination="fi.w1.wpa_supplicant1"/>
+                <allow send_interface="fi.w1.wpa_supplicant1"/>
+                <allow receive_sender="fi.w1.wpa_supplicant1" receive_type="signal"/>
+        </policy>
+        <policy user="lvuser">
+                <allow own="fi.epitest.hostap.WPASupplicant"/>
+
+                <allow send_destination="fi.epitest.hostap.WPASupplicant"/>
+                <allow send_interface="fi.epitest.hostap.WPASupplicant"/>
+
+                <allow own="fi.w1.wpa_supplicant1"/>
+
+                <allow send_destination="fi.w1.wpa_supplicant1"/>
+                <allow send_interface="fi.w1.wpa_supplicant1"/>
+                <allow receive_sender="fi.w1.wpa_supplicant1" receive_type="signal"/>
+        </policy>
+        <policy context="default">
+                <deny own="fi.epitest.hostap.WPASupplicant"/>
+                <deny send_destination="fi.epitest.hostap.WPASupplicant"/>
+                <deny send_interface="fi.epitest.hostap.WPASupplicant"/>
+
+                <deny own="fi.w1.wpa_supplicant1"/>
+                <deny send_destination="fi.w1.wpa_supplicant1"/>
+                <deny send_interface="fi.w1.wpa_supplicant1"/>
+                <deny receive_sender="fi.w1.wpa_supplicant1" receive_type="signal"/>
+        </policy>
+</busconfig>

--- a/recipes-connectivity/wpa-supplicant/files/fi.epitest.hostap.WPASupplicant.service
+++ b/recipes-connectivity/wpa-supplicant/files/fi.epitest.hostap.WPASupplicant.service
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=fi.epitest.hostap.WPASupplicant
+Exec=/usr/sbin/wpa_supplicant -Dnl80211 -i wlan0 -c /etc/natinst/share/wpa_supplicant.conf -u
+User=root

--- a/recipes-connectivity/wpa-supplicant/files/fi.w1.wpa_supplicant1.service
+++ b/recipes-connectivity/wpa-supplicant/files/fi.w1.wpa_supplicant1.service
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=fi.w1.wpa_supplicant1
+Exec=/usr/sbin/wpa_supplicant -Dnl80211 -i wlan0 -c /etc/natinst/share/wpa_supplicant.conf -u
+User=root

--- a/recipes-connectivity/wpa-supplicant/wpa-supplicant_2.%.bbappend
+++ b/recipes-connectivity/wpa-supplicant/wpa-supplicant_2.%.bbappend
@@ -2,6 +2,14 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI =+ "file://wep-hexkeys-and-wpa-psk-hexkeys-fix.patch \
             file://report-eap-authentication-state.patch \
+            file://dbus-wpa_supplicant.conf;subdir=nilrt \
+            file://fi.epitest.hostap.WPASupplicant.service;subdir=nilrt \
+            file://fi.w1.wpa_supplicant1.service;subdir=nilrt \
 "
 
 PACKAGECONFIG_append = " openssl"
+
+do_install_append () {
+	install -m 644 ${WORKDIR}/nilrt/dbus-wpa_supplicant.conf ${D}/${sysconfdir}/dbus-1/system.d
+	install -m 644 ${WORKDIR}/nilrt/*.service ${D}/${datadir}/dbus-1/system-services
+}


### PR DESCRIPTION
Add NILRT specific wpa-supplicant dbus configuration and service
files which used to live in os-common.

Signed-off-by: Gratian Crisan <gratian.crisan@ni.com>