### PR TITLE
pkggrp-ni-coreimagerepo: add pkggrp-ni-transconf

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-coreimagerepo.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-coreimagerepo.bb
@@ -5,12 +5,13 @@ inherit packagegroup
 
 RDEPENDS_${PN} = "\
 	packagegroup-ni-base \
+	packagegroup-ni-crio \
 	packagegroup-ni-ptest \
+	packagegroup-ni-restoremode \
+	packagegroup-ni-runmode \
+	packagegroup-ni-transconf \
 	packagegroup-ni-tzdata \
 	packagegroup-ni-wifi \
-	packagegroup-ni-runmode \
-	packagegroup-ni-crio \
-	packagegroup-ni-restoremode \
 	${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'packagegroup-core-x11', '', d)} \
 	packagegroup-core-standalone-sdk-target \
 	packagegroup-kernel-module-build \


### PR DESCRIPTION
Add the transconf packagegroup to the coreimagrepo so that we only have one necessary BB target to create the `core/` package feed. Previously, pkggrp-ni-transconf was built as an automatic dependency of one of the image builds done in the NIOE component.

-----

The transconf packagegroup is needed by all RAUC-enabled images to
provide package-specific hooks for core components. Add it to the
coreimagerepo to ensure that it is always available to RAUC image
builds.

* Trivial sort of the packagegroups in the RDEPENDS variable.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>