### PR TITLE
nilrt-proprietary: Add ni-rtlog, ni-wireless-cert-storage

### DIFF
--- a/recipes-core/images/nilrt-proprietary.inc
+++ b/recipes-core/images/nilrt-proprietary.inc
@@ -14,6 +14,7 @@ IMAGE_INSTALL_NODEPS = "\
         ni-avahi-client \
         ni-ca-certs \
         ni-rt-exec-webservice \
+        ni-rtlog \
         ni-service-locator \
         ni-skyline-file-client \
         ni-skyline-message-client \
@@ -32,6 +33,7 @@ IMAGE_INSTALL_NODEPS = "\
         ni-webdav-system-webserver-support \
         ni-webserver-libs \
         ni-webservices-webserver-support \
+        ni-wireless-cert-storage \
         nicurl \
         nirtcfg \
         nirtmdnsd \


### PR DESCRIPTION
These packages were installed in the image in os-common previously.

Built nilrt-base-image and verified installation of packages.

@ni/rtos 