### PR TITLE
nisdbootconfig: remove from base package and only install on safemode

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -39,7 +39,6 @@ NILRT_NXG_x64_PACKAGES = "\
 NILRT_ARM_PACKAGES = "\
 	jitterentropy-rngd \
 	mtd-utils-ubifs \
-	nisdbootconfig \
 "
 
 NILRT_x64_PACKAGES = "\

--- a/recipes-core/packagegroups/packagegroup-ni-safemode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-safemode.bb
@@ -16,3 +16,7 @@ RDEPENDS_${PN} = " \
 	e2fsprogs-mke2fs \
 	e2fsprogs-tune2fs \
 "
+
+RDEPENDS_${PN}_append_armv7a = " \
+	nisdbootconfig \
+"

--- a/recipes-ni/nisdbootconfig/files/nisdbootconfig
+++ b/recipes-ni/nisdbootconfig/files/nisdbootconfig
@@ -2,19 +2,15 @@
 set -e
 
 # check if target is NOT using ubifs (mtd)
-if ! cat /proc/mtd | grep -qs mtd ; then
+if ! grep -qs mtd /proc/mtd ; then
 
     # configure the partitions to mount by label in fstab
     sed -i '/ubifs/d' /etc/fstab
     echo LABEL=nibootfs         /boot                ext4       sync           0  0 >>/etc/fstab
     echo LABEL=niconfig         /etc/natinst/share   ext4       sync           0  0 >>/etc/fstab
+    echo LABEL=nirootfs         /mnt/userfs          ext4       defaults       0  0 >>/etc/fstab
     mkdir -p /etc/natinst/share
-
-    # configure the nirootfs partition if we are in safemode
-    if [ -f /etc/natinst/safemode ]; then
-        echo LABEL=nirootfs         /mnt/userfs          ext4       defaults       0  0 >>/etc/fstab
-        mkdir -p /mnt/userfs
-    fi
+    mkdir -p /mnt/userfs
 
     # configure the path for fw_printenv to read environmental variables from u-boot
     # replace /dev/mtd4 and /dev/mtd5 with /boot/uboot/uboot.env

--- a/recipes-ni/nisdbootconfig/nisdbootconfig.bb
+++ b/recipes-ni/nisdbootconfig/nisdbootconfig.bb
@@ -1,5 +1,5 @@
 SUMMARY = "NI SDboot Config"
-DESCRIPTION = "Configuration script for arm target booting from SD Card"
+DESCRIPTION = "Configuration script for safemode to enable arm target to boot from SD Card"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 SECTION = "base"


### PR DESCRIPTION
Commit ec1173c adds nisdbootconfig into base package with the condition to
only install on ARM images for both safemode and runmode. However, software
installation did not succeed because nisdbootconfig as a bootscript cannot
set up fw_env.config early enough for installation scripts that uses
fw_printenv. Hence, the nisdbootconfig script for runmode will be moved into
postinst of systemlink base image.

This commit includes removing the safemode check portion of the script,
removing nisdbootconfig from base recipe and adding it into safemode recipe
with append_armv7a.

@ni/rtos 

Signed-off-by: wkoe <wilson.koe@ni.com>