### PR TITLE
pkggrp-ni-coreimagrepo: add oe-core packagegroups

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-coreimagerepo.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-coreimagerepo.bb
@@ -4,6 +4,8 @@ LICENSE = "MIT"
 inherit packagegroup
 
 RDEPENDS_${PN} = "\
+	packagegroup-base \
+	packagegroup-core-boot \
 	packagegroup-ni-base \
 	packagegroup-ni-crio \
 	packagegroup-ni-ptest \


### PR DESCRIPTION
Packagesgroups-(base, core-boot) are normally included in all images
which inherit the OE base image class. Include them in the coreimagerepo
to ensure that they are available in the feeds at image-creation-time.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

@ni/rtos 