### PR TITLE
x64.conf: remove lms RDEPENDS

### DIFF
--- a/conf/machine/x64.conf
+++ b/conf/machine/x64.conf
@@ -9,8 +9,6 @@ DEFAULTTUNE ?= "core2-64"
 require conf/machine/include/tune-core2.inc
 require conf/machine/include/x86-base.inc
 
-MACHINE_EXTRA_RRECOMMENDS += "lms"
-
 XSERVER = "${XSERVER_X86_BASE} \
 	   ${XSERVER_X86_EXT} \
 	   ${XSERVER_X86_I915} \


### PR DESCRIPTION
The 'lms' recipe is provided by the meta-intel layer - which has not
been a part of the NILRT sources for many releases. Remove the RDEPENDS
on lms for consistency and because it blocks installation of
packagegroup-base-extended.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>