### PR TITLE
Switch Dunfell images to use build from feeds for core packages.

### DIFF
--- a/recipes-core/images/nilrt-base.inc
+++ b/recipes-core/images/nilrt-base.inc
@@ -16,24 +16,24 @@ IMAGE_FEATURES += "\
 IMAGE_ROOTFS_EXTRA_SPACE = "500000"
 
 # boot management
-IMAGE_INSTALL += "\
+IMAGE_INSTALL_NODEPS += "\
 	rauc \
 	rauc-mark-good \
 "
 
+# kernel software
+IMAGE_INSTALL_NODEPS += "\
+	dkms \
+"
+
 # user software
-IMAGE_INSTALL += "\
+IMAGE_INSTALL_NODEPS += "\
 	packagegroup-ni-base \
 	packagegroup-ni-runmode \
 	packagegroup-ni-transconf \
 	packagegroup-ni-tzdata \
 	packagegroup-ni-wifi \
 	packagegroup-ni-xfce \
-"
-
-# kernel software
-IMAGE_INSTALL += "\
-	dkms \
 "
 
 addtask image_build_test before do_rootfs

--- a/recipes-core/images/nilrt-proprietary.inc
+++ b/recipes-core/images/nilrt-proprietary.inc
@@ -6,7 +6,7 @@
 LDCONFIGDEPEND = ""
 
 # NI infrastructure packages to be installed in the image
-IMAGE_INSTALL_NODEPS = "\
+IMAGE_INSTALL_NODEPS += "\
         libnitargetcfg \
         ni-arch-gen \
         ni-auth \


### PR DESCRIPTION
Change all package installs in the base images to use `IMAGE_INSTALL_NODEPS`, to force bitbake to use the configured opkg feeds for core package installation (as opposed to building recipes locally).

This PR doesn't cover *every* package which would be installed to the base images and initramfs images, but does at least the vast majority.