### PR TITLE
pkggrp-base: replace wireless-regdb-static

### DIFF
--- a/recipes-core/packagegroups/packagegroup-base.bbappend
+++ b/recipes-core/packagegroups/packagegroup-base.bbappend
@@ -1,0 +1,7 @@
+
+# The `wireless-regdb-static` subpackage installs static databases for wireless
+# regulatory negotiation. NILRT uses CRDA for run-time negotiation, so these
+# databse files are superfluous. They also CONFLICT with `wireless-regdb` and
+# so need to be removed.
+RDEPENDS_packagegroup-base-wifi_remove += "wireless-regdb-static"
+RDEPENDS_packagegroup-base-wifi += "wireless-regdb"


### PR DESCRIPTION
The base packagegroup provided by OE-core uses the static variant of the
wireless regulatory databases (wireless-regdb-static). NILRT needs the
dynamic version provided by CONFLICTing package (wireless-regdb).

Replace the static version with the dynamic version to enable base
packagegroup installation.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

-----

Resolves this [this AZDO build error](https://dev.azure.com/ni/DevCentral/_build/results?buildId=676790&view=logs&j=44e70749-ceba-5737-fad1-33069546191c&t=a2065b91-4596-5839-9588-2e1a5df2fc02&l=8253).

@ni/rtos 