### PR TITLE
fw_printenv: Add fw_env.config from os-common

### DIFF
--- a/recipes-ni/ni-utils/files/x64/fw_env.config
+++ b/recipes-ni/ni-utils/files/x64/fw_env.config
@@ -1,0 +1,7 @@
+# Configuration file for fw_(printenv/saveenv) utility.
+# Up to two entries are valid, in this case the redundand
+# environment sector is assumed present.
+
+# MTD device name	Device offset	Env. size	Flash sector size
+/dev/mtd4		0x0000		0x20000		0x20000
+/dev/mtd5		0x0000		0x20000		0x20000

--- a/recipes-ni/ni-utils/fw-printenv_1.0.bb
+++ b/recipes-ni/ni-utils/fw-printenv_1.0.bb
@@ -9,6 +9,7 @@ SRC_URI = "\
 	file://EFI_NI_vars \
 	file://SMBIOS_NI_vars \
 	file://grubvar_readonly \
+	file://fw_env.config \
 "
 
 COMPATIBLE_MACHINE = "x64"
@@ -24,6 +25,7 @@ S = "${WORKDIR}"
 do_install () {
 	install -d ${D}${base_sbindir}
 	install -d ${D}${datadir}/fw_printenv
+	install -d ${D}${sysconfdir}
 
 	install -m 0550   ${WORKDIR}/fw_printenv         ${D}${base_sbindir}
 	sed -i -e 's,@FW_PRINTENV_DIR@,${datadir}/fw_printenv,g' ${D}${base_sbindir}/fw_printenv
@@ -34,4 +36,6 @@ do_install () {
 	install -m 0444   ${WORKDIR}/EFI_NI_vars         ${D}${datadir}/fw_printenv
 	install -m 0444   ${WORKDIR}/SMBIOS_NI_vars      ${D}${datadir}/fw_printenv
 	install -m 0444   ${WORKDIR}/grubvar_readonly    ${D}${datadir}/fw_printenv
+
+	install -m 0644   ${WORKDIR}/fw_env.config       ${D}${sysconfdir}
 }


### PR DESCRIPTION
Move fw_env.config from os-common.

Built the recipe and confirmed the ipk contains the new contents.

@ni/rtos 