### PR TITLE
linux: set a static kernel version extension

### DIFF
--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -3,8 +3,7 @@ require recipes-kernel/linux/linux-yocto.inc
 
 machine_srcrev="${SRCREV}"
 
-# Set the version for traceability purposes
-LINUX_VERSION_EXTENSION = "$([ -z "${BUILDNAME}" ] || echo '-')${BUILDNAME}"
+LINUX_VERSION_EXTENSION = "-ni"
 
 # Setting EXTRA_OEMAKE to include CFLAGS settings is required as
 # the Kbuild system will clobber CC (which is used by OE for setting


### PR DESCRIPTION
The BUILDNAME variable is set to values like `20.7.0d127-x64-` on build
machines and `20.7.0d9999-x64-` on developer machines. As a result, dev
builds which try to use build-machine-produced exports will appear to
use mismatching kernels and image builds will fail.

Set the kernel version extension to a static value to enable developers
using build machine artifacts.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

---

## Testing

Built `linux-nilrt` on my dev machine and verified that the ipk it creates is now:
`kernel-4.14.146-rt67-ni_4.14+git100+78f4e2b071-r0.55_x64.ipk`

was previously like
`kernel-4.14.146-rt67-20.7.0d177-x64-_4.14+git100+78f4e2b071-r0.28_x64.ipk`

@ni/rtos 