### PR TITLE
rt-tests: Fix PREEMPT_RT presence test

### DIFF
--- a/recipes-rt/rt-tests/files/kernel_test_preempt_rt_presence.sh
+++ b/recipes-rt/rt-tests/files/kernel_test_preempt_rt_presence.sh
@@ -3,11 +3,11 @@
 source $(dirname "$0")/ptest-format.sh
 ptest_test=$(basename "$0" ".sh")
 
-if [ $(uname -a | grep 'PREEMPT RT' | wc -l) -eq 0 ]; then
+if uname -a | grep -qs 'PREEMPT_RT'; then
+	ptest_pass
+else
 	echo "kernel was not configured to use PREEMPT_RT"
 	ptest_fail
-else
-	ptest_pass
 fi
 
 ptest_report


### PR DESCRIPTION
The kernel_test_preempt_rt_presence.sh ptest incorrectly greps for the presence
of 'PREEMPT RT' string instead of the expected 'PREEMPT_RT' in the 'uname -a'
output (note the missing underscore).

In the process also simplify the test to avoid spawning a subshell and a call
to 'wc'.

Signed-off-by: Gratian Crisan <gratian.crisan@ni.com>