### PR TITLE
initrdscripts: add ptest for ni_provisioning script

### DIFF
--- a/recipes-core/initrdscripts/files/ptest/run-ptest
+++ b/recipes-core/initrdscripts/files/ptest/run-ptest
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+SCRIPT_ROOT=$(dirname $0)
+
+${SCRIPT_ROOT}/test_ni_provisioning.sh

--- a/recipes-core/initrdscripts/files/ptest/test_ni_provisioning.sh
+++ b/recipes-core/initrdscripts/files/ptest/test_ni_provisioning.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+#
+# Test that the booted storage disk matches the partition scheme which we
+# expect from the ni_provisioning script. This ptest only supports the efi-ab
+# bootscheme present on new x64, RAUC-based targets.
+exec 2>&1
+
+
+PTEST_TEST='ni_provisioning'
+
+print_error() {
+	echo ERROR: $@ >&2
+	found_error=true
+}
+
+ptest_fail() {
+	echo "FAIL: $PTEST_TEST"
+	exit 1
+}
+
+ptest_pass() {
+	echo "PASS: $PTEST_TEST"
+	exit 0
+}
+
+ptest_skip() {
+	echo "SKIP: $PTEST_TEST"
+	exit 77
+}
+
+
+test_part_id () {
+	local device=${1}
+	local label=${2}
+	local uuid=${3}
+
+	local correct_re_label=${4}
+	local correct_re_uuid=${5}
+
+	echo "test_part_id() ${@:1:3}"
+
+	if [[ ! "${label}" =~ $correct_re_label ]]; then
+		print_error "Partition ${label} @ ${device} does not match required label ${correct_re_label}"
+		found_error=true
+	fi
+	if [[ ! "${uuid}" =~ $correct_re_uuid ]]; then
+		print_error "Partition ${label} @ ${device} does not match required type UUID ${correct_re_uuid}"
+		found_error=true
+	fi
+}
+
+
+found_error=false
+
+if uname --machine | grep -q arm; then
+	echo "INFO: detected an ARM machine architecture." \
+	     "This ptest is only valid for non-ARM, RAUC systems."
+	ptest_skip
+fi
+
+
+## PARTITION TESTS ##
+echo "## Checking that RAUC partitons are present..."
+RE_ESP_UUID=C12A7328\-F81F\-11D2\-BA4B\-00A0C93EC93B
+
+# Determine the configured /boot storage device. Assert that this device should
+# be the root of the partitions we evaluate in the remainder of this test.
+# For RAUC systems, we expect this to be: /dev/sda, but it isn't required to be.
+boot_part=$(findmnt --kernel --first-only --noheadings --output SOURCE /boot)
+test -n "${boot_part}" || (print_error "No detected /boot mount; system state invalid."; ptest_fail)
+boot_dev=/dev/$(lsblk -no PKNAME ${boot_part})
+test -e "${boot_dev}" || (print_error "Boot device ${boot_dev} does not exist; system state invalid."; ptest_fail)
+
+
+readarray -t parts < <(fdisk -l ${boot_dev} -o Device,Name,Type-UUID | grep -o -E '^\/dev\/.*')
+
+# ASSERT: part 0 is: niboota and is an ESP partition
+test_part_id ${parts[0]} niboota $RE_ESP_UUID
+# ASSERT: part 1 is: nibootb and is an ESP partition
+test_part_id ${parts[1]} nibootb $RE_ESP_UUID
+# ASSERT: part 2 is: niuser and is any partition type
+test_part_id ${parts[2]} niuser '.*'
+
+# bail out if the partition tests failed
+$found_error && ptest_fail
+
+
+## PARTITION CONTENTS TESTING ##
+echo "## Checking that niboot* contents are similar..."
+set -eo pipefail
+
+# Unmount the read-only partitions and remove their empty directories
+unmount_ro_partitions () {
+	set +e
+	for part in $@; do
+		[ -d ${part} ] && umount -f ${part} && rmdir ${part}
+	done
+}
+
+# After provisioning, niboota and nibootb should contain exactly the same contents.
+mnt_a=$(mktemp -d --tmpdir $PTEST_TEST.niboota.XXXXX)
+mnt_b=$(mktemp -d --tmpdir $PTEST_TEST.nibootb.XXXXX)
+
+trap "unmount_ro_partitions ${mnt_a} ${mnt_b}; exit 99" EXIT
+
+mount -o ro -L niboota ${mnt_a}
+mount -o ro -L nibootb ${mnt_b}
+
+diff --recursive ${mnt_a} ${mnt_b} || \
+	print_error "niboot partition contents differ appreciably."
+echo "----"
+
+trap - EXIT
+unmount_ro_partitions ${mnt_a} ${mnt_b}
+
+
+## EFI VARIABLE TESTS ###
+echo "## Checking EFI bootorder..."
+found_niboota=false
+found_nibootb=false
+
+efibootmgr -v  # INFO
+IFS=',' read -a efi_bootorder < <(efibootmgr | grep '^BootOrder: ' | cut -d' ' -f2)
+
+echo "----"
+# ASSERT: bootpriorities 0 and 1 are niboota and nibootb, in any order.
+for bootnum in 0 1; do
+	bootorder=${efi_bootorder[${bootnum}]}
+	bootlabel=$(efibootmgr | grep "^Boot${bootorder}\*" | cut -d' ' -f2-)
+	case $bootlabel in
+		niboota)
+			found_niboota=true
+			echo 'INFO: Found niboota in bootorder.'
+			;;
+		nibootb)
+			found_nibootb=true
+			echo 'INFO: Found nibootb in bootorder.'
+			;;
+		*)
+			print_error "efi_bootorder[${bootnum}] is (${bootorder}, \"${bootlabel}\"); not one of: niboota, nibootb"
+			found_error=true
+			;;
+	esac
+done
+# fail if either a or b was not found
+($found_niboota && $found_nibootb) || found_error=true
+
+$found_error && ptest_fail
+
+
+ptest_pass

--- a/recipes-core/initrdscripts/files/ptest/test_ni_provisioning.sh
+++ b/recipes-core/initrdscripts/files/ptest/test_ni_provisioning.sh
@@ -88,6 +88,28 @@ test_part_id ${parts[2]} niuser $RE_X64_ROOT_UUID
 $found_error && ptest_fail
 
 
+## RAUC PARTITION DEVICE LINKS TESTING ##
+echo "## Checking for RAUC partition device links in /dev..."
+test -d /dev/niboot || print_error "/dev/niboot does not exist."
+
+niboot_links=(\
+	/dev/niboot/niboot.current \
+	/dev/niboot/niboot.other \
+	/dev/niboot/niboota \
+	/dev/niboot/nibootb \
+	/dev/niboot/niuser \
+)
+for link in ${niboot_links[@]}; do
+	if [ -L "$link" ]; then
+		echo "${link} [OK]"
+	else
+		echo "${link} [FAIL]"
+		print_error "Device link \"$link\" does not exist."
+	fi
+done
+# the link subtests are not critical failures, so keep testing, even if they fail.
+
+
 ## PARTITION CONTENTS TESTING ##
 echo "## Checking that niboot* contents are similar..."
 set -eo pipefail

--- a/recipes-core/initrdscripts/files/ptest/test_ni_provisioning.sh
+++ b/recipes-core/initrdscripts/files/ptest/test_ni_provisioning.sh
@@ -61,7 +61,10 @@ fi
 
 ## PARTITION TESTS ##
 echo "## Checking that RAUC partitons are present..."
+# The UUIDs here should match those set by the disk_config_x64 file.
+# https://github.com/ni/meta-nilrt/blob/983d50796302b394aa428b992dae48b4da32ff08/recipes-core/initrdscripts/files/disk_config_x64#L28
 RE_ESP_UUID=C12A7328\-F81F\-11D2\-BA4B\-00A0C93EC93B
+RE_X64_ROOT_UUID=4F68BCE3\-E8CD\-4DB1\-96E7\-FBCAF984B709
 
 # Determine the configured /boot storage device. Assert that this device should
 # be the root of the partitions we evaluate in the remainder of this test.
@@ -79,7 +82,7 @@ test_part_id ${parts[0]} niboota $RE_ESP_UUID
 # ASSERT: part 1 is: nibootb and is an ESP partition
 test_part_id ${parts[1]} nibootb $RE_ESP_UUID
 # ASSERT: part 2 is: niuser and is any partition type
-test_part_id ${parts[2]} niuser '.*'
+test_part_id ${parts[2]} niuser $RE_X64_ROOT_UUID
 
 # bail out if the partition tests failed
 $found_error && ptest_fail

--- a/recipes-core/initrdscripts/init-restore-mode_1.0.bb
+++ b/recipes-core/initrdscripts/init-restore-mode_1.0.bb
@@ -3,12 +3,12 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 SRC_URI = "\
-	file://init-restore-mode.sh \
 	file://00-init-restore-mode.sh \
-        file://efifix \
+	file://efifix \
+	file://init-restore-mode.sh \
 	file://ni_provisioning \
-	file://ni_provisioning.common \
 	file://ni_provisioning.answers.default \
+	file://ni_provisioning.common \
 "
 
 SRC_URI_append_xilinx-zynqhf = "\
@@ -16,12 +16,20 @@ SRC_URI_append_xilinx-zynqhf = "\
 "
 
 SRC_URI_append_x64 = "\
-	file://ni_provisioning.safemode \
 	file://disk_config_x64 \
 	file://grub.cfg	\
+	file://ni_provisioning.safemode \
+	file://ptest \
 "
 
 RDEPENDS_${PN} += "bash rauc"
+
+inherit ptest
+
+RDEPENDS_${PN}-ptest += "bash efibootmgr"
+# The ptests should be run on a system which has already been provisioned, so a
+# dependency on the provisioning scripts is not necessary.
+RDEPENDS_${PN}-ptest_remove += "${PN}"
 
 do_install() {
 	install -m 0755 ${WORKDIR}/init-restore-mode.sh ${D}/init
@@ -42,6 +50,11 @@ do_install_append_x64() {
 
 do_install_append_xilinx-zynqhf() {
 	install -m 0755 ${WORKDIR}/disk_config_xilinx-zynqhf ${D}/disk_config
+}
+
+do_install_ptest_append_x64() {
+	install -m 0755 ${WORKDIR}/ptest/run-ptest               ${D}${PTEST_PATH}
+	install -m 0755 ${WORKDIR}/ptest/test_ni_provisioning.sh ${D}${PTEST_PATH}
 }
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
Signed-off-by: Alex Stewart <alex.stewart@ni.com>

## IPK info
```
root@NI-Unknown-525400123456:/etc/opkg# opkg info init-restore-mode-ptest
Package: init-restore-mode-ptest
Version: 1.0-r0.1584
Depends: bash, efibootmgr
Recommends: init-restore-mode-lic, ptest-runner
Status: install ok installed
Section: devel
Architecture: x64
Maintainer: NI Linux Real-Time Maintainers <nilrt@ni.com>
MD5Sum: 670856f8d7c2117324598ba3059d51e4
Size: 2584
Filename: init-restore-mode-ptest_1.0-r0.1584_x64.ipk
Source: init-restore-mode_1.0.bb
Description: Extremely basic live image init script - Package test files
Installed-Size: 4102
Installed-Time: 1614100987
OE: init-restore-mode
License: MIT
```

## SAMPLE OUTPUT

*From a recently provisioned QEMU image:*
```bash
root@NI-Unknown-525400123456:/etc/opkg# ptest-runner
START: ptest-runner
2021-02-23T17:23
BEGIN: /usr/lib/init-restore-mode/ptest
## Checking that RAUC partitons are present...
test_part_id() /dev/sda1 niboota C12A7328-F81F-11D2-BA4B-00A0C93EC93B
test_part_id() /dev/sda2 nibootb C12A7328-F81F-11D2-BA4B-00A0C93EC93B
test_part_id() /dev/sda3 niuser 4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709
## Checking that niboot* contents are similar...
----
## Checking EFI bootorder...
BootCurrent: 0004
Timeout: 0 seconds
BootOrder: 0000,0001,0003,0004,0005,0006
Boot0000* EFI Floppy	PciRoot(0x0)/Pci(0x1,0x0)/Floppy(0x0)
Boot0001* EFI Floppy 1	PciRoot(0x0)/Pci(0x1,0x0)/Floppy(0x1)
Boot0003* EFI DVD/CDROM	PciRoot(0x0)/Pci(0x1,0x1)/Ata(1,0,0)
Boot0004* EFI Hard Drive	PciRoot(0x0)/Pci(0x1,0x1)/Ata(0,0,0)
Boot0005* EFI Network	PciRoot(0x0)/Pci(0x3,0x0)/MAC(525400123456,1)
Boot0006* EFI Internal Shell	MemoryMapped(11,0x900000,0x11fffff)/FvFile(7c04a583-9e3e-4f1c-ad65-e05268d0b4d1)
----
ERROR: efi_bootorder[0] is (0000, "EFI Floppy"); not one of: niboota, nibootb
ERROR: efi_bootorder[1] is (0001, "EFI Floppy 1"); not one of: niboota, nibootb
FAIL: ni_provisioning

ERROR: Exit status is 256
END: /usr/lib/init-restore-mode/ptest
2021-02-23T17:23
STOP: ptest-runner
```
* The bootorder failures are known bugs for the provisioning image.

## Testing

* Built the recipe and installed the new `-ptest` IPK to a VM.
* Verified that the IPK installs correctly and also installs the `ptest-runner` along with it.
* Removed the package and verified that the ptest contents are removed.

## Notes

* I haven't decided if this test is appropriate for the `ptest-smoke` packagegroup. We might like to explicitly install and run it only after the provisioning tool has run. 