### PR TITLE
initrdscripts: update ptest with differing files

### DIFF
--- a/recipes-core/initrdscripts/files/ptest/test_ni_provisioning.sh
+++ b/recipes-core/initrdscripts/files/ptest/test_ni_provisioning.sh
@@ -131,8 +131,15 @@ trap "unmount_ro_partitions ${mnt_a} ${mnt_b}; exit 99" EXIT
 mount -o ro -L niboota ${mnt_a}
 mount -o ro -L nibootb ${mnt_b}
 
-diff --recursive ${mnt_a} ${mnt_b} || \
+DIFF_BLACKLIST=$(cat <<-EOF
+	slot.raucs
+EOF
+)
+if diff --exclude-from=- --recursive ${mnt_a} ${mnt_b}; then
+	echo "INFO: All tracked files are similar."
+else
 	print_error "niboot partition contents differ appreciably."
+fi <<<"$DIFF_BLACKLIST"
 echo "----"
 
 trap - EXIT


### PR DESCRIPTION
The contents of /boot/slot.raucs is expected to differ between RAUC
slots on a properly-formatted system. Blacklist it from being diffed in
the ptest.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

When I manually run the `/ni_provisioning` script in the ISO, I can get a properly-configured system. It also creates the `/boot/slot.raucs` file which @billpittman expected to be present and differ between the RAUC partitions. When I manually provision in this way, and with this new blacklist, the provisioning ptest passes and looks like this:
```bash
## Checking that RAUC partitons are present...
test_part_id() /dev/sda1 niboota C12A7328-F81F-11D2-BA4B-00A0C93EC93B
test_part_id() /dev/sda2 nibootb C12A7328-F81F-11D2-BA4B-00A0C93EC93B
test_part_id() /dev/sda3 niuser 4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709
## Checking for RAUC partition device links in /dev...
/dev/niboot/niboot.current [OK]
/dev/niboot/niboot.other [OK]
/dev/niboot/niboota [OK]
/dev/niboot/nibootb [OK]
/dev/niboot/niuser [OK]
## Checking that niboot* contents are similar...
INFO: All tracked files are similar.
----
## Checking EFI bootorder...
BootCurrent: 0007
Timeout: 0 seconds
BootOrder: 0007,0008,0000,0001,0003,0004,0005,0006
Boot0000* EFI Floppy	PciRoot(0x0)/Pci(0x1,0x0)/Floppy(0x0)
Boot0001* EFI Floppy 1	PciRoot(0x0)/Pci(0x1,0x0)/Floppy(0x1)
Boot0003* EFI DVD/CDROM	PciRoot(0x0)/Pci(0x1,0x1)/Ata(1,0,0)
Boot0004* EFI Hard Drive	PciRoot(0x0)/Pci(0x1,0x1)/Ata(0,0,0)
Boot0005* EFI Network	PciRoot(0x0)/Pci(0x3,0x0)/MAC(525400123456,1)
Boot0006* EFI Internal Shell	MemoryMapped(11,0x900000,0x11fffff)/FvFile(7c04a583-9e3e-4f1c-ad65-e05268d0b4d1)
Boot0007* niboota	HD(1,GPT,f94a89f5-d01e-440f-891c-6f41863c23a3,0x800,0xbe000)/File(\efi\nilrt\bootx64.efi)
Boot0008* nibootb	HD(2,GPT,035141bf-9a4c-4002-a83a-8bd9f0f312a5,0xbe800,0xbf000)/File(\efi\nilrt\bootx64.efi)
----
INFO: Found niboota in bootorder.
INFO: Found nibootb in bootorder.
PASS: ni_provisioning
```

I still need to figure out why the automatic provisioning process doesn't work.

----

@ni/rtos 