### PR TITLE
misc. changes to make the RAUC-enabled provisioning ISO work

### DIFF
--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -15,10 +15,6 @@ VIRTUAL-RUNTIME_xserver_common = "xserver-common"
 
 VIRTUAL-RUNTIME_mountpoint ?= "busybox"
 
-# on older NILRT distro flavors the kernel is installed in non-standard paths
-# for backward compatibility
-KERNEL_IMAGEDEST = "boot/runmode"
-
 # Needs to change thanks to NIAuth
 # - cf oe-core base-files/base-files/profile
 # - cf oe-core base-files/base-files_3.0.14.bb

--- a/recipes-core/images/nilrt-base-bundle-image.bb
+++ b/recipes-core/images/nilrt-base-bundle-image.bb
@@ -36,10 +36,11 @@ bootimg_fixup() {
 	echo >>"${IMAGE_ROOTFS}/boot/readme.txt" " - initrd.cpio.gz: ${INITRAMFS_IMAGE}-${MACHINE}.cpio.gz ramdisk image"
 	echo >>"${IMAGE_ROOTFS}/boot/readme.txt" " - baserootfs.squashfs: ${BASEROOTFS_IMAGE}-${MACHINE}.tar.bz2 root file system image"
 
-	# Move /boot/runmode/bzImage to /boot/bzImage
-	mv "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/$(readlink "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/bzImage")" "${IMAGE_ROOTFS}/boot/bzImage"
-	# Remove /boot/runmode
-	rm -rf "${IMAGE_ROOTFS}/boot/runmode"
+	# FAT partitions do not understand links of any type. Rename the
+	# versioned bzImage to just 'bzImage' in the bundle, instead of
+	# linking. Otherwise, RAUC will fail when untarring the bundle to the
+	# FAT slot.
+	mv "${IMAGE_ROOTFS}/boot/$(readlink "${IMAGE_ROOTFS}/boot/bzImage")" "${IMAGE_ROOTFS}/boot/bzImage"
 
 	# Bitbake insists on installing glibc which is not needed on
 	#  EFI system partition. Cleanup all non-boot related files.

--- a/recipes-core/rauc/files/system.conf
+++ b/recipes-core/rauc/files/system.conf
@@ -1,4 +1,4 @@
-# NI Linux RT NXG system layout for RAUC:
+# NI Linux RT system layout for RAUC:
 #  Partitions 1 and 2 (niboota, nibootb) are redundant A/B system
 #   partitions containing a boot loader, kernel, and base user
 #   image toggled via EFI boot order.
@@ -8,6 +8,7 @@
 [system]
 compatible=nilrt-efi-ab
 bootloader=efi
+statusfile=per-slot
 
 # system partition A
 [slot.niboot.0]


### PR DESCRIPTION
* Use `/boot/bzImage` is the canonical location for the kernel image.
* Assert `statusfile=per-slot` in the `/etc/rauc/system.conf` to re-assure RAUC that we mean to use per-slot status files.

## Testing
I have been using these changes while working on the provisioning ISO functional tests. The bundle image build and installs correctly via RAUC.

----

@ni/rtos 