### PR TITLE
nilrt-proprietary: Add ni-wireless-ath6kl package

### DIFF
--- a/recipes-core/images/nilrt-proprietary.inc
+++ b/recipes-core/images/nilrt-proprietary.inc
@@ -33,6 +33,7 @@ IMAGE_INSTALL_NODEPS += "\
         ni-webdav-system-webserver-support \
         ni-webserver-libs \
         ni-webservices-webserver-support \
+        ni-wireless-ath6kl \
         ni-wireless-cert-storage \
         nicurl \
         nirtcfg \


### PR DESCRIPTION
Add the Atheros wireless firmware package previously installed in the image
via os-common. This package is made available via the ni-main feed.

Signed-off-by: Gratian Crisan <gratian.crisan@ni.com>