### PR TITLE
nilrt-proprietary: Add ni-wifibledd package

### DIFF
--- a/recipes-core/images/nilrt-proprietary.inc
+++ b/recipes-core/images/nilrt-proprietary.inc
@@ -33,6 +33,7 @@ IMAGE_INSTALL_NODEPS += "\
         ni-webdav-system-webserver-support \
         ni-webserver-libs \
         ni-webservices-webserver-support \
+        ni-wifibledd \
         ni-wireless-ath6kl \
         ni-wireless-cert-storage \
         nicurl \


### PR DESCRIPTION
Add the NI WiFi button and LED daemon package previously installed in the
image via os-common.

Signed-off-by: Gratian Crisan <gratian.crisan@ni.com>