### PR TITLE
Add ptest for safemode migration

### DIFF
--- a/recipes-core/dist-nilrt/dist-nilrt-grub-gateway.bb
+++ b/recipes-core/dist-nilrt/dist-nilrt-grub-gateway.bb
@@ -7,6 +7,7 @@ ALLOW_EMPTY_${PN}-dev = "0"
 
 SRC_URI += "\
     file://nilrt-gateway-install \
+    file://ptest \
 "
 
 DEPENDS = "safemode-image"
@@ -33,6 +34,18 @@ python do_package_prepend() {
              line = fp.readline()
     if found != True:
         bb.fatal("Safemode version not found (check safemode-image recipe) !!!")
+}
+
+inherit ptest
+
+RDEPENDS_${PN}-ptest += "bash"
+# The ptests should be run on a system which has already been provisioned, so a
+# dependency on the migration IPK is not necessary.
+RDEPENDS_${PN}-ptest_remove += "${PN}"
+
+do_install_ptest_append_x64() {
+    install -m 0755 ${WORKDIR}/ptest/run-ptest ${D}${PTEST_PATH}
+    install -m 0755 ${WORKDIR}/ptest/test_safemode_provisioning.sh ${D}${PTEST_PATH}
 }
 
 FILES_${PN} = "\

--- a/recipes-core/dist-nilrt/files/ptest/run-ptest
+++ b/recipes-core/dist-nilrt/files/ptest/run-ptest
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+SCRIPT_ROOT=$(dirname $0)
+
+${SCRIPT_ROOT}/test_safemode_provisioning.sh

--- a/recipes-core/dist-nilrt/files/ptest/test_safemode_provisioning.sh
+++ b/recipes-core/dist-nilrt/files/ptest/test_safemode_provisioning.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+#
+# Test that the booted storage disk matches the partition scheme which we
+# expect from the ni_provisioning script. This ptest only supports the
+# bootscheme present on x64, safemode-based targets.
+exec 2>&1
+
+
+PTEST_TEST='ni_provisioning'
+
+print_error() {
+	echo ERROR: $@ >&2
+	found_error=true
+}
+
+ptest_fail() {
+	echo "FAIL: $PTEST_TEST"
+	exit 1
+}
+
+ptest_pass() {
+	echo "PASS: $PTEST_TEST"
+	exit 0
+}
+
+ptest_skip() {
+	echo "SKIP: $PTEST_TEST"
+	exit 77
+}
+
+
+test_part_id () {
+	local device=${1}
+	local label=${2}
+	local uuid=${3}
+
+	local correct_re_label=${4}
+	local correct_re_uuid=${5}
+
+	echo "test_part_id() ${@:1:3}"
+
+	if [[ ! "${label}" =~ $correct_re_label ]]; then
+		print_error "Partition ${label} @ ${device} does not match required label ${correct_re_label}"
+	fi
+	if [[ ! "${uuid}" =~ $correct_re_uuid ]]; then
+		print_error "Partition ${label} @ ${device} does not match required type UUID ${correct_re_uuid}"
+	fi
+}
+
+
+found_error=false
+
+if uname --machine | grep -q arm; then
+	echo "INFO: detected an ARM machine architecture." \
+		  "This ptest is only valid for non-ARM, safemode systems."
+	ptest_skip
+fi
+
+
+## PARTITION TESTS ##
+echo "## Checking that safemode partitons are present..."
+# The UUIDs here should match those set by the disk_config_x64 file.
+# https://github.com/ni/meta-nilrt/blob/983d50796302b394aa428b992dae48b4da32ff08/recipes-core/initrdscripts/files/disk_config_x64#L28
+RE_ESP_UUID=C12A7328\-F81F\-11D2\-BA4B\-00A0C93EC93B
+RE_X64_OTHER_UUID=0FC63DAF\-8483\-4772\-8E79\-3D69D8477DE4
+
+# Determine the configured /boot storage device. Assert that this device should
+# be the root of the partitions we evaluate in the remainder of this test.
+boot_part=$(findmnt --kernel --first-only --noheadings --output SOURCE /boot)
+test -n "${boot_part}" || { print_error "No detected /boot mount; system state invalid."; ptest_fail; }
+boot_dev=/dev/$(lsblk -no PKNAME ${boot_part})
+test -e "${boot_dev}" || { print_error "Boot device ${boot_dev} does not exist; system state invalid."; ptest_fail; }
+
+
+readarray -t parts < <(fdisk -l ${boot_dev} -o Device,Name,Type-UUID | grep -o -E '^\/dev\/.*')
+
+# ASSERT: Only 4 partitions exist
+expected_partitions=4
+test ${#parts[@]} = $expected_partitions || { print_error "Expected $expected_partitions partitions, found ${#parts[@]}"; ptest_fail; }
+
+# ASSERT: part 0 is: nigrub and is an ESP partition
+test_part_id ${parts[0]} nigrub $RE_ESP_UUID
+# ASSERT: part 1 is: nibootfs and is a data partition type
+test_part_id ${parts[1]} nibootfs $RE_X64_OTHER_UUID
+# ASSERT: part 2 is: niconfig and is a data partition type
+test_part_id ${parts[2]} niconfig $RE_X64_OTHER_UUID
+# ASSERT: part 3 is: nirootfs and is a data partition type
+test_part_id ${parts[3]} nirootfs $RE_X64_OTHER_UUID
+
+part_1=( ${parts[1]} )
+test $boot_part = ${part_1[0]} || { print_error "booted from ${boot_part} partition instead of ${part_1[0]} (nibootfs)"; ptest_fail; }
+
+# bail out if the partition tests failed
+$found_error && ptest_fail
+
+
+## PARTITION CONTENTS TESTING ##
+echo "## Checking that nibootfs contents are as expected..."
+safemode_files=(                       \
+	/boot/bootmode                      \
+	/boot/.safe/bzImage                 \
+	/boot/.safe/bootimage.ini           \
+	/boot/.safe/EFI_NI_vars             \
+	/boot/.safe/GRUB_NI_readonly_vars   \
+	/boot/.safe/bootimage.cfg           \
+	/boot/.safe/SMBIOS_NI_vars          \
+	/boot/.safe/ramdisk.gz              \
+	/boot/.safe/ramdisk.xz              \
+	/boot/grub/recoverytool-ni-version  \
+	/boot/grub/grub-ni-version          \
+	/boot/grub/grubenv                  \
+)
+
+for file in ${safemode_files[@]}; do
+	if [ -e "$file" ]; then
+		echo "${file} [OK]"
+	else
+		echo "${file} [FAIL]"
+		print_error "File \"$file\" does not exist."
+	fi
+done
+
+$found_error && ptest_fail
+
+ptest_pass

--- a/recipes-core/initrdscripts/files/ptest/test_ni_provisioning.sh
+++ b/recipes-core/initrdscripts/files/ptest/test_ni_provisioning.sh
@@ -70,9 +70,9 @@ RE_X64_ROOT_UUID=4F68BCE3\-E8CD\-4DB1\-96E7\-FBCAF984B709
 # be the root of the partitions we evaluate in the remainder of this test.
 # For RAUC systems, we expect this to be: /dev/sda, but it isn't required to be.
 boot_part=$(findmnt --kernel --first-only --noheadings --output SOURCE /boot)
-test -n "${boot_part}" || (print_error "No detected /boot mount; system state invalid."; ptest_fail)
+test -n "${boot_part}" || { print_error "No detected /boot mount; system state invalid."; ptest_fail; }
 boot_dev=/dev/$(lsblk -no PKNAME ${boot_part})
-test -e "${boot_dev}" || (print_error "Boot device ${boot_dev} does not exist; system state invalid."; ptest_fail)
+test -e "${boot_dev}" || { print_error "Boot device ${boot_dev} does not exist; system state invalid."; ptest_fail; }
 
 
 readarray -t parts < <(fdisk -l ${boot_dev} -o Device,Name,Type-UUID | grep -o -E '^\/dev\/.*')
@@ -92,12 +92,12 @@ $found_error && ptest_fail
 echo "## Checking for RAUC partition device links in /dev..."
 test -d /dev/niboot || print_error "/dev/niboot does not exist."
 
-niboot_links=(\
+niboot_links=(                \
 	/dev/niboot/niboot.current \
-	/dev/niboot/niboot.other \
-	/dev/niboot/niboota \
-	/dev/niboot/nibootb \
-	/dev/niboot/niuser \
+	/dev/niboot/niboot.other   \
+	/dev/niboot/niboota        \
+	/dev/niboot/nibootb        \
+	/dev/niboot/niuser         \
 )
 for link in ${niboot_links[@]}; do
 	if [ -L "$link" ]; then

--- a/recipes-core/initrdscripts/files/ptest/test_ni_provisioning.sh
+++ b/recipes-core/initrdscripts/files/ptest/test_ni_provisioning.sh
@@ -41,11 +41,9 @@ test_part_id () {
 
 	if [[ ! "${label}" =~ $correct_re_label ]]; then
 		print_error "Partition ${label} @ ${device} does not match required label ${correct_re_label}"
-		found_error=true
 	fi
 	if [[ ! "${uuid}" =~ $correct_re_uuid ]]; then
 		print_error "Partition ${label} @ ${device} does not match required type UUID ${correct_re_uuid}"
-		found_error=true
 	fi
 }
 
@@ -170,7 +168,6 @@ for bootnum in 0 1; do
 			;;
 		*)
 			print_error "efi_bootorder[${bootnum}] is (${bootorder}, \"${bootlabel}\"); not one of: niboota, nibootb"
-			found_error=true
 			;;
 	esac
 done


### PR DESCRIPTION
@ni/rtos 

Output of run-ptest

```
(safemode) admin@NI-cRIO-903x-VM-29af4652:/usr/lib/dist-nilrt-grub-gateway/ptest# ./run-ptest 
## Checking that RAUC partitons are present...
test_part_id() /dev/sda1 nigrub C12A7328-F81F-11D2-BA4B-00A0C93EC93B
test_part_id() /dev/sda2 nibootfs 0FC63DAF-8483-4772-8E79-3D69D8477DE4
test_part_id() /dev/sda3 niconfig 0FC63DAF-8483-4772-8E79-3D69D8477DE4
test_part_id() /dev/sda4 nirootfs 0FC63DAF-8483-4772-8E79-3D69D8477DE4
## Checking that nibootfs contents are as expected...
/boot/bootmode [OK]
/boot/.safe/bzImage [OK]
/boot/.safe/bootimage.ini [OK]
/boot/.safe/EFI_NI_vars [OK]
/boot/.safe/GRUB_NI_readonly_vars [OK]
/boot/.safe/bootimage.cfg [OK]
/boot/.safe/SMBIOS_NI_vars [OK]
/boot/.safe/ramdisk.gz [OK]
/boot/.safe/ramdisk.xz [OK]
/boot/grub/recoverytool-ni-version [OK]
/boot/grub/grub-ni-version [OK]
/boot/grub/grubenv [OK]
PASS: ni_provisioning
(safemode) admin@NI-cRIO-903x-VM-29af4652:/usr/lib/dist-nilrt-grub-gateway/ptest# 
```

NOTE: Depends on https://github.com/ni/meta-nilrt/pull/139 to build.