### PR TITLE
dist-nilrt-efi-ab-gateway: Disable -lic package creation

### DIFF
--- a/recipes-core/dist-nilrt/dist-nilrt-efi-ab-gateway.bb
+++ b/recipes-core/dist-nilrt/dist-nilrt-efi-ab-gateway.bb
@@ -2,9 +2,13 @@ SUMMARY = "IPK to repartition a safemode based installation to an A/B EFI implem
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
+LICENSE_CREATE_PACKAGE = "0"
+
 SRC_URI = "\
     file://nilrt-gateway-install \
+    file://MIT \
 "
+FILESEXTRAPATHS_prepend := "${COMMON_LICENSE_DIR}:"
 
 PV = "${DISTRO_VERSION}"
 RDEPENDS_${PN} += "bash"
@@ -17,7 +21,9 @@ do_install[depends] = "${IMAGE}:do_image_complete"
 
 do_install_append_x64() {
     install -d ${D}/usr/share/nilrt
+    install -d ${D}/usr/share/licenses/${PN}
     install -m 0755 ${WORKDIR}/nilrt-gateway-install ${D}/usr/share/nilrt/nilrt-install
+    install -m 0755 ${WORKDIR}/MIT ${D}/usr/share/licenses/${PN}/MIT
     install -m 0755 ${DEPLOY_DIR_IMAGE}/${ISO_NAME}-${MACHINE}.wic ${D}/usr/share/nilrt/restore-mode-image-${MACHINE}.iso
 }
 
@@ -32,4 +38,5 @@ python do_package_ipk_append() {
 FILES_${PN}_x64 = "\
     /usr/share/nilrt/restore-mode-image-${MACHINE}.iso \
     /usr/share/nilrt/nilrt-install \
+    /usr/share/licenses/${PN}/MIT \
 "


### PR DESCRIPTION
The recipe as is creates a separate accompanying -lic package and
adds a "RECOMMENDS" to it from the base dist package.
When we publish packages to ni.com, we do not want to publish a
separate -lic package for each dist package because that can grow out
of control very quickly and start to pollute the feed.
So, disable the -lic package creation and install the license file
as part of the base dist package.

@ni/rtos 