### PR TITLE
Staple meta-nilrt recipes for 20.7 release.

### DIFF
--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -34,7 +34,7 @@ SRC_URI = "\
 	${NILRT_GIT}/${GIT_KERNEL_REPO};protocol=git;nocheckout=1;branch=${KBRANCH} \
 	file://export-kernel-headers.sh \
 "
-SRCREV="${AUTOREV}"
+SRCREV="db94e1d70abfe097c354d6eadb0adbe7044b699e"
 PV = "${LINUX_VERSION}+git${SRCPV}"
 
 # This checks ${PV} == version from kernel sources which our PV/AUTOREV breaks, so skip it.

--- a/recipes-rt/librtpi/librtpi_0.0.1.bb
+++ b/recipes-rt/librtpi/librtpi_0.0.1.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
 "
 
 PV = "0.0.1+git${SRCPV}"
-SRCREV="${AUTOREV}"
+SRCREV="558653f9fd48ec755d8feca7bce3cd7824018d9b"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Staple the `linux-nilrt` and `librtpi` recipes to their release commit hashes.

I will also cherry-pick the `librtpi` staple commit to the sumo mainline, since I highly doubt we will frequently rev that recipe in the future.

The `salt` recipe is the only remaining AUTOREV recipe in meta-nilrt; I'm waiting for NIR to give me a salt release branch to staple it.

@ni/rtos @gratian @shruthi-ravi 