### PR TITLE
librtpi: staple SRCREV to latest

### DIFF
--- a/recipes-rt/librtpi/librtpi_0.0.1.bb
+++ b/recipes-rt/librtpi/librtpi_0.0.1.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
 "
 
 PV = "0.0.1+git${SRCPV}"
-SRCREV="${AUTOREV}"
+SRCREV="558653f9fd48ec755d8feca7bce3cd7824018d9b"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Staple the librtpi SRCREV to a commit hash because the commit velocity
for that repo does not justify it being on AUTOREV, and to service the
LV 20.7 release.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>
(cherry picked from commit 9ecbbf6c60a6c19ce8530f2d158c6d8197b6177f)

@ni/rtos 