### PR TITLE
nilrt.conf: bump NILRT version

### DIFF
--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -2,9 +2,9 @@ require nilrt.inc
 
 DISTRO_NAME = "NI Linux Real-Time"
 
-DISTRO_VERSION = "8.7"
+DISTRO_VERSION = "8.8"
 
-NILRT_RELEASE_NAME = "2020.7"
+NILRT_RELEASE_NAME = "2021"
 
 DISTRO_FEATURES_append_x64 = "\
         x11 \


### PR DESCRIPTION
Bump the mainline NILRT version to 8.8.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

The NIOE and os-common /8.7 components have already been switched to the 20.7 product branch. So it is appropriate to upgrade the NIRLT version on the mainline branch to 8.8.

@ni/rtos 