### PR TITLE
nilrt.conf: rename the release to "unstable"

### DIFF
--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -4,7 +4,7 @@ DISTRO_NAME = "NI Linux Real-Time"
 
 DISTRO_VERSION = "9.0"
 
-NILRT_RELEASE_NAME = "2021"
+NILRT_RELEASE_NAME = "unstable"
 
 DISTRO_FEATURES_append_x64 = "\
         x11 \

--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -4,7 +4,7 @@ DISTRO_NAME = "NI Linux Real-Time"
 
 DISTRO_VERSION = "9.0"
 
-NILRT_RELEASE_NAME = "unstable"
+NILRT_FEED_NAME = "unstable"
 
 DISTRO_FEATURES_append_x64 = "\
         x11 \

--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -141,7 +141,7 @@ PACKAGE_ENABLE_FILELIST ?= "True"
 
 # Root URI of all NILRT feeds
 NILRT_FEEDS_URI                    ?= "http://download.ni.com/ni-linux-rt/feeds"
-NILRT_FEEDS_URI_RELEASE            ?= "${NILRT_FEEDS_URI}/${NILRT_RELEASE_NAME}"
+NILRT_FEEDS_URI_RELEASE            ?= "${NILRT_FEEDS_URI}/${NILRT_FEED_NAME}"
 NILRT_MACHINE_FEED_URI_x64         ?= "${NILRT_FEEDS_URI_RELEASE}/x64"
 NILRT_MACHINE_FEED_URI_xilinx-zynq ?= "${NILRT_FEEDS_URI_RELEASE}/arm"
 

--- a/recipes-extended/lsb/lsb-release_%.bbappend
+++ b/recipes-extended/lsb/lsb-release_%.bbappend
@@ -2,5 +2,5 @@
 # nilrt-xfce to be the same as nilrt
 do_install_append() {
 	sed -i 's/DISTRIB_ID=nilrt-xfce/DISTRIB_ID=nilrt/' ${D}${sysconfdir}/lsb-release
-	echo "DISTRIB_CODENAME=${NILRT_RELEASE_NAME}" >> ${D}${sysconfdir}/lsb-release
+	echo "DISTRIB_CODENAME=${NILRT_FEED_NAME}" >> ${D}${sysconfdir}/lsb-release
 }


### PR DESCRIPTION
Ever-changing planning requirements mean that it is difficult to assert
a version number on a purely development branch like 'dunfell'. Instead
of trying to guess the next labview release version, use a static string
like 'unstable' as the release name.

As a NILRT branch ref falls onto the commitment schedule, its release
name can be changed to a version number.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

@shruthi-ravi I *think* this is all that is necessary to change the feed locations. I'm not seeing anywhere else in the new (dunfell) components that we encoded the `2021` or `21.X` version numbers. I'm doing a build now to confirm.

@ni/rtos This is in response to [PR 148](https://github.com/ni/meta-nilrt/pull/148). Any objections to the new feed name? It's [based on the debian feed names](https://www.debian.org/releases).