### PR TITLE
u-boot: update SRCREV to point to the latest commit of u-boot-fw-utils

### DIFF
--- a/recipes-bsp/u-boot/nilrt-u-boot.inc
+++ b/recipes-bsp/u-boot/nilrt-u-boot.inc
@@ -1,4 +1,4 @@
 UBOOT_BRANCH ?= "nizynq/15.0/v2012.10"
 UBOOT_MACHINE ?= "nicrio9068_config"
 
-SRCREV = "2194b4c9d5ea9684d6c982f2036e15b980bbd3d5"
+SRCREV = "3fe8a01a00724a9252baea4d852b8b7fbe17e5b2"


### PR DESCRIPTION
u-boot: update SRCREV to point to the latest commit of u-boot-fw-utils
    
    Points the SRCREV of this recipe to commit 3fe8a01 which contains the changes
    required for fw_env tools to work on artmemis.
    
    This commit includes changes the SRCREV in nilrt-u-boot.inc
    
    Signed-off-by: wkoe <wilson.koe@ni.com>

@ni/rtos 