### PR TITLE
Allow kernel recipes to be stapled.

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-current.inc
+++ b/recipes-kernel/linux/linux-nilrt-current.inc
@@ -5,3 +5,6 @@ GIT_KERNEL_REPO = "linux.git"
 
 require linux-nilrt.inc
 
+# This is the place to overwrite the source AUTOREV from linux-nilrt.inc, if
+# the kernel recipe requires a particular ref.
+#SRCREV = ""

--- a/recipes-kernel/linux/linux-nilrt-current.inc
+++ b/recipes-kernel/linux/linux-nilrt-current.inc
@@ -7,4 +7,4 @@ require linux-nilrt.inc
 
 # This is the place to overwrite the source AUTOREV from linux-nilrt.inc, if
 # the kernel recipe requires a particular ref.
-#SRCREV = ""
+SRCREV = "db94e1d70abfe097c354d6eadb0adbe7044b699e"

--- a/recipes-kernel/linux/linux-nilrt-next.inc
+++ b/recipes-kernel/linux/linux-nilrt-next.inc
@@ -5,6 +5,10 @@ GIT_KERNEL_REPO = "linux.git"
 
 require linux-nilrt.inc
 
+# This is the place to overwrite the source AUTOREV from linux-nilrt.inc, if
+# the kernel recipe requires a particular ref.
+#SRCREV = ""
+
 kernel_do_deploy_append() {
     cp -rf ${STAGING_KERNEL_DIR} $deployDir/staging_kernel_dir
     cp -rf ${STAGING_KERNEL_BUILDDIR} $deployDir/staging_kernel_builddir

--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -34,7 +34,9 @@ SRC_URI = "\
 	${NILRT_GIT}/${GIT_KERNEL_REPO};protocol=git;nocheckout=1;branch=${KBRANCH} \
 	file://export-kernel-headers.sh \
 "
-SRCREV="db94e1d70abfe097c354d6eadb0adbe7044b699e"
+# Generically use the *latest* rev from the kernel source branch, if none is
+# specified by a recipe.
+SRCREV ?= "${AUTOREV}"
 PV = "${LINUX_VERSION}+git${SRCPV}"
 
 # This checks ${PV} == version from kernel sources which our PV/AUTOREV breaks, so skip it.


### PR DESCRIPTION
The current `linux*.inc` implementations will error when you try to staple them to a commit hash which is not shared between the `-next` and `-current` flavors, as seen in the 20.7 build log:
```
WARNING: linux-nilrt-next-5.10+gitAUTOINC+db94e1d70a-r0 do_fetch: Failed to fetch URL git://github.com/ni/linux.git;protocol=git;nocheckout=1;branch=nilrt/master/5.10, attempting MIRRORS if available
ERROR: linux-nilrt-next-5.10+gitAUTOINC+db94e1d70a-r0 do_fetch: Fetcher failure: Unable to find revision db94e1d70abfe097c354d6eadb0adbe7044b699e in branch nilrt/master/5.10 even from upstream
ERROR: linux-nilrt-next-5.10+gitAUTOINC+db94e1d70a-r0 do_fetch: Fetcher failure for URL: 'git://github.com/ni/linux.git;protocol=git;nocheckout=1;branch=nilrt/master/5.10'. Unable to fetch URL from any source.
ERROR: linux-nilrt-next-5.10+gitAUTOINC+db94e1d70a-r0 do_fetch: Function failed: base_do_fetch
ERROR: Logfile of failure stored in: /srv/jenkins/perforce/ThirdPartyExports/NIOpenEmbedded/trunk/8.7/objects/feed/linuxU/x64/gcc-4.7-oe/release/build/tmp-glibc/work/x64-nilrt-linux/linux-nilrt-next/5.10+gitAUTOINC+db94e1d70a-r0/temp/log.do_fetch.12179
NOTE: recipe linux-nilrt-next-5.10+gitAUTOINC+db94e1d70a-r0: task do_fetch: Failed
ERROR: Task (/srv/jenkins/perforce/ThirdPartyExports/NIOpenEmbedded/trunk/8.7/source/meta-nilrt/recipes-kernel/linux/linux-nilrt-next_git.bb:do_fetch) failed with exit code '1'
```

This patchset allows each flavor to override their `AUTOREV` values independently, when we need to staple them.

The `linux: allow non-AUTOREV SRCREVs` commit will be cherry-picked to `nilrt/master/sumo` and `nilrt/master/dunfell` in subequent PRs.

## Testing
* Builds on my dev machine.

@ni/rtos 