### PR TITLE
linux: allow non-AUTOREV SRCREVs

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-current.inc
+++ b/recipes-kernel/linux/linux-nilrt-current.inc
@@ -5,3 +5,6 @@ GIT_KERNEL_REPO = "linux.git"
 
 require linux-nilrt.inc
 
+# This is the place to overwrite the source AUTOREV from linux-nilrt.inc, if
+# the kernel recipe requires a particular ref.
+#SRCREV = ""

--- a/recipes-kernel/linux/linux-nilrt-next.inc
+++ b/recipes-kernel/linux/linux-nilrt-next.inc
@@ -5,6 +5,10 @@ GIT_KERNEL_REPO = "linux.git"
 
 require linux-nilrt.inc
 
+# This is the place to overwrite the source AUTOREV from linux-nilrt.inc, if
+# the kernel recipe requires a particular ref.
+#SRCREV = ""
+
 kernel_do_deploy_append() {
     cp -rf ${STAGING_KERNEL_DIR} $deployDir/staging_kernel_dir
     cp -rf ${STAGING_KERNEL_BUILDDIR} $deployDir/staging_kernel_builddir

--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -33,7 +33,9 @@ SRC_URI = "\
 	${NILRT_GIT}/${GIT_KERNEL_REPO};protocol=git;nocheckout=1;branch=${KBRANCH} \
 	file://export-kernel-headers.sh \
 "
-SRCREV="${AUTOREV}"
+# Generically use the *latest* rev from the kernel source branch, if none is
+# specified by a recipe.
+SRCREV ?= "${AUTOREV}"
 PV = "${LINUX_VERSION}+git${SRCPV}"
 
 # This checks ${PV} == version from kernel sources which our PV/AUTOREV breaks, so skip it.


### PR DESCRIPTION
The current linux-nilrt.inc implementation forces all currency-flavors
of the kernel (-current/-next), to use the same `SRCREV` value - usually
$AUTOREV. In a release context, supported kernel packages need to have
their SRCREVs stapled to a particular hash, which might be
impossible to share between all flavors which inherit from
linux-nilrt.inc.

Make the SRCREV in linux-nilrt.inc AUTOREV by default, but allow
inheriting recipes to overwrite the value with a static hash, if they
choose.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>
(cherry picked from commit d52ee4de4a8d58555a6c39acc94c032d92e48719)
(cherry picked from commit 50e97b339858b365d9ac5aa9804eaf6eaa6aa7d5)

Dunfell version of PR #151 

@ni/rtos 