### PR TITLE
libglade: fix distro_features_check warning

### DIFF
--- a/recipes-gnome/libglade/libglade_2.6.4.bb
+++ b/recipes-gnome/libglade/libglade_2.6.4.bb
@@ -11,7 +11,7 @@ SECTION = "libs"
 PR = "r5"
 DEPENDS = "zlib gdk-pixbuf gtk+ glib-2.0-native"
 
-inherit autotools pkgconfig gnomebase gtk-doc distro_features_check
+inherit autotools pkgconfig gnomebase gtk-doc features_check
 ANY_OF_DISTRO_FEATURES = "${GTK2DISTROFEATURES}"
 GNOME_COMPRESS_TYPE="bz2"
 


### PR DESCRIPTION
The distro_features_check class has been replaced upstream by the
distro_check class - which is a superset of the prior's functionality.
distro_features_check currently just redirects to features_check anyway
and should be safe to replace.

https://www.yoctoproject.org/docs/latest/ref-manual/ref-manual.html#migration-3.1-features-check

Replace the class inherit with the new class name.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>