### PR TITLE
Always include the minor rev in the NILRT feed URIs

### DIFF
--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -4,7 +4,7 @@ DISTRO_NAME = "NI Linux Real-Time"
 
 DISTRO_VERSION = "8.8"
 
-NILRT_FEED_NAME = "2021"
+NILRT_FEED_NAME = "2021.0"
 
 DISTRO_FEATURES_append_x64 = "\
         x11 \

--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -4,7 +4,7 @@ DISTRO_NAME = "NI Linux Real-Time"
 
 DISTRO_VERSION = "8.8"
 
-NILRT_RELEASE_NAME = "2021"
+NILRT_FEED_NAME = "2021"
 
 DISTRO_FEATURES_append_x64 = "\
         x11 \

--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -105,7 +105,7 @@ PACKAGE_ENABLE_FILELIST ?= "True"
 
 # Root URI of all NILRT feeds
 NILRT_FEEDS_URI                    ?= "http://download.ni.com/ni-linux-rt/feeds"
-NILRT_FEEDS_URI_RELEASE            ?= "${NILRT_FEEDS_URI}/${NILRT_RELEASE_NAME}"
+NILRT_FEEDS_URI_RELEASE            ?= "${NILRT_FEEDS_URI}/${NILRT_FEED_NAME}"
 NILRT_MACHINE_FEED_URI_x64         ?= "${NILRT_FEEDS_URI_RELEASE}/x64"
 NILRT_MACHINE_FEED_URI_xilinx-zynq ?= "${NILRT_FEEDS_URI_RELEASE}/arm"
 

--- a/recipes-extended/lsb/lsb_%.bbappend
+++ b/recipes-extended/lsb/lsb_%.bbappend
@@ -2,5 +2,5 @@
 # nilrt-xfce to be the same as nilrt
 do_install_append() {
 	sed -i 's/DISTRIB_ID=nilrt-xfce/DISTRIB_ID=nilrt/' ${D}${sysconfdir}/lsb-release
-	echo "DISTRIB_CODENAME=${NILRT_RELEASE_NAME}" >> ${D}${sysconfdir}/lsb-release
+	echo "DISTRIB_CODENAME=${NILRT_FEED_NAME}" >> ${D}${sysconfdir}/lsb-release
 }


### PR DESCRIPTION
Historically, NILRT releases which align to "major" LV releases have omitted the minor rev from their feed URLs. eg. they advertise /2020/ rather than /2020.0/. This made more sense when NILRT was only trying to release once a year, and when LV releases were more regular. Now, they are quarterly and frequently have minor revs. Maintaining different codepaths depending on whether or not it is a "major" LV release is unnecessarily burdensome.

This patchset cherry-picks the trivial `NIRLT_FEED_NAME` variable name refactor from the dunfell branch, and adds the `.0` minor version string to the feed URL.

## Testing

From environment inspection on my dev machine...
```
# $NILRT_FEED_NAME
#   set /mnt/workspace/build-container/../sources/meta-nilrt/conf/distro/nilrt.conf:7
#     "2021.0"
NILRT_FEED_NAME="2021.0"
...
# $NILRT_MACHINE_FEED_URI_x64
#   set? /mnt/workspace/build-container/../sources/meta-nilrt/conf/distro/nilrt.inc:109
#     "${NILRT_FEEDS_URI_RELEASE}/x64"
NILRT_MACHINE_FEED_URI_x64="http://nickdanger.amer.corp.natinst.com/feeds/2021.0/x64"
```

@ni/rtos 