### PR TITLE
dist-nilrt-*.bb: Include license file in pkg

### DIFF
--- a/recipes-core/dist-nilrt/dist-nilrt-efi-ab.bb
+++ b/recipes-core/dist-nilrt/dist-nilrt-efi-ab.bb
@@ -1,6 +1,8 @@
 SUMMARY = "IPK to install the current DISTRO_VERSION of base bundle"
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+LICENSE_CREATE_PACKAGE = "0"
 
 PV = "${DISTRO_VERSION}"
 BUNDLE = "nilrt-base-bundle"
@@ -11,7 +13,10 @@ ALLOW_EMPTY_${PN}-dev = "0"
 
 SRC_URI += "\
     file://${PN}-install \
+    file://MIT \
 "
+
+FILESEXTRAPATHS_prepend := "${COMMON_LICENSE_DIR}:"
 
 do_install[depends] = " \
     ${BUNDLE}:do_deploy \
@@ -19,11 +24,14 @@ do_install[depends] = " \
 
 do_install_x64() {
     install -d ${D}/usr/share/nilrt
+    install -d ${D}/usr/share/licenses/${PN}
     install -m 0755 ${WORKDIR}/${PN}-install  ${D}/usr/share/nilrt/nilrt-install
+    install -m 0755 ${WORKDIR}/MIT ${D}/usr/share/licenses/${PN}/MIT
     install -m 0755 ${DEPLOY_DIR_IMAGE}/${BUNDLE}-${MACHINE}.raucb ${D}/usr/share/nilrt
 }
 
 FILES_${PN} = "\
     /usr/share/nilrt/${BUNDLE}-${MACHINE}.raucb \
     /usr/share/nilrt/nilrt-install \
+    /usr/share/licenses/${PN}/MIT \
 "

--- a/recipes-core/dist-nilrt/dist-nilrt-grub-gateway.bb
+++ b/recipes-core/dist-nilrt/dist-nilrt-grub-gateway.bb
@@ -1,6 +1,8 @@
 SUMMARY = "Partition the target with the original safemode partioning scheme"
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+LICENSE_CREATE_PACKAGE = "0"
 
 ALLOW_EMPTY_${PN}-dbg = "0"
 ALLOW_EMPTY_${PN}-dev = "0"
@@ -8,7 +10,10 @@ ALLOW_EMPTY_${PN}-dev = "0"
 SRC_URI += "\
     file://nilrt-gateway-install \
     file://ptest \
+    file://MIT \
 "
+
+FILESEXTRAPATHS_prepend := "${COMMON_LICENSE_DIR}:"
 
 DEPENDS = "safemode-image"
 RDEPENDS_${PN} += "bash"
@@ -16,7 +21,9 @@ do_install[depends] = "safemode-restore-image:do_image_complete"
 
 do_install_x64() {
     install -d ${D}/usr/share/nilrt
+    install -d ${D}/usr/share/licenses/${PN}
     install -m 0755 ${WORKDIR}/nilrt-gateway-install ${D}/usr/share/nilrt/nilrt-install
+    install -m 0755 ${WORKDIR}/MIT ${D}/usr/share/licenses/${PN}/MIT
     install -m 0755 ${DEPLOY_DIR_IMAGE}/safemode-restore-image-${MACHINE}.wic ${D}/usr/share/nilrt/safemode-restore-image-${MACHINE}.iso
 }
 
@@ -51,4 +58,5 @@ do_install_ptest_append_x64() {
 FILES_${PN} = "\
     /usr/share/nilrt/safemode-restore-image-${MACHINE}.iso \
     /usr/share/nilrt/nilrt-install \
+    /usr/share/licenses/${PN}/MIT \
 "


### PR DESCRIPTION
Testing: Built locally, verified license file is present in package and -lic wasn't generated

@ni/rtos 