### PR TITLE
niwatchdogpet: move watchdogpet later to fix fw_printenv read error

### DIFF
--- a/recipes-ni/niwatchdogpet/niwatchdogpet_1.0.bb
+++ b/recipes-ni/niwatchdogpet/niwatchdogpet_1.0.bb
@@ -12,7 +12,7 @@ SRC_URI = "file://LICENSE \
 	   file://niwatchdogpet.sh"
 
 INITSCRIPT_NAME = "niwatchdogpet"
-INITSCRIPT_PARAMS = "start 04 S ."
+INITSCRIPT_PARAMS = "start 05 S ."
 
 CFLAGS_append = " -std=c89 -Wall -Werror -pedantic"
 


### PR DESCRIPTION
While developing safemode for artemis, we found out that fw_printenw call in
niwatchdogpet cannot function properly because the config lives in
/boot/uboot/uboot.env, which requires the /boot partition to be mounted first.
The mounting of /boot for artemis depends on /dev/mmcblk0p1 node to be ready,
which requires udev to be initialized first. Hence, by moving niwatchdogpet
from S04 to S05, we can resolve this issue.

This commit changes niwatchdogpet startup from S04 to S05.

@ni/rtos 

Signed-off-by: wkoe <wilson.koe@ni.com>