### PR TITLE
nilrt.inc: re-add USERADD-staticids

### DIFF
--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -39,6 +39,30 @@ RM_WORK_EXCLUDE += " \
 	safemode-restore-image \
 "
 
+# Various packages dynamically add users and groups to the system at package
+# install time.  For programs that do not care what the uid/gid is of the
+# resulting users/groups, the order of the install will determine the final
+# uid/gid.  This can lead to non-deterministic uid/gid values from one build
+# to another.  Use the following settings to specify that all user/group adds
+# should be created based on a static passwd/group file.
+#
+# Note, if you enable or disable the useradd-staticids in a configured system,
+# the TMPDIR may contain incorrect uid/gid values.  Clearing the TMPDIR
+# will correct this condition.
+#
+# By default the system looks in the BBPATH for files/passwd and files/group
+# the default can be overriden by specifying USERADD_UID/GID_TABLES.
+#
+USERADDEXTENSION = "useradd-staticids"
+#USERADD_UID_TABLES = "files/passwd"
+#USERADD_GID_TABLES = "files/group"
+#
+# In order to prevent generating a system where a dynamicly assigned uid/gid
+# can exist, you should enable the following setting.  This will force the
+# system to error out if the user/group name is not defined in the
+# files/passwd or files/group (or specified replacements.)
+USERADD_ERROR_DYNAMIC = "1"
+
 LVRT_USER = "lvuser"
 LVRT_GROUP = "ni"
 


### PR DESCRIPTION
While rearchitecting the layer and distro configuration files for the
meta-orgconf deprecation effort [1], I accidently forgot to move the
USERADD block of local.conf into the distro.conf. As a result, the
uid/gid tables generated by OE - though internally valid - were not
consistent with what is expected by externally-built NI software.

Re-add the USERADD block of configuration to return to consistent
uid/gids.

[1] https://github.com/ni/meta-nilrt/pull/159

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

I have not modified the content of the configuration block from what we were using previously, or what we are currently using the the dunfell mainline.

## Testing

Rebuilding a minimal rootfs now, to verify that the passwd/group files look correct.

@ni/rtos 