### PR TITLE
niwatchdogpet: Move watchdogpet later in startup

### DIFF
--- a/recipes-ni/niwatchdogpet/niwatchdogpet_1.0.bb
+++ b/recipes-ni/niwatchdogpet/niwatchdogpet_1.0.bb
@@ -12,7 +12,7 @@ SRC_URI = "file://LICENSE \
 	   file://niwatchdogpet.sh"
 
 INITSCRIPT_NAME = "niwatchdogpet"
-INITSCRIPT_PARAMS = "start 03 S ."
+INITSCRIPT_PARAMS = "start 04 S ."
 
 CFLAGS_append = " -std=c89 -Wall -Werror -pedantic"
 


### PR DESCRIPTION
Move niwatchdogpet later in startup, S03->S04.  The script
calls fw_printenv which needs to be after populate-volatile.sh
otherwise we get errors about /var/lock/fw_printenv.lock.

Signed-off-by: Bill Pittman <bill.pittman@ni.com>