### PR TITLE
packagegroups; disable building the debug-kernel pkggrp

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-desirable.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-desirable.bb
@@ -7,7 +7,6 @@ inherit packagegroup
 # essential packagegroups
 RDEPENDS_${PN} += "\
 	packagegroup-core-tools-debug \
-	packagegroup-ni-debug-kernel \
 	packagegroup-ni-ptest \
 	packagegroup-ni-selinux \
 "

--- a/recipes-core/packagegroups/packagegroup-ni-extra.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-extra.bb
@@ -71,7 +71,6 @@ RDEPENDS_${PN} = "\
 
 # meta-nilrt
 RDEPENDS_${PN} += "\
-	packagegroup-ni-debug-kernel \
 	packagegroup-ni-selinux \
 "
 


### PR DESCRIPTION
The kernel-debug recipes have package names which are just long enough
to blow the 260 character limit on the nibuild export tooling.
Therefore, sumo builds cannot be exported.

Temporarily disable building the debug-kernel packagegroup, until we can
figure out a long-term solution.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

## Testing
* I will let heisenberg test this.

@ni/rtos 