### PR TITLE
ni-grpc-device MVP implementation

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-desirable.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-desirable.bb
@@ -16,6 +16,7 @@ RDEPENDS_${PN}_append_x64 = "\
 	packagegroup-ni-nohz-kernel \
 	packagegroup-ni-mono-extra \
 	florence \
+	ni-grpc-device \
 "
 
 RDEPENDS_${PN} += "\

--- a/recipes-ni/ni-grpc-device/ni-grpc-device_1.0.1.bb
+++ b/recipes-ni/ni-grpc-device/ni-grpc-device_1.0.1.bb
@@ -6,12 +6,12 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 SRC_URI = "\
-	https://github.com/ni/grpc-device/releases/download/${${PN}_RELEASE_TAG}/ni-grpc-device-server-ni-linux-rt-x64.tar.gz;name=release-tar;downloadfilename=${PN}_${${PN}_RELEASE_TAG}.tar.gz;subdir=${PN}-server \
+	https://github.com/ni/grpc-device/releases/download/${${PN}_RELEASE_TAG}/ni-grpc-device-server-ni-linux-rt-x64.tar.gz;name=release-server-tar;downloadfilename=${PN}_${${PN}_RELEASE_TAG}.tar.gz;subdir=${PN}-server \
 	https://github.com/ni/grpc-device/releases/download/${${PN}_RELEASE_TAG}/ni-grpc-device-client.tar.gz;name=release-client-tar;downloadfilename=${PN}-client_${PN}_${${PN}_RELEASE_TAG}.tar.gz;subdir=${PN}-client \
 "
 
-SRC_URI[release-tar.md5sum] = "200de2f8b1cbc4c26af42cfaed1b01ea"
-SRC_URI[release-tar.sha256sum] = "32e0767b28f71a3024921904aa7bcd879cf9e9f2a98661722ac549446bca0aed"
+SRC_URI[release-server-tar.md5sum] = "200de2f8b1cbc4c26af42cfaed1b01ea"
+SRC_URI[release-server-tar.sha256sum] = "32e0767b28f71a3024921904aa7bcd879cf9e9f2a98661722ac549446bca0aed"
 SRC_URI[release-client-tar.md5sum] = "11da718d6be42848a1e4155e56bdb641"
 SRC_URI[release-client-tar.sha256sum] = "0555fc1f2867b4ed9314354ed87041b7065365a24ddaf3526c1871f519df34ad"
 

--- a/recipes-ni/ni-grpc-device/ni-grpc-device_1.0.1.bb
+++ b/recipes-ni/ni-grpc-device/ni-grpc-device_1.0.1.bb
@@ -1,5 +1,5 @@
-SUMMARY = "gRPC server providing remote access to NI device driver APIs."
-DESCRIPTION = ""
+SUMMARY = "NI gRPC Device Server"
+DESCRIPTION = "gRPC server providing remote access to NI device driver APIs."
 HOMEPAGE = "https://github.com/ni/grpc-device"
 SECTION = "base"
 LICENSE = "MIT"

--- a/recipes-ni/ni-grpc-device/ni-grpc-device_1.0.1.bb
+++ b/recipes-ni/ni-grpc-device/ni-grpc-device_1.0.1.bb
@@ -1,0 +1,40 @@
+SUMMARY = "gRPC server providing remote access to NI device driver APIs."
+DESCRIPTION = ""
+HOMEPAGE = "https://github.com/ni/grpc-device"
+SECTION = "base"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "\
+	https://github.com/ni/grpc-device/releases/download/${${PN}_RELEASE_TAG}/ni-grpc-device-server-ni-linux-rt-x64.tar.gz;name=release-tar;downloadfilename=${PN}_${${PN}_RELEASE_TAG}.tar.gz;subdir=${PN}-server \
+	https://github.com/ni/grpc-device/releases/download/${${PN}_RELEASE_TAG}/ni-grpc-device-client.tar.gz;name=release-client-tar;downloadfilename=${PN}-client_${PN}_${${PN}_RELEASE_TAG}.tar.gz;subdir=${PN}-client \
+"
+
+SRC_URI[release-tar.md5sum] = "200de2f8b1cbc4c26af42cfaed1b01ea"
+SRC_URI[release-tar.sha256sum] = "32e0767b28f71a3024921904aa7bcd879cf9e9f2a98661722ac549446bca0aed"
+SRC_URI[release-client-tar.md5sum] = "11da718d6be42848a1e4155e56bdb641"
+SRC_URI[release-client-tar.sha256sum] = "0555fc1f2867b4ed9314354ed87041b7065365a24ddaf3526c1871f519df34ad"
+
+${PN}_RELEASE_TAG ?= "v${PV}"
+${PN}_RELEASE_TAG = "v${PV}-rc1"
+
+S = "${WORKDIR}"
+
+DEPENDS += "\
+"
+
+RDEPENDS_${PN} += "\
+	python3 \
+"
+
+do_install_append () {
+	install -d ${D}${bindir}
+	install --mode=0755 --owner=0 --group=0 ${S}/${PN}-server/ni_grpc_device_server ${D}${bindir}
+
+	install -d ${D}${datadir}/${BPN}
+	install --mode=0644 --owner=0 --group=0 ${S}/${PN}-server/server_config.json ${D}${datadir}/${BPN}/server_config.json.example
+
+	# package .proto files from the -client archive for use by developers
+	install -d ${D}${includedir}/${PN}
+	install --mode 644 --owner=0 --group=0 ${S}/${PN}-client/proto/*.proto ${D}${includedir}/${PN}/
+}

--- a/recipes-ni/ni-grpc-device/ni-grpc-device_1.0.1.bb
+++ b/recipes-ni/ni-grpc-device/ni-grpc-device_1.0.1.bb
@@ -20,13 +20,6 @@ ${PN}_RELEASE_TAG = "v${PV}-rc1"
 
 S = "${WORKDIR}"
 
-DEPENDS += "\
-"
-
-RDEPENDS_${PN} += "\
-	python3 \
-"
-
 do_install_append () {
 	install -d ${D}${bindir}
 	install --mode=0755 --owner=0 --group=0 ${S}/${PN}-server/ni_grpc_device_server ${D}${bindir}


### PR DESCRIPTION
To enable the `ni-sync-remote` package and other grpc implementations which use the [grpc-device](https://github.com/ni/grpc-device) project, add a new recipe `ni-grpc-device` which provides the required device-agnostic grpc server daemon.

This MVP implementation simply repackages the server daemon and .proto files from the 1.0.1 github release into IPKs.

This patchset also adds the `ni-grpc-device` recipe to `packagegroup-ni-desirable`, as it is the best place to ensure that the recipe is built, but is not installed to the sumo images.

The data tree for the package family looks like this:
```
packages-split/
├── ni-grpc-device
│   └── usr
│       ├── bin
│       │   └── ni_grpc_device_server
│       └── share
│           └── ni-grpc-device
│               └── server_config.json.example
├── ni-grpc-device-dbg
│   └── usr
│       └── bin
│           └── .debug
│               └── ni_grpc_device_server
├── ni-grpc-device-dev
│   └── usr
│       └── include
│           └── ni-grpc-device
│               ├── nifake.proto
│               ├── niscope.proto
│               ├── niswitch.proto
│               ├── nisync.proto
│               └── session.proto
├── ni-grpc-device-doc
├── ni-grpc-device-lic
│   └── usr
│       └── share
│           └── licenses
│               └── ni-grpc-device
│                   ├── generic_MIT
│                   └── MIT
├── ni-grpc-device-locale
├── ni-grpc-device.shlibdeps
└── ni-grpc-device-staticdev
```

The grpc-device upstream is making some changes which will soon propagate to this recipe:
1. They are removing `nifake.proto` from the release tar, since it is only sane for use by the upstream build unit tests.
2. They are adding LICENSE and NOTICE files to the upstream release artifacts. When they do, I will use those in the IPKs instead of the generic MIT licenses.

Ptests for this package are in the works and will be added by a follow-on patchset.

## Testing
* Installed the package family to a sumo VM and verified that everything installed to the correct places, and that the daemon will start with the provided `server_config.json.sample` file.

@ni/rtos 