### PR TITLE
opkg-utils: Including in BSI

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -116,6 +116,7 @@ RDEPENDS_${PN} = "\
 	openssh-ssh \
 	opkg \
 	opkg-keyrings \
+	opkg-utils \
 	os-release \
 	run-postinsts \
 	start-stop-daemon \


### PR DESCRIPTION
Specify opkg-utils (which includes the `opkg-feed` utility) to be part of the base system image. That way we don't have to add it via a CDF separately.

There is a separate PR to update opkg-utils from 0.4.2 to 0.4.3 which is the first version to include `opkg-feed`.

FYI @ni/rtos 