### PR TITLE
packagegroups: add opkg-utils in runmode, not base

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -116,7 +116,6 @@ RDEPENDS_${PN} = "\
 	openssh-ssh \
 	opkg \
 	opkg-keyrings \
-	opkg-utils \
 	os-release \
 	run-postinsts \
 	start-stop-daemon \

--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -24,6 +24,7 @@ RDEPENDS_${PN} = "\
 	librtpi \
 	lldpd \
 	niwatchdogpet \
+	opkg-utils \
 	parted \
 	rtctl \
 	systemimageupdateinfo \


### PR DESCRIPTION
The opkg-utils recipe carries with it a python3 dependency, which makes
it too heavy to put in packagegroup-ni-base, as that is consumed by ARM
safemodes. To keep it out of safemode but keep it in the BSI, relocate
it to packagegroup-ni-runmode.

Fixes: e3075f44311b ("opkg-utils: Including in BSI")
Signed-off-by: Brandon Streiff <brandon.streiff@ni.com>