### PR TITLE
Shorten linux-kernel package names

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-desirable.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-desirable.bb
@@ -7,6 +7,7 @@ inherit packagegroup
 # essential packagegroups
 RDEPENDS_${PN} += "\
 	packagegroup-core-tools-debug \
+	packagegroup-ni-debug-kernel \
 	packagegroup-ni-ptest \
 	packagegroup-ni-selinux \
 "

--- a/recipes-core/packagegroups/packagegroup-ni-extra.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-extra.bb
@@ -71,6 +71,7 @@ RDEPENDS_${PN} = "\
 
 # meta-nilrt
 RDEPENDS_${PN} += "\
+	packagegroup-ni-debug-kernel \
 	packagegroup-ni-selinux \
 "
 

--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -12,7 +12,7 @@ machine_srcrev="${SRCREV}"
 KBUILD_FRAGMENTS_LOCATION ?= "nilrt"
 
 # Set the version for traceability purposes
-LINUX_VERSION_EXTENSION = "$([ "${LINUX_KERNEL_TYPE}" != "standard" ] && echo '-${LINUX_KERNEL_TYPE}')$([ -z "${BUILDNAME}" ] || echo '-')${BUILDNAME}"
+LINUX_VERSION_EXTENSION = "$([ "${LINUX_KERNEL_TYPE}" != "standard" ] && echo '-${LINUX_KERNEL_TYPE}')"
 
 # Setting EXTRA_OEMAKE to include CFLAGS settings is required as
 # the Kbuild system will clobber CC (which is used by OE for setting

--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -11,7 +11,6 @@ machine_srcrev="${SRCREV}"
 # Provide a unique name for each recipe saved in the same source folder
 KBUILD_FRAGMENTS_LOCATION ?= "nilrt"
 
-# Set the version for traceability purposes
 LINUX_VERSION_EXTENSION = "$([ "${LINUX_KERNEL_TYPE}" != "standard" ] && echo '-${LINUX_KERNEL_TYPE}')"
 
 # Setting EXTRA_OEMAKE to include CFLAGS settings is required as


### PR DESCRIPTION
Currently, the `BUILDNAME` variable string is appended to each kernel package and subpackage name, including the generated kernel-module packages. As a result, the package name (and therefore filepath) get very long. eg.

```
kernel-debug-module-nf-conntrack-broadcast-4.14.146-rt67-debug-cg-8.8.0d13-xilinx-zynq-27_4.14+git38+a0899816ee-r0.13_xilinx-zynq.ipk.

-cg-8.8.0d13-xilinx-zynq-27  # just the BUILDNAME
```

We add the `BUILDNAME` for traceability, but haven't actually used it for tracing very frequently (ever?). Further, these long filenames are starting to exceed the 260 character limit imposed by nibuild tooling. We previously had to disable the kernel-debug recipe entirely, because of that limit.

This patchset removes the `BUILDNAME` part of the package name - which should have no functional impact on the packages, but saves us many characters in the final filepaths. It then reverts the commit which disabled the debug kernel recipes (ie. enables them again.)

New packages look like:
```
kernel-debug-module-nf-conntrack-broadcast-4.14.146-rt67-debug_4.14+git0+a0899816ee-r0_xilinx-zynq.ipk
```

My simple calculations show that the longest IPK names have been reduced by ~27 characters.

## Testing

The kernel recipes build on my dev machine. I will let the build systems verify that it meets total path length requirements. But I will be very surprised if this doesn't resolve the issue (we should be ~25 characters under the limit, now).

## Future Work

The `LINUX_VERSION_EXTENSION` will be cherry-picked into the dunfell branch as well, for consistency and also because the same path length limit exists in the ni-central tooling.

There are better long-term solutions to our path-length woes (namely, archiving the built feeds in NIOE/rtos_nifeeds before export). But those solutions require rearchitecture of the components and will be easier to implement once we have migrated NIOE into AZDO.

@ni/rtos 