### PR TITLE
linux-nilrt: reconcile version extension with sumo

### DIFF
--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -3,7 +3,7 @@ require recipes-kernel/linux/linux-yocto.inc
 
 machine_srcrev="${SRCREV}"
 
-LINUX_VERSION_EXTENSION = "-ni"
+LINUX_VERSION_EXTENSION = "$([ "${LINUX_KERNEL_TYPE}" != "standard" ] && echo '-${LINUX_KERNEL_TYPE}')"
 
 # Setting EXTRA_OEMAKE to include CFLAGS settings is required as
 # the Kbuild system will clobber CC (which is used by OE for setting


### PR DESCRIPTION
The LINUX_VERSION_EXTENSION is deviated between the sumo and dunfell
branches. Reconcile its value for consistency.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

Related to `nilrt/master/sumo` PR #181 .

## Testing
`linux-nilrt-debug` recipe builds on my machine and the kernel-debug-module IPKs seem to have the correct extension (matches with sumo).

@ni/rtos 