### PR TITLE
RFC: add PACKAGE_EXCLUDE to make sure we keep python out of base images

### DIFF
--- a/recipes-core/images/nilrt-image-common.inc
+++ b/recipes-core/images/nilrt-image-common.inc
@@ -11,6 +11,9 @@ IMAGE_PREPROCESS_COMMAND += "rootfs_update_timestamp;"
 # Do not install license subpackages if they are only recommended.
 BAD_RECOMMENDATIONS_pn-${PN} += "*-lic"
 
+# Do not allow python to be installed into base images due to size
+PACKAGE_EXCLUDE += "python-core python3-core"
+
 # NILRT images expect the default kernel is an actual file
 # (e.g. bzImage) and not a symbolic link; fix it up here.
 ROOTFS_POSTPROCESS_COMMAND += "move_kernel;"


### PR DESCRIPTION
This patch adds a `PACKAGE_EXCLUDE` to `nilrt-image-common.inc` for `python-core` and `python3-core` so that they aren't unknowingly added to our base images again, due to the size of the python runtimes.