### PR TITLE
packagegroups: use opkg-utils-shell-tools subset instead of whole package

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -24,7 +24,7 @@ RDEPENDS_${PN} = "\
 	librtpi \
 	lldpd \
 	niwatchdogpet \
-	opkg-utils \
+	opkg-utils-shell-tools \
 	parted \
 	rtctl \
 	systemimageupdateinfo \


### PR DESCRIPTION
Now that we have the option to use a subset of the main package, do
so. This lets us utilize the opkg-feed script without taking on all
of python3 in the process.

Signed-off-by: Brandon Streiff <brandon.streiff@ni.com>