### PR TITLE
kernel-tests: Fix kernel-test-nohz x64 only dependency

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-desirable.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-desirable.bb
@@ -16,6 +16,7 @@ RDEPENDS_${PN}_append_x64 = "\
 	packagegroup-ni-next-kernel \
 	packagegroup-ni-nohz-kernel \
 	packagegroup-ni-mono-extra \
+	kernel-test-nohz \
 	florence \
 	ni-grpc-device \
 "
@@ -35,7 +36,6 @@ RDEPENDS_${PN} += "\
 	iperf2 \
 	iperf3 \
 	kernel-performance-tests \
-	kernel-test-nohz \
 	ldd \
 	ltrace \
 	mysql-python \

--- a/recipes-kernel/kernel-tests/kernel-test-nohz.bb
+++ b/recipes-kernel/kernel-tests/kernel-test-nohz.bb
@@ -10,7 +10,8 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-files:"
 
 S = "${WORKDIR}"
 
-RDEPENDS_${PN}-ptest += "bash packagegroup-ni-nohz-kernel procps rt-tests"
+RDEPENDS_${PN}-ptest += "bash procps rt-tests"
+RDEPENDS_${PN}-ptest_append_x64 += "packagegroup-ni-nohz-kernel"
 ALLOW_EMPTY_${PN} = "1"
 
 SRC_URI += "\


### PR DESCRIPTION
kernel-test-nohz ptest is expected to run on NO_HZ_FULL configured (5.10) kernels currently only available for x64 NILRT machines. Fix run-time dependencies to:

- only add it to the packagegroup-ni-desirable for x64
- only declare a run-time dependency on packagegroup-ni-nohz-kernel for x64. The test can still be built via bitbake for Zynq if desired but it is not  the expected use case.

Tests:

- bitbake kernel-test-nohz succeeds on both x64 and Zynq targets after these changes.