### PR TITLE
kernel-devsrc: add elfutils-dev as dependency

### DIFF
--- a/recipes-kernel/linux/kernel-devsrc.bbappend
+++ b/recipes-kernel/linux/kernel-devsrc.bbappend
@@ -3,3 +3,9 @@ pkg_postinst_ontarget_kernel-devsrc () {
    make prepare
    make modules_prepare
 }
+
+# "make prepare" skips building objtool if elfutils-dev is not installed at
+# postinst time; however if you install elfutils-dev later, then when dkms
+# tries to build modules it expects objtool to be available, but it's not.
+# Depending on elfutils-dev forces it to be there during postinst.
+RDEPENDS_${PN}_append += "${@bb.utils.contains('ARCH', 'x86', 'elfutils-dev', '', d)}"


### PR DESCRIPTION
The dkms module rebuild machinery expects to have objtool if elfutils-dev
is on the system at the time of rebuild, but if elfutils-dev was not
present at the time that kernel-devsrc was installed, then objtool is not
generated. Resolve this by making elfutils-dev a dependency; thus it
should always be present if kernel-devsrc is.

Signed-off-by: Brandon Streiff <brandon.streiff@ni.com>
Natinst-AzDO-ID: 1470108