### PR TITLE
linux-nilrt: Switch 4.14 kernel to 21.0 branch

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-debug_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-debug_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "NILRT linux kernel debug build"
-NI_RELEASE_VERSION = "master"
+NI_RELEASE_VERSION = "21.0"
 LINUX_VERSION = "4.14"
 LINUX_KERNEL_TYPE = "debug"
 

--- a/recipes-kernel/linux/linux-nilrt_git.bb
+++ b/recipes-kernel/linux/linux-nilrt_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "Linux kernel based on nilrt branch"
-NI_RELEASE_VERSION = "master"
+NI_RELEASE_VERSION = "21.0"
 LINUX_VERSION = "4.14"
 
 require linux-nilrt.inc


### PR DESCRIPTION
Switch the 4.14 kernel to a release-specific branch for the 21.0 release.

Signed-off-by: Jeffrey Pautler <jeffrey.pautler@ni.com>

Testing: Built locally