### PR TITLE
Upgrade uboot branch to 2017

### DIFF
--- a/conf/machine/xilinx-zynqhf.conf
+++ b/conf/machine/xilinx-zynqhf.conf
@@ -19,7 +19,7 @@ UBOOT_ARCH = "arm"
 # we're not building a full u-boot in OE, justfw_{print|set}env and mkimage,
 # thus we use a generic machine.
 #UBOOT_MACHINE ?= "config"
-UBOOT_MACHINE ?= "nicrio9068"
+UBOOT_MACHINE ?= "ni_elvisiii_defconfig"
 
 UBOOT_LOADADDRESS ?= "0x8000"
 UBOOT_ENTRYPOINT ?= "${UBOOT_LOADADDRESS}"

--- a/recipes-bsp/u-boot/files/0001-Makefile-Quote-the-HOSTCC-command-line-parameter.patch
+++ b/recipes-bsp/u-boot/files/0001-Makefile-Quote-the-HOSTCC-command-line-parameter.patch
@@ -1,0 +1,30 @@
+Upstream status: Obsolete
+
+From 46f83b1364ca4459d11b62034a747f9571089f6d Mon Sep 17 00:00:00 2001
+From: Joe Hershberger <joe.hershberger@ni.com>
+Date: Fri, 11 Jun 2021 10:32:52 -0500
+Subject: [PATCH] Makefile: Quote the HOSTCC command-line parameter
+
+OpenEmbedded may set "CC" to a command with parameters, so quoting this
+assignment will allow the sub-make to have the complete command.
+
+Signed-off-by: Joe Hershberger <joe.hershberger@ni.com>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index fd6a9a705a..6d00baf2ce 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1398,7 +1398,7 @@ checkarmreloc: u-boot
+	fi
+
+ env fdtview: scripts_basic
+-	$(Q)$(MAKE) HOSTCC=$(CC) $(build)=tools/$@
++	$(Q)$(MAKE) HOSTCC='$(CC)' $(build)=tools/$@
+
+ tools-only: scripts_basic $(version_h) $(timestamp_h)
+	$(Q)$(MAKE) $(build)=tools
+--
+2.11.0

--- a/recipes-bsp/u-boot/nilrt-u-boot.inc
+++ b/recipes-bsp/u-boot/nilrt-u-boot.inc
@@ -1,4 +1,4 @@
-UBOOT_BRANCH ?= "nizynq/15.0/v2012.10"
-UBOOT_MACHINE ?= "nicrio9068_config"
+UBOOT_BRANCH ?= "nizynq/21.0/v2017.03"
+UBOOT_MACHINE ?= "ni_elvisiii_defconfig"
 
-SRCREV = "3fe8a01a00724a9252baea4d852b8b7fbe17e5b2"
+SRCREV = "653fc09e01ff78e08f9683e1585f4fac05f289d9"

--- a/recipes-bsp/u-boot/u-boot-fw-utils_2018.%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-fw-utils_2018.%.bbappend
@@ -12,21 +12,15 @@ SRC_URI_append_arm = "\
 "
 
 SRC_URI_append = " \
-        file://0001-Remove-hardcoded-softfp-from-arm-makefile.patch \
         file://fw-enw-fix-missing-stdint-h.patch \
-        file://0001-gcc5-backport-add-compiler-gcc5.h.patch \
-        file://0002-gcc5-use-gcc-inline-version-instead-c99.patch \
         file://0003-gcc5-include-io.h-needs-inline-def-from-compiler-gcc.h.patch \
-        file://fix-build-error-under-gcc6.patch \
-        file://fix-build-error-under-gcc7.patch \
+        file://0001-Makefile-Quote-the-HOSTCC-command-line-parameter.patch \
 "
 
 do_compile(){
-    unset LDFLAGS
-    unset CFLAGS
-    unset CPPFLAGS
     oe_runmake ${UBOOT_MACHINE}
-    oe_runmake HOSTCC="${CC}" HOSTSTRIP="${TARGET_PREFIX}strip" env
+    oe_runmake env
+
 }
 
 do_install_append(){


### PR DESCRIPTION
Tested with roboRIO 2.0 with the steps below:
1. build safemode with the OE that consist of the fw_printenv
2. copy the safemode to roboRIO 2.0
3. boot up roboRIO 2.0 and run fw_printenv, able to see all env variable
4. run fw_setenv to update bootdelay variable and perform reset
5. boot into safemode again and run fw_printenv, able to see the updated bootdelay variable
6. reboot the system and boot into UBOOT
7. update the bootdelay variable in UBOOT and reset the system
8. boot into safemode, run fw_printenv the bootdelay variable display the value as in configure in UBOOT.