### PR TITLE
[21.0] kernel-devsrc: add elfutils-dev as dependency

### DIFF
--- a/recipes-kernel/linux/kernel-devsrc.bbappend
+++ b/recipes-kernel/linux/kernel-devsrc.bbappend
@@ -3,3 +3,9 @@ pkg_postinst_ontarget_kernel-devsrc () {
    make prepare
    make modules_prepare
 }
+
+# "make prepare" skips building objtool if elfutils-dev is not installed at
+# postinst time; however if you install elfutils-dev later, then when dkms
+# tries to build modules it expects objtool to be available, but it's not.
+# Depending on elfutils-dev forces it to be there during postinst.
+RDEPENDS_${PN}_append += "${@bb.utils.contains('ARCH', 'x86', 'elfutils-dev', '', d)}"


### PR DESCRIPTION
Cherry-pick PR #192 to the `nilrt/21.0/sumo` release branch, without change.

@ni/rtos 