### PR TITLE
kernel-test-nohz: Fix test duration math

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-test-nohz-files/nohz_test.c
+++ b/recipes-kernel/kernel-tests/kernel-test-nohz-files/nohz_test.c
@@ -313,7 +313,7 @@ static void test(uint64_t duration, bool warmup)
 		error_exit("Failed to allocate space for histogram data");
 
 	clock_gettime(CLOCK_MONOTONIC, &prev_ts);
-	end_sec = prev_ts.tv_sec + test_duration;
+	end_sec = prev_ts.tv_sec + duration;
 
 	while (prev_ts.tv_sec < end_sec) {
 		clock_gettime(CLOCK_MONOTONIC, &ts);

--- a/recipes-kernel/kernel-tests/kernel-test-nohz.bb
+++ b/recipes-kernel/kernel-tests/kernel-test-nohz.bb
@@ -2,7 +2,7 @@ SUMMARY = "Linux kernel NO_HZ_FULL polling test"
 HOMEPAGE = "https://kernel.org"
 SECTION = "tests"
 LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://nohz_test.c;md5=63ba22ad04083bd5cd255a065d4ce2d0"
+LIC_FILES_CHKSUM = "file://nohz_test.c;md5=d25cf78b2ec478f88868ccbc1967e9da"
 
 inherit ptest
 


### PR DESCRIPTION
The test function for the kernel-test-nohz ptest was incorrectly computing
the test end time based on the global 'test_duration' variable as opposed
to the 'duration' parameter passed in. This resulted in tests running for
double the amount specified due to the warm-up iterations taking the
full 'test_duration'. Fix this by using the local variable as intended.

Signed-off-by: Gratian Crisan <gratian.crisan@ni.com>