### PR TITLE
kernel-test-nohz: Add postinst/postrm script fragments for configuring CPU isolation

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-test-nohz.bb
+++ b/recipes-kernel/kernel-tests/kernel-test-nohz.bb
@@ -31,4 +31,25 @@ do_install_ptest_append() {
     install -m 0755 ${S}/nohz_test ${D}${PTEST_PATH}
 }
 
+pkg_postinst_ontarget_${PN}-ptest_append() {
+    CPUS=`nproc`
+    ISOLATED_CPU=$((CPUS - 1))
+    OTHBOOTARGS=`fw_printenv othbootargs 2>/dev/null | sed -e "s/^othbootargs=//g" | sed -e "s/isolcpus=[^ ]*[ ]*\|nohz_full=[^ ]*[ ]*//g"`
+
+    if [ $ISOLATED_CPU -gt 0 ]; then
+        fw_setenv othbootargs $OTHBOOTARGS 'isolcpus='$ISOLATED_CPU' nohz_full='$ISOLATED_CPU
+    else
+        echo "[kernel-test-nohz:error] This test requires a system with 2 or more CPUs"
+        exit 1
+    fi
+
+    echo "[kernel-test-nohz:info] This test requires a reboot after install for kernel changes to take effect"
+}
+
+pkg_postrm_${PN}-ptest_append() {
+    OTHBOOTARGS=`fw_printenv othbootargs 2>/dev/null | sed -e "s/^othbootargs=//g" | sed -e "s/isolcpus=[^ ]*[ ]*\|nohz_full=[^ ]*[ ]*//g"`
+    fw_setenv othbootargs $OTHBOOTARGS
+    echo "[kernel-test-nohz:info] This test requires a reboot after uninstall for kernel changes to take effect"
+}
+
 PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
The NO_HZ_FULL kernel ptest relies on CPU isolation for running an
undisturbed RT polling test.

Add a postinst script fragment that changes the kernel boot parameters via
the 'othbootargs' variable to include the necessary 'isolcpus' and
'nohz_full' parameters configured to use the last CPU available on the
system under test. These parameters isolate that CPU and flag it for
stopping the scheduler tick whenever possible.

The corresponding postrm script fragment undoes changes to 'othbootargs'
(which is normally empty).

Signed-off-by: Gratian Crisan <gratian.crisan@ni.com>