### PR TITLE
fw_printenv: Fix variable values getting truncated on '=' symbols

### DIFF
--- a/recipes-ni/ni-utils/files/x64/fw_printenv
+++ b/recipes-ni/ni-utils/files/x64/fw_printenv
@@ -43,7 +43,7 @@ show_variable_grub(){
 			key=$(echo "$line" | cut -d "=" -f 1)
 			#if the $1 matches exactly the key, extract the value
 			if [ "$key" = "$1" ] ; then
-				value_tmp=$(echo "$line" | cut -d "=" -f 2)
+				value_tmp=$(echo "$line" | cut -d "=" -f 2-)
 				echo "$value_tmp"
 				break
 			fi


### PR DESCRIPTION
Using the current fw_printenv implementation to print the value for a
single grub variable results in truncated output if the value field
contains '=' symbols.

e.g.

```
  # fw_printenv othbootargs
  othbootargs=isolcpus
```

instead of the expected:

```
  # fw_printenv othbootargs
  othbootargs=isolcpus=7 nohz_full=7
```

Fix the 'cut' call used to extract the variable value in
show_variable_grub() to include the rest of the line after the 'key' field.

Signed-off-by: Gratian Crisan <gratian.crisan@ni.com>