### PR TITLE
rt-tests: fix irq_test_priority to retrieve only the interface irq thread

### DIFF
--- a/recipes-rt/rt-tests/files/irq_test_priority.sh
+++ b/recipes-rt/rt-tests/files/irq_test_priority.sh
@@ -34,7 +34,7 @@ function test_priority() {
 			ptest_fail
 		fi
 
-		irq_pids[$dev_irq]=`ps -o pid,comm | grep "irq\/$dev_irq" | awk -F' ' '{print $1}'`
+		irq_pids[$dev_irq]=`ps -o pid,comm | grep "irq\/$dev_irq-$active_network_if" | awk -F' ' '{print $1}'`
 
 		(( dev_prio=$(get_prio_for_task ${irq_pids[$dev_irq]}) ))
 		let dev_prio++
@@ -68,7 +68,7 @@ function test_priority() {
 
 	let priority_preserved=0
 	for dev_irq in $dev_irqs; do
-		irq_pid=`ps -o pid,comm | grep "irq\/$dev_irq" | awk -F' ' '{print $1}'`
+		irq_pid=`ps -o pid,comm | grep "irq\/$dev_irq-$active_network_if" | awk -F' ' '{print $1}'`
 		if [ ${new_prios[$dev_irq]} -eq `awk '{print $40}' /proc/$irq_pid/stat` ]; then
 			let priority_preserved=1
 		fi


### PR DESCRIPTION
The test uses `ps` to try and find the irq used by the network device, but
in the case where the irq is shared, you can end up with a space-separated
list of results; e.g. by searching only for "irq/$dev_irq", we get "71 72
391 3613" out of:
```
      71 irq/10-uhci_hcd
      72 irq/10-uchi_hcd
     391 irq/10-virtio0
    3613 irq/10-eth0
```
Tighten the grep pattern to include the interface name; this narrows us
down to a single result, making the test work as expected.

Natinst-AzDO-ID: 1050836
Signed-off-by: Brandon Streiff <brandon.streiff@ni.com>