### PR TITLE
Misc. updates to the ni_provisioning scripts

### DIFF
--- a/recipes-core/initrdscripts/files/disk_config_x64
+++ b/recipes-core/initrdscripts/files/disk_config_x64
@@ -2,87 +2,87 @@
 
 install_default_error_handler()
 {
-    trap 'handle_err ${BASH_SOURCE} ${LINENO} ${FUNCNAME:-unknown} $? "$BASH_COMMAND"' ERR
+	trap 'handle_err ${BASH_SOURCE} ${LINENO} ${FUNCNAME:-unknown} $? "$BASH_COMMAND"' ERR
 }
 
 handle_err()
 {
-    TMP_EVAL=`eval echo $5`
-    die "$1:$2 (fn=$3): Unexpected status code $4 while running command: '$TMP_EVAL'"
+	TMP_EVAL=`eval echo $5`
+	die "$1:$2 (fn=$3): Unexpected status code $4 while running command: '$TMP_EVAL'"
 }
 
 disk_partition()
 {
-    local disk="$1"
+	local disk="$1"
 
-    umount "$disk"? || true
+	umount "$disk"? || true
 
-    dd if="/dev/zero" of="$disk" bs=1M count=1
+	dd if="/dev/zero" of="$disk" bs=1M count=1
 
-    parted -s "$disk" --align optimal      \
-        mklabel "gpt"                      \
-        mkpart "niboota"       1MB  250MB  \
-        mkpart "nibootb"     250MB  500MB  \
-        mkpart "niuser"      500MB  100%
+	parted -s "$disk" --align optimal \
+		mklabel "gpt" \
+		mkpart "niboota"   1MB  250MB \
+		mkpart "nibootb" 250MB  500MB \
+		mkpart "niuser"  500MB  100%
 
-    # Per https://www.freedesktop.org/wiki/Specifications/DiscoverablePartitionsSpec/
-    #  C12A7328-F81F-11D2-BA4B-00A0C93EC93B -- EFI System Partition
-    #  4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709 -- Root Partition (x86-64)
-    sgdisk --typecode="1:C12A7328-F81F-11D2-BA4B-00A0C93EC93B" "$disk"
-    sgdisk --typecode="2:C12A7328-F81F-11D2-BA4B-00A0C93EC93B" "$disk"
-    sgdisk --typecode="3:4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709" "$disk"
+	# Per https://www.freedesktop.org/wiki/Specifications/DiscoverablePartitionsSpec/
+	#  C12A7328-F81F-11D2-BA4B-00A0C93EC93B -- EFI System Partition
+	#  4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709 -- Root Partition (x86-64)
+	sgdisk --typecode="1:C12A7328-F81F-11D2-BA4B-00A0C93EC93B" "$disk"
+	sgdisk --typecode="2:C12A7328-F81F-11D2-BA4B-00A0C93EC93B" "$disk"
+	sgdisk --typecode="3:4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709" "$disk"
 
-    partprobe -s "$disk"
+	partprobe -s "$disk"
 }
 
 partition_format()
 {
-    local disk="$1" label="$2"
+	local disk="$1" label="$2"
 
-    partitions=($(lsblk -rnpo NAME -x NAME ${disk} | tail +2))
-    disk_check "$disk"
+	partitions=($(lsblk -rnpo NAME -x NAME ${disk} | tail +2))
+	disk_check "$disk"
 
-    case "$label" in
-        niboota)
-            dd if="/dev/zero" of="${partitions[0]}" bs=1M count=1
-            mkfs.vfat -n "niboota" "${partitions[0]}"
-            ;;
-        nibootb)
-            dd if="/dev/zero" of="${partitions[1]}" bs=1M count=1
-            mkfs.vfat -n "nibootb" "${partitions[1]}"
-            ;;
-        niuser)
-            # niuser partition is managed by initramfs
-            dd if="/dev/zero" of="${partitions[2]}" bs=1M count=1
-            ;;
-        *)
-            die "Invalid or unspecified label!"
-    esac
+	case "$label" in
+		niboota)
+			dd if="/dev/zero" of="${partitions[0]}" bs=1M count=1
+			mkfs.vfat -n "niboota" "${partitions[0]}"
+			;;
+		nibootb)
+			dd if="/dev/zero" of="${partitions[1]}" bs=1M count=1
+			mkfs.vfat -n "nibootb" "${partitions[1]}"
+			;;
+		niuser)
+			# niuser partition is managed by initramfs
+			dd if="/dev/zero" of="${partitions[2]}" bs=1M count=1
+			;;
+		*)
+			die "Invalid or unspecified label!"
+	esac
 }
 
 partition_check()
 {
-    local partition="$1"
+	local partition="$1"
 
-    [[ -e "$partition" ]] || die "Invalid or unspecified partition!"
+	[[ -e "$partition" ]] || die "Invalid or unspecified partition!"
 }
 
 disk_check()
 {
-    local disk="$1"
+	local disk="$1"
 
-    [[ -b "$disk" ]] || die "Invalid or unspecified disk!"
+	[[ -b "$disk" ]] || die "Invalid or unspecified disk!"
 }
 
 disk_setup()
 {
-    local disk="$1"
+	local disk="$1"
 
-    disk_check "$disk"
+	disk_check "$disk"
 
-    disk_partition "$disk"
+	disk_partition "$disk"
 
-    partition_format "$disk" "niboota"
-    partition_format "$disk" "nibootb"
-    partition_format "$disk" "niuser"
+	partition_format "$disk" "niboota"
+	partition_format "$disk" "nibootb"
+	partition_format "$disk" "niuser"
 }

--- a/recipes-core/initrdscripts/files/init-nilrt-ramfs.sh
+++ b/recipes-core/initrdscripts/files/init-nilrt-ramfs.sh
@@ -24,45 +24,45 @@ exec 2>/dev/kmsg
 exec 1>&2
 
 function status () {
-    echo "initramfs: $*" || true
+	echo "initramfs: $*" || true
 }
 
 function warn () {
-    echo "initramfs WARNING: $*" || true
+	echo "initramfs WARNING: $*" || true
 }
 
 # prints to kernel log and screen
 function error () {
-    echo "initramfs ERROR: $*" || true
+	echo "initramfs ERROR: $*" || true
 
-    cat >/dev/tty0 || true <<ENDSCREENERROR
+	cat >/dev/tty0 || true <<ENDSCREENERROR
 
-  initramfs ERROR: $*
+initramfs ERROR: $*
 
 ENDSCREENERROR
 
-    false
+	false
 }
 
 function panic_and_reboot() {
-    set +e
+	set +e
 
-    error "Uh oh. Something went wrong. Rebooting in 10 seconds."
+	error "Uh oh. Something went wrong. Rebooting in 10 seconds."
 
-    umount -a -r
-    sync
+	umount -a -r
+	sync
 
-    sleep 10
-    reboot -f
+	sleep 10
+	reboot -f
 
-    exit 1
+	exit 1
 }
 
 # This script never exits on a successful run
 trap panic_and_reboot EXIT
 
 ORIG_KMSG_CONFIG=$(cat "/proc/sys/kernel/printk_devkmsg")
-echo on              > "/proc/sys/kernel/printk_devkmsg"
+echo on			  > "/proc/sys/kernel/printk_devkmsg"
 status "Set printk_devkmsg=on (previous: $ORIG_KMSG_CONFIG)"
 
 ARCH=$(uname -m)
@@ -74,63 +74,63 @@ status "Running init process on ARCH=$ARCH"
 # except C0 in all cpu cores until we get a BIOS update with cstates disabled
 if [ "$ARCH" == "x86_64" ]; then
 (
-    shopt -s nullglob
-    for cstate_disable_file in /sys/devices/system/cpu/cpu*/cpuidle/state[^0]/disable; do
-        status "Setting cstate_disable_file=$cstate_disable_file"
-        echo 1 > "$cstate_disable_file"
-    done
+	shopt -s nullglob
+	for cstate_disable_file in /sys/devices/system/cpu/cpu*/cpuidle/state[^0]/disable; do
+		status "Setting cstate_disable_file=$cstate_disable_file"
+		echo 1 > "$cstate_disable_file"
+	done
 )
 fi
 
 # Asserts grep-safe fs identifiers
 function assert_valid_fs_id() {
-    local name="$1"
-    local value="$2"
-    echo "$value" | egrep -q '^[a-zA-Z0-9\-]+$' || error "$name: Invalid fs label or UUID"
+	local name="$1"
+	local value="$2"
+	echo "$value" | egrep -q '^[a-zA-Z0-9\-]+$' || error "$name: Invalid fs label or UUID"
 }
 
 function read_config_token() {
-    local filename="$1"
-    local token="$2"
-    local value=""
+	local filename="$1"
+	local token="$2"
+	local value=""
 
-    if [ -e "$filename" ]; then
-        value=$(grep "^$token=" "$filename" | head -1 | cut -d"=" -f2) || value=""
-    fi
+	if [ -e "$filename" ]; then
+		value=$(grep "^$token=" "$filename" | head -1 | cut -d"=" -f2) || value=""
+	fi
 
-    echo "$value"
+	echo "$value"
 }
 
 function drop_config_token() {
-    local filename="$1"
-    local token="$2"
+	local filename="$1"
+	local token="$2"
 
-    if [ ! -e "$filename" ]; then
-        return
-    fi
+	if [ ! -e "$filename" ]; then
+		return
+	fi
 
-    rm -f "$filename.new"
-    cp -p "$filename" "$filename.new"
+	rm -f "$filename.new"
+	cp -p "$filename" "$filename.new"
 
-    sed -i "/^""$token""=/d" "$filename.new"
+	sed -i "/^""$token""=/d" "$filename.new"
 
-    mv "$filename.new" "$filename"
+	mv "$filename.new" "$filename"
 }
 
 function read_file() {
-    local filename="$1"
-    local maxsize="$2"
-    local value=""
+	local filename="$1"
+	local maxsize="$2"
+	local value=""
 
-    if [ -e "$filename" ]; then
-        value=$(head -c "$maxsize" "$filename") || value=""
-    fi
+	if [ -e "$filename" ]; then
+		value=$(head -c "$maxsize" "$filename") || value=""
+	fi
 
-    echo "$value"
+	echo "$value"
 }
 
 function read_sha256sum_file() {
-    read_file "$1" 65
+	read_file "$1" 65
 }
 
 # Parse kernel cmd line to find nibootX partition's fs label
@@ -147,23 +147,23 @@ status "Waiting for root device"
 slumber=10
 time_started=$SECONDS
 while true; do
-    # Find boot dev nodes using a combination of fs label and UUID so that
-    #  multiple NILRT installations may co-exist on the same system
-    current_niboot_part_device=$(lsblk -l -n -o NAME,LABEL,UUID | tr -s " " | egrep " $current_niboot_fs_label $current_niboot_fs_uuid\$" | head -1 | cut -d" " -f1) || true
+	# Find boot dev nodes using a combination of fs label and UUID so that
+	#  multiple NILRT installations may co-exist on the same system
+	current_niboot_part_device=$(lsblk -l -n -o NAME,LABEL,UUID | tr -s " " | egrep " $current_niboot_fs_label $current_niboot_fs_uuid\$" | head -1 | cut -d" " -f1) || true
 
-    if [ -n "$current_niboot_part_device" ]; then
-        # Found root device
-        status "Root device detected."
-        break
-    fi
+	if [ -n "$current_niboot_part_device" ]; then
+		# Found root device
+		status "Root device detected."
+		break
+	fi
 
-    time_elapsed=$((SECONDS - time_started))
-    if [ $time_elapsed -ge $slumber ]; then
-        error "Root device not found. System is unbootable."
-    else
-        # Sleep for 10ms each trial
-        sleep 0.01
-    fi
+	time_elapsed=$((SECONDS - time_started))
+	if [ $time_elapsed -ge $slumber ]; then
+		error "Root device not found. System is unbootable."
+	else
+		# Sleep for 10ms each trial
+		sleep 0.01
+	fi
 done
 
 current_boot_disk_device=$(lsblk -l -n -o PKNAME "/dev/$current_niboot_part_device")
@@ -185,14 +185,14 @@ ln -sf "/dev/$nibootb_part_device" /dev/niboot/nibootb
 ln -sf "/dev/$niuser_part_device" /dev/niboot/niuser
 
 if   [ "$current_niboot_part_device" == "$niboota_part_device" ]; then
-    ln -sf niboota /dev/niboot/niboot.current
-    ln -sf nibootb /dev/niboot/niboot.other
+	ln -sf niboota /dev/niboot/niboot.current
+	ln -sf nibootb /dev/niboot/niboot.other
 elif [ "$current_niboot_part_device" == "$nibootb_part_device" ]; then
-    ln -sf niboota /dev/niboot/niboot.other
-    ln -sf nibootb /dev/niboot/niboot.current
+	ln -sf niboota /dev/niboot/niboot.other
+	ln -sf nibootb /dev/niboot/niboot.current
 else
-    warn "Unrecognized current_niboot_part_device=$current_niboot_part_device"
-    ln -sf "/dev/$current_niboot_part_device" /dev/niboot/niboot.current
+	warn "Unrecognized current_niboot_part_device=$current_niboot_part_device"
+	ln -sf "/dev/$current_niboot_part_device" /dev/niboot/niboot.current
 fi
 
 # Mount niboot.current
@@ -207,29 +207,29 @@ mkdir "$U_MNT"
 readonly U_OVERLAY_CFG="$U_MNT/overlay/upper/etc/niboot/init-action.cfg"
 
 function mount_niuser_helper() {
-    mount -o rw,sync,relatime "/dev/niboot/niuser" "$U_MNT"
+	mount -o rw,sync,relatime "/dev/niboot/niuser" "$U_MNT"
 }
 
 do_format_niuser=false
 
 if mount_niuser_helper; then
-    if [ "$(read_config_token "$U_OVERLAY_CFG" reformat_niuser)" == "true" ]; then
-        status "init-action.cfg directed reformat of niuser"
-        umount "$U_MNT"
-        do_format_niuser=true
-    fi
+	if [ "$(read_config_token "$U_OVERLAY_CFG" reformat_niuser)" == "true" ]; then
+		status "init-action.cfg directed reformat of niuser"
+		umount "$U_MNT"
+		do_format_niuser=true
+	fi
 else
-    status "Failed to mount niuser, reformatting"
-    do_format_niuser=true
+	status "Failed to mount niuser, reformatting"
+	do_format_niuser=true
 fi
 
 if $do_format_niuser; then
-    mkfs.ext4 -q -F -L "niuser" "/dev/niboot/niuser"
+	mkfs.ext4 -q -F -L "niuser" "/dev/niboot/niuser"
 
-    # Try to mount again
-    if ! mount_niuser_helper; then
-        error "Failed to mount niuser after re-creating file system"
-    fi
+	# Try to mount again
+	if ! mount_niuser_helper; then
+		error "Failed to mount niuser after re-creating file system"
+	fi
 fi
 
 current_baserootfs_sha256sum=$(sha256sum "$B_MNT/baserootfs.squashfs" | cut -d" " -f1)
@@ -238,82 +238,82 @@ do_reset_overlay=false
 
 # First check if we are explicitly directed to reset the overlay
 if [ "$(read_config_token "$U_OVERLAY_CFG" reset_overlay)" == "true" ]; then
-    status "init-action.cfg directed reset of upper file system"
-    do_reset_overlay=true
+	status "init-action.cfg directed reset of upper file system"
+	do_reset_overlay=true
 else
-    # otherwise verify the baserootfs checksum matches
-    current_overlay_sha256sum=$(read_sha256sum_file "$U_MNT/overlay/lower.sha256sum")
-    if [ "$current_overlay_sha256sum" == "$current_baserootfs_sha256sum" ]; then
-        status "Current overlay matches baserootfs"
-    else
-        # Bad current overlay checksum, lets see if we can fall back to old overlay
-        old_overlay_sha256sum=$(read_sha256sum_file "$U_MNT/overlay.old/lower.sha256sum")
-        if [ "$old_overlay_sha256sum" == "$current_baserootfs_sha256sum" ]; then
-            status "Old overlay matches baserootfs, falling back"
+	# otherwise verify the baserootfs checksum matches
+	current_overlay_sha256sum=$(read_sha256sum_file "$U_MNT/overlay/lower.sha256sum")
+	if [ "$current_overlay_sha256sum" == "$current_baserootfs_sha256sum" ]; then
+		status "Current overlay matches baserootfs"
+	else
+		# Bad current overlay checksum, lets see if we can fall back to old overlay
+		old_overlay_sha256sum=$(read_sha256sum_file "$U_MNT/overlay.old/lower.sha256sum")
+		if [ "$old_overlay_sha256sum" == "$current_baserootfs_sha256sum" ]; then
+			status "Old overlay matches baserootfs, falling back"
 
-            # Remove current overlay if it exists
-            # This is fail safe because the condition that got us here still hold:
-            #  - do_reset_overlay will stay false, that's the default
-            #  - current_overlay_sha256sum will become ""
-            #  - old_overlay_sha256sum will stay the same
-            rm -Rf "$U_MNT/overlay"
+			# Remove current overlay if it exists
+			# This is fail safe because the condition that got us here still hold:
+			#  - do_reset_overlay will stay false, that's the default
+			#  - current_overlay_sha256sum will become ""
+			#  - old_overlay_sha256sum will stay the same
+			rm -Rf "$U_MNT/overlay"
 
-            # Promote old overlay to current
-            mv "$U_MNT/overlay.old" "$U_MNT/overlay"
-        else
-            status "Resetting upper file system due to different baserootfs image"
-            do_reset_overlay=true
-        fi
-    fi
+			# Promote old overlay to current
+			mv "$U_MNT/overlay.old" "$U_MNT/overlay"
+		else
+			status "Resetting upper file system due to different baserootfs image"
+			do_reset_overlay=true
+		fi
+	fi
 fi
 
 if $do_reset_overlay; then
-    # Demote current overlay to old if it exist, removing any old
-    #  overlay which may be present
-    if [ -e "$U_MNT/overlay" ]; then
-        rm -Rf "$U_MNT/overlay.old"
-        mv "$U_MNT/overlay" "$U_MNT/overlay.old"
-    fi
+	# Demote current overlay to old if it exist, removing any old
+	#  overlay which may be present
+	if [ -e "$U_MNT/overlay" ]; then
+		rm -Rf "$U_MNT/overlay.old"
+		mv "$U_MNT/overlay" "$U_MNT/overlay.old"
+	fi
 
-    # Create new overlay with current baserootfs hash
-    # This is done as an atomic operation to facilitate recovery (above)
-    #  after catastrophic failure like power loss
-    rm -Rf "$U_MNT/overlay.new"
-    mkdir "$U_MNT/overlay.new"
-    echo "$current_baserootfs_sha256sum" > "$U_MNT/overlay.new/lower.sha256sum"
-    mv "$U_MNT/overlay.new" "$U_MNT/overlay"
+	# Create new overlay with current baserootfs hash
+	# This is done as an atomic operation to facilitate recovery (above)
+	#  after catastrophic failure like power loss
+	rm -Rf "$U_MNT/overlay.new"
+	mkdir "$U_MNT/overlay.new"
+	echo "$current_baserootfs_sha256sum" > "$U_MNT/overlay.new/lower.sha256sum"
+	mv "$U_MNT/overlay.new" "$U_MNT/overlay"
 fi
 
 boot_safemode=false
 
 if [ "$(read_config_token "$U_OVERLAY_CFG" boot_safemode)" == "true" ]; then
-    status "Booting safemode, directed by user config"
-    drop_config_token "$U_OVERLAY_CFG" boot_safemode
-    boot_safemode=true
+	status "Booting safemode, directed by user config"
+	drop_config_token "$U_OVERLAY_CFG" boot_safemode
+	boot_safemode=true
 fi
 
 for file in /sys/bus/acpi/drivers/nirtfeatures/*/safe_mode; do
-    status=$(read_file "$file" 10)
-    if [ "$status" == "1" ]; then
-        status "Booting safemode, directed by firmware ($file = 1)"
-        boot_safemode=true
-    fi
+	status=$(read_file "$file" 10)
+	if [ "$status" == "1" ]; then
+		status "Booting safemode, directed by firmware ($file = 1)"
+		boot_safemode=true
+	fi
 done
 
 init_options=""
 
 if $boot_safemode; then
-    init_options="4"
+	init_options="4"
 fi
 
 for file in /sys/bus/acpi/drivers/nirtfeatures/*/ip_reset; do
-    status=$(read_file "$file" 10)
-    if [ "$status" == "1" ]; then
-        status "Reset network configuration, directed by firmware ($file = 1)"
-        if [  -e "$U_MNT/overlay/upper/var/lib/connman/"  ]; then
-            find "$U_MNT/overlay/upper/var/lib/connman/" -mindepth 1 -maxdepth 1 -exec rm -Rf {} \;
-        fi
-    fi
+	status=$(read_file "$file" 10)
+	if [ "$status" == "1" ]; then
+		status "Reset network configuration, directed by firmware ($file = 1)"
+		if [  -e "$U_MNT/overlay/upper/var/lib/connman/"  ]; then
+			find "$U_MNT/overlay/upper/var/lib/connman/" -mindepth 1 -maxdepth 1 -exec rm -Rf {} \;
+		fi
+	fi
 done
 
 status "Create mount point for overlay"

--- a/recipes-core/initrdscripts/files/init-nilrt-ramfs.sh
+++ b/recipes-core/initrdscripts/files/init-nilrt-ramfs.sh
@@ -62,7 +62,7 @@ function panic_and_reboot() {
 trap panic_and_reboot EXIT
 
 ORIG_KMSG_CONFIG=$(cat "/proc/sys/kernel/printk_devkmsg")
-echo on			  > "/proc/sys/kernel/printk_devkmsg"
+echo on > "/proc/sys/kernel/printk_devkmsg"
 status "Set printk_devkmsg=on (previous: $ORIG_KMSG_CONFIG)"
 
 ARCH=$(uname -m)

--- a/recipes-core/initrdscripts/files/init-restore-mode.sh
+++ b/recipes-core/initrdscripts/files/init-restore-mode.sh
@@ -10,36 +10,36 @@ NIRECOVERY_MOUNTPOINT=/mnt/NIRECOVERY
 MOUNT_NIRECOVERY_USB_TIME=10
 
 early_setup() {
-    mkdir -p /proc
-    mkdir -p /sys
-    mkdir -p /run/lock
-    mount -t proc proc /proc
-    mount -t sysfs sysfs /sys
-    mount -t efivarfs efivarfs /sys/firmware/efi/efivars
-    mount -t devtmpfs none /dev
+	mkdir -p /proc
+	mkdir -p /sys
+	mkdir -p /run/lock
+	mount -t proc proc /proc
+	mount -t sysfs sysfs /sys
+	mount -t efivarfs efivarfs /sys/firmware/efi/efivars
+	mount -t devtmpfs none /dev
 
-    COUNT=0
-    while [ $COUNT -le "$MOUNT_NIRECOVERY_USB_TIME" ]; do
-        mount_nirecovery_usb
-        if mountpoint -q $NIRECOVERY_MOUNTPOINT; then
-            break
-        fi
-        COUNT=$(expr $COUNT + 1)
-        sleep 1
-    done
+	COUNT=0
+	while [ $COUNT -le "$MOUNT_NIRECOVERY_USB_TIME" ]; do
+		mount_nirecovery_usb
+		if mountpoint -q $NIRECOVERY_MOUNTPOINT; then
+			break
+		fi
+		COUNT=$(expr $COUNT + 1)
+		sleep 1
+	done
 
-    # Set hostname
-    echo "recovery" | tee /etc/hostname > /proc/sys/kernel/hostname
+	# Set hostname
+	echo "recovery" | tee /etc/hostname > /proc/sys/kernel/hostname
 }
 
 # Removes the /boot/bootmode file that may force
 # grub to boot into restore over and over again.
 remove_bootmode() {
-    NILRT_MOUNT_POINT=/mnt
-    if mount -L nilrt $NILRT_MOUNT_POINT; then
-        rm $NILRT_MOUNT_POINT/boot/bootmode
-        umount $NILRT_MOUNT_POINT
-    fi
+	NILRT_MOUNT_POINT=/mnt
+	if mount -L nilrt $NILRT_MOUNT_POINT; then
+		rm $NILRT_MOUNT_POINT/boot/bootmode
+		umount $NILRT_MOUNT_POINT
+	fi
 }
 
 # HACK: BIOS enables cstates when they should be disabled and this makes the
@@ -47,47 +47,47 @@ remove_bootmode() {
 # performance of the restore-mode's rootfs unpacking. We disable all cstates
 # except C0 in all cpu cores until we get a BIOS update with cstates disabled
 disable_x64_cstates() {
-    shopt -s nullglob
-    for CSTATE_DISABLE in /sys/devices/system/cpu/cpu*/cpuidle/state[^0]/disable; do
-        echo 1 > $CSTATE_DISABLE
-    done
+	shopt -s nullglob
+	for CSTATE_DISABLE in /sys/devices/system/cpu/cpu*/cpuidle/state[^0]/disable; do
+		echo 1 > $CSTATE_DISABLE
+	done
 }
 
 show_console() {
-    while true; do
-        echo ""
-        echo " ------------------------------------------------------"
-        echo " -  NI Linux Real-Time Recovery shell                 -"
-        echo " ------------------------------------------------------"
-        echo ""
+	while true; do
+		echo ""
+		echo " ------------------------------------------------------"
+		echo " -  NI Linux Real-Time Recovery shell                 -"
+		echo " ------------------------------------------------------"
+		echo ""
 
-        /usr/bin/setsid /sbin/getty 38400 console --noclear -a root --login-options "-p -- \u"
+		/usr/bin/setsid /sbin/getty 38400 console --noclear -a root --login-options "-p -- \u"
 
-        sleep 1
-    done
+		sleep 1
+	done
 }
 
 start_serial_console() {
-    SERIAL_TTY="ttyS0"
-    if [ -c /dev/${SERIAL_TTY} ]; then
-        if [ $(cat /sys/devices/virtual/tty/console/active) != "${SERIAL_TTY}" ]; then
-            while true; do
-                /usr/bin/setsid /sbin/getty 115200 ${SERIAL_TTY} --noclear -a root --login-options "-p -- \u"
+	SERIAL_TTY="ttyS0"
+	if [ -c /dev/${SERIAL_TTY} ]; then
+		if [ $(cat /sys/devices/virtual/tty/console/active) != "${SERIAL_TTY}" ]; then
+			while true; do
+				/usr/bin/setsid /sbin/getty 115200 ${SERIAL_TTY} --noclear -a root --login-options "-p -- \u"
 
-                sleep 1
-            done
-        fi
-    fi
+				sleep 1
+			done
+		fi
+	fi
 }
 
 mount_nirecovery_usb()
 {
-    if ! mountpoint -q $NIRECOVERY_MOUNTPOINT; then
-        if [ ! -d $NIRECOVERY_MOUNTPOINT ]; then
-            mkdir -p $NIRECOVERY_MOUNTPOINT
-        fi
-        mount -o ro,sync,relatime -L NIRECOVERY $NIRECOVERY_MOUNTPOINT &> /dev/null
-    fi
+	if ! mountpoint -q $NIRECOVERY_MOUNTPOINT; then
+		if [ ! -d $NIRECOVERY_MOUNTPOINT ]; then
+			mkdir -p $NIRECOVERY_MOUNTPOINT
+		fi
+		mount -o ro,sync,relatime -L NIRECOVERY $NIRECOVERY_MOUNTPOINT &> /dev/null
+	fi
 }
 
 early_setup
@@ -96,19 +96,19 @@ start_serial_console &
 
 # Arch-specific set-up
 if [[ $ARCH == "x86_64" ]]; then
-    disable_x64_cstates
-    # support VMWare image keyboard
-    modprobe atkbd 2> /dev/null
-    remove_bootmode 2> /dev/null
+	disable_x64_cstates
+	# support VMWare image keyboard
+	modprobe atkbd 2> /dev/null
+	remove_bootmode 2> /dev/null
 fi
 
 if [[ $ARCH =~ ^(x86_64|armv7l)$ ]]; then
-    /ni_provisioning
+	/ni_provisioning
 else
-    echo ""
-    echo "ERROR: ARCH=$ARCH is not supported by provisioning tool."
-    echo " You can try running /ni_provisioning manually from the shell."
-    echo ""
+	echo ""
+	echo "ERROR: ARCH=$ARCH is not supported by provisioning tool."
+	echo " You can try running /ni_provisioning manually from the shell."
+	echo ""
 fi
 
 sync

--- a/recipes-core/initrdscripts/files/init-restore-mode.sh
+++ b/recipes-core/initrdscripts/files/init-restore-mode.sh
@@ -70,7 +70,8 @@ show_console() {
 start_serial_console() {
 	SERIAL_TTY="ttyS0"
 	if [ -c /dev/${SERIAL_TTY} ]; then
-		if [ $(cat /sys/devices/virtual/tty/console/active) != "${SERIAL_TTY}" ]; then
+		active_consoles=$(cat /sys/devices/virtual/tty/console/active)
+		if [[ ! "${active_consoles[@]}" =~ "${SERIAL_TTY}" ]]; then
 			while true; do
 				/usr/bin/setsid /sbin/getty 115200 ${SERIAL_TTY} --noclear -a root --login-options "-p -- \u"
 

--- a/recipes-core/initrdscripts/files/init-runmode-ramfs.sh
+++ b/recipes-core/initrdscripts/files/init-runmode-ramfs.sh
@@ -19,57 +19,57 @@ exec 2>/dev/kmsg
 exec 1>&2
 
 function status () {
-    echo "initramfs: $*"
+	echo "initramfs: $*"
 }
 
 function warn () {
-    echo "initramfs WARNING: $*"
+	echo "initramfs WARNING: $*"
 }
 
 # prints to kernel log and screen
 function error () {
-    echo "initramfs ERROR: $*"
-    cat >/dev/tty0 <<ENDSCREENERROR
+	echo "initramfs ERROR: $*"
+	cat >/dev/tty0 <<ENDSCREENERROR
 
-  initramfs ERROR: $*
+initramfs ERROR: $*
 
 ENDSCREENERROR
 }
 
 ORIG_KMSG_CONFIG="`cat /proc/sys/kernel/printk_devkmsg`"
-echo on              >"/proc/sys/kernel/printk_devkmsg"
+echo on >"/proc/sys/kernel/printk_devkmsg"
 status "Set printk_devkmsg=on (previous: $ORIG_KMSG_CONFIG)"
 
 ARCH="`uname -m`"
 status "Running init process on ARCH=$ARCH"
 
 if [ "$ARCH" == "x86_64" ]; then
-    # Root device which is detected asynchronously may not show up
-    #  early, so continously polling for it until it is available
-    #  or 10s timeout.
-    status "Waiting for root device"
-    slumber=10
-    time_started=$SECONDS
-    while true; do
-        rootdevice_list="`lsblk -l -n -o NAME,PARTUUID | tr -s " " | grep " $rootuuid"`"
+	# Root device which is detected asynchronously may not show up
+	#  early, so continously polling for it until it is available
+	#  or 10s timeout.
+	status "Waiting for root device"
+	slumber=10
+	time_started=$SECONDS
+	while true; do
+		rootdevice_list="`lsblk -l -n -o NAME,PARTUUID | tr -s " " | grep " $rootuuid"`"
 
-        if [ -n "$rootdevice_list" ]; then
-            # Found root device
-            status "Root device detected."
-            break
-        fi
+		if [ -n "$rootdevice_list" ]; then
+			# Found root device
+			status "Root device detected."
+			break
+		fi
 
-        time_elapsed=$((SECONDS - time_started))
-        if [ $time_elapsed -ge $slumber ]; then
-            error "Root device not found. System is unbootable."
-            # Let the system hang while still displaying the message,
-            #  since we have no way to force into safemode.
-            while true; do true; done
-        else
-            # Sleep for 10ms each trial
-            sleep 0.01
-        fi
-    done
+		time_elapsed=$((SECONDS - time_started))
+		if [ $time_elapsed -ge $slumber ]; then
+			error "Root device not found. System is unbootable."
+			# Let the system hang while still displaying the message,
+			#  since we have no way to force into safemode.
+			while true; do true; done
+		else
+			# Sleep for 10ms each trial
+			sleep 0.01
+		fi
+	done
 fi
 
 status "Setting next boot to safemode in case booting runmode fails"
@@ -85,96 +85,96 @@ mkdir -p /var/volatile
 mount -t tmpfs tmpfs /var/volatile
 
 if [ "$ARCH" == "x86_64" ]; then
-    status "Running depmod"
-    depmod -a
+	status "Running depmod"
+	depmod -a
 
-    bootdevice=""
+	bootdevice=""
 
-    rootdevice_count="`echo "$rootdevice_list" | wc -l`"
-    rootdevice="/dev/`echo "$rootdevice_list" | head -1 | cut -d" " -f1`"
-    case "$rootdevice_count" in
-    0)  warn "rootuuid=$rootuuid not found, won't be able to boot (rootdevice=$rootdevice)" ;;
-    1)  status "Found rootuuid=$rootuuid at rootdevice=$rootdevice" ;;
-    \?) warn "rootuuid=$rootuuid not unique, booting first rootdevice=$rootdevice" ;;
-    esac
+	rootdevice_count="`echo "$rootdevice_list" | wc -l`"
+	rootdevice="/dev/`echo "$rootdevice_list" | head -1 | cut -d" " -f1`"
+	case "$rootdevice_count" in
+	0)  warn "rootuuid=$rootuuid not found, won't be able to boot (rootdevice=$rootdevice)" ;;
+	1)  status "Found rootuuid=$rootuuid at rootdevice=$rootdevice" ;;
+	\?) warn "rootuuid=$rootuuid not unique, booting first rootdevice=$rootdevice" ;;
+	esac
 
-    status "Check for TPM"
-    modprobe tpm_tis
-    if [ -e "/dev/tpm0" ]; then
-        # Enable verbose status messages in nilrtdiskcrypt when
-        #  "initramfs_debug" or "debug" flag are passed to kernel
-        if egrep "(^| )initramfs_debug($| )" /proc/cmdline; then
-            export VERBOSE=2
-        elif egrep "(^| )debug($| )" /proc/cmdline; then
-            export VERBOSE=1
-        fi
+	status "Check for TPM"
+	modprobe tpm_tis
+	if [ -e "/dev/tpm0" ]; then
+		# Enable verbose status messages in nilrtdiskcrypt when
+		#  "initramfs_debug" or "debug" flag are passed to kernel
+		if egrep "(^| )initramfs_debug($| )" /proc/cmdline; then
+			export VERBOSE=2
+		elif egrep "(^| )debug($| )" /proc/cmdline; then
+			export VERBOSE=1
+		fi
 
-        status "Reseal runmode key"
-        nilrtdiskcrypt_reseal -u 1
+		status "Reseal runmode key"
+		nilrtdiskcrypt_reseal -u 1
 
-        # NILRT on rootfs will mount niconfig by label. Verify niconfig
-        #  also opens or do not open either.
-        configdevice="/dev/$(lsblk -l -n -o PARTLABEL,NAME | grep '^niconfig '| tr -s ' ' | cut -d' ' -f2)"
-        status "Found configdevice=$configdevice"
+		# NILRT on rootfs will mount niconfig by label. Verify niconfig
+		#  also opens or do not open either.
+		configdevice="/dev/$(lsblk -l -n -o PARTLABEL,NAME | grep '^niconfig '| tr -s ' ' | cut -d' ' -f2)"
+		status "Found configdevice=$configdevice"
 
-        status "Check for encrypted disks at rootdevice=$rootdevice and configdevice=$configdevice"
-        if nilrtdiskcrypt_canopen -d "$rootdevice" -d "$configdevice"; then
-            status "Open partitions rootdevice=$rootdevice and configdevice=$configdevice"
-            cryptdevs=( $(nilrtdiskcrypt_open -k 1 -d "$rootdevice" -d "$configdevice") )
+		status "Check for encrypted disks at rootdevice=$rootdevice and configdevice=$configdevice"
+		if nilrtdiskcrypt_canopen -d "$rootdevice" -d "$configdevice"; then
+			status "Open partitions rootdevice=$rootdevice and configdevice=$configdevice"
+			cryptdevs=( $(nilrtdiskcrypt_open -k 1 -d "$rootdevice" -d "$configdevice") )
 
-            do_failsafe=false
+			do_failsafe=false
 
-            [ -n "${cryptdevs[0]}" ] || do_failsafe=true
-            [ -n "${cryptdevs[1]}" ] || do_failsafe=true
+			[ -n "${cryptdevs[0]}" ] || do_failsafe=true
+			[ -n "${cryptdevs[1]}" ] || do_failsafe=true
 
-            [ "`lsblk -l -n -o LABEL | egrep "^nirootfs$" | wc -l`" == 1 ] || do_failsafe=true
-            [ "`lsblk -l -n -o LABEL | egrep "^niconfig$" | wc -l`" == 1 ] || do_failsafe=true
+			[ "`lsblk -l -n -o LABEL | egrep "^nirootfs$" | wc -l`" == 1 ] || do_failsafe=true
+			[ "`lsblk -l -n -o LABEL | egrep "^niconfig$" | wc -l`" == 1 ] || do_failsafe=true
 
-            lsblk -l -n -o LABEL,TYPE,NAME | egrep -q "^nirootfs +crypt +""`basename "${cryptdevs[0]}"`""\$" || do_failsafe=true
-            lsblk -l -n -o LABEL,TYPE,NAME | egrep -q "^niconfig +crypt +""`basename "${cryptdevs[1]}"`""\$" || do_failsafe=true
+			lsblk -l -n -o LABEL,TYPE,NAME | egrep -q "^nirootfs +crypt +""`basename "${cryptdevs[0]}"`""\$" || do_failsafe=true
+			lsblk -l -n -o LABEL,TYPE,NAME | egrep -q "^niconfig +crypt +""`basename "${cryptdevs[1]}"`""\$" || do_failsafe=true
 
-            # all or nothing failsafe
-            if $do_failsafe; then
-                nilrtdiskcrypt_close -d "$rootdevice"
-                nilrtdiskcrypt_close -d "$configdevice"
-                nilrtdiskcrypt_disableunseal
+			# all or nothing failsafe
+			if $do_failsafe; then
+				nilrtdiskcrypt_close -d "$rootdevice"
+				nilrtdiskcrypt_close -d "$configdevice"
+				nilrtdiskcrypt_disableunseal
 
-                error "Failed to open nirootfs and niconfig"
-            else
-                bootdevice="${cryptdevs[0]}"
-            fi
-        else
-            status "No encrypted paritions found"
-            bootdevice="$rootdevice"
+				error "Failed to open nirootfs and niconfig"
+			else
+				bootdevice="${cryptdevs[0]}"
+			fi
+		else
+			status "No encrypted paritions found"
+			bootdevice="$rootdevice"
 
-            status "Cleanup TPM modules"
-            modprobe -r tpm_tis
-            remaining_modules="`lsmod | grep tpm || true`"
-            [ -z "$remaining_modules" ] || warn "TPM modules remaining after cleanup: $remaining_modules"
-        fi
+			status "Cleanup TPM modules"
+			modprobe -r tpm_tis
+			remaining_modules="`lsmod | grep tpm || true`"
+			[ -z "$remaining_modules" ] || warn "TPM modules remaining after cleanup: $remaining_modules"
+		fi
 
-        # no more nilrtdiskcrypt
-        unset VERBOSE
-    else
-        status "No /dev/tpm0"
-        bootdevice="$rootdevice"
-    fi
+		# no more nilrtdiskcrypt
+		unset VERBOSE
+	else
+		status "No /dev/tpm0"
+		bootdevice="$rootdevice"
+	fi
 
-    status "Mount bootdevice=$bootdevice at /mnt/root"
-    mkdir -p /mnt/root
-    mount "$bootdevice" /mnt/root
+	status "Mount bootdevice=$bootdevice at /mnt/root"
+	mkdir -p /mnt/root
+	mount "$bootdevice" /mnt/root
 
-    if [ -f /mnt/root/sbin/init -o -L /mnt/root/sbin/init ]; then
-        status "switch_root to /mnt/root (restore printk_devkmsg=$ORIG_KMSG_CONFIG)"
-        umount /var/volatile
-        echo "$ORIG_KMSG_CONFIG" >"/proc/sys/kernel/printk_devkmsg"
-        exec switch_root /mnt/root /sbin/init
-    else
-        error "No /mnt/root/sbin/init, cannot boot bootdevice=$bootdevice"
-        error "System is unbootable. Force safemode and reformat."
-    fi
+	if [ -f /mnt/root/sbin/init -o -L /mnt/root/sbin/init ]; then
+		status "switch_root to /mnt/root (restore printk_devkmsg=$ORIG_KMSG_CONFIG)"
+		umount /var/volatile
+		echo "$ORIG_KMSG_CONFIG" >"/proc/sys/kernel/printk_devkmsg"
+		exec switch_root /mnt/root /sbin/init
+	else
+		error "No /mnt/root/sbin/init, cannot boot bootdevice=$bootdevice"
+		error "System is unbootable. Force safemode and reformat."
+	fi
 else
-    error "ARCH=$ARCH is not supported by this initramfs"
+	error "ARCH=$ARCH is not supported by this initramfs"
 fi
 
 # cleanup

--- a/recipes-core/initrdscripts/files/ni_provisioning
+++ b/recipes-core/initrdscripts/files/ni_provisioning
@@ -4,19 +4,19 @@ INVALID_NILRT_ID_MSG="Invalid value for PROVISION_PART_NILRT_ID. Use UUID=<value
 
 # verify required tools are installed
 for toolName in poweroff reboot mount umount sync ls rm ln mkdir cp echo printf dirname basename find grep egrep tar bzip2 bunzip2 lsblk cut udevadm date sleep head; do
-    if ! type "$toolName" >/dev/null; then
-        printf "\n***Error: Missing $toolName\n"
-        printf "PROVISIONING FAILED!"
-        exit 1
-    fi
+	if ! type "$toolName" >/dev/null; then
+		printf "\n***Error: Missing $toolName\n"
+		printf "PROVISIONING FAILED!"
+		exit 1
+	fi
 done
 
 if [ -e /ni_provisioning.common ]; then
-    source /ni_provisioning.common
+	source /ni_provisioning.common
 else
-    printf "\n***Error: File ni_provisioning.common not found!\n"
-    printf "PROVISIONING FAILED!"
-    exit 1
+	printf "\n***Error: File ni_provisioning.common not found!\n"
+	printf "PROVISIONING FAILED!"
+	exit 1
 fi
 
 early_setup "$@"
@@ -25,93 +25,93 @@ early_setup "$@"
 source_default_answer_file
 
 if in_recovery_mode; then
-    echo "Automatic provision and reboot in recovery mode"
-    PROVISION_REPARTITION_TARGET="y"
-    PROVISION_REBOOT_METHOD="reboot"
+	echo "Automatic provision and reboot in recovery mode"
+	PROVISION_REPARTITION_TARGET="y"
+	PROVISION_REBOOT_METHOD="reboot"
 fi
 
 if [[ $restore == "provision-safe" ]]; then
-    # source user's answer file, if present
-    source_answer_file
-    echo
+	# source user's answer file, if present
+	source_answer_file
+	echo
 
-    if [[ "$PROVISION_REPARTITION_TARGET" != "y" ]]; then
-        ask_for_continue
-    fi
+	if [[ "$PROVISION_REPARTITION_TARGET" != "y" ]]; then
+		ask_for_continue
+	fi
 
-    if [[ $PROVISION_REPARTITION_TARGET == "y" ]]; then
-        source /ni_provisioning.safemode
-        if [[ "${FORCE_PROVISIONING}" -eq 1 ]]; then
-            PROVISION_REBOOT_METHOD=${RESTART_OPTION}
-        fi
-        ASK_BEFORE_REBOOT=1
-    fi
+	if [[ $PROVISION_REPARTITION_TARGET == "y" ]]; then
+		source /ni_provisioning.safemode
+		if [[ "${FORCE_PROVISIONING}" -eq 1 ]]; then
+			PROVISION_REBOOT_METHOD=${RESTART_OPTION}
+		fi
+		ASK_BEFORE_REBOOT=1
+	fi
 elif [[ $restore == "backward-migrate" ]]; then
-    source /ni_provisioning.safemode
-    ASK_BEFORE_REBOOT=1
-    PROVISION_REBOOT_METHOD="reboot"
+	source /ni_provisioning.safemode
+	ASK_BEFORE_REBOOT=1
+	PROVISION_REBOOT_METHOD="reboot"
 elif [[ $restore == "provision" ]]; then
-    # source user's answer file, if present
-    source_answer_file
-    echo
+	# source user's answer file, if present
+	source_answer_file
+	echo
 
-    if [[ "$PROVISION_PART_NILRT_ID" = "auto" ]]; then
-        ask_for_continue
+	if [[ "$PROVISION_PART_NILRT_ID" = "auto" ]]; then
+		ask_for_continue
 
-        if [[ $PROVISION_REPARTITION_TARGET == "y" ]]; then
-            provision_target usb
-        fi
-    else
-        # TODO
-        die "Not supported yet"
+		if [[ $PROVISION_REPARTITION_TARGET == "y" ]]; then
+			provision_target usb
+		fi
+	else
+		# TODO
+		die "Not supported yet"
 
-        case "$PROVISION_PART_NILRT_ID" in
-            LABEL=*)
-                ;;
-            UUID=*)
-                ;;
-            PARTUUID=*)
-                ;;
-            *)
-                die "$INVALID_NILRT_ID_MSG"
-                ;;
-        esac
+		case "$PROVISION_PART_NILRT_ID" in
+			LABEL=*)
+				;;
+			UUID=*)
+				;;
+			PARTUUID=*)
+				;;
+			*)
+				die "$INVALID_NILRT_ID_MSG"
+				;;
+		esac
 
-        column=${PROVISION_PART_NILRT_ID%%=*}
-        nilrt_id=${PROVISION_PART_NILRT_ID##*=}
-        if [[ -z "$nilrt_id" ]]; then
-            die "$INVALID_NILRT_ID_MSG"
-        fi
-        if [[ "$column" = "LABEL" ]]; then
-            grep_options=""
-        else
-            grep_options="-i"
-        fi
-        nilrt_path=`lsblk -rnpo NAME,"$column" | grep $grep_options "$nilrt_id" | cut -d' ' -f1`
-        if [[ -z "$nilrt_path" ]]; then
-            die "Partition with "$PROVISION_PART_NILRT_ID" not found."
-        fi
+		column=${PROVISION_PART_NILRT_ID%%=*}
+		nilrt_id=${PROVISION_PART_NILRT_ID##*=}
+		if [[ -z "$nilrt_id" ]]; then
+			die "$INVALID_NILRT_ID_MSG"
+		fi
+		if [[ "$column" = "LABEL" ]]; then
+			grep_options=""
+		else
+			grep_options="-i"
+		fi
+		nilrt_path=`lsblk -rnpo NAME,"$column" | grep $grep_options "$nilrt_id" | cut -d' ' -f1`
+		if [[ -z "$nilrt_path" ]]; then
+			die "Partition with "$PROVISION_PART_NILRT_ID" not found."
+		fi
 
-        ask_for_continue
-        if [[ $PROVISION_REPARTITION_TARGET == "y" ]]; then
-            if [[ "$column" = "UUID" ]]; then
-                uuid="$nilrt_id"
-            else
-                uuid=""
-            fi
-            restore_runmode_image "$nilrt_path" "$uuid" "$PROVISION_PART_NILRT_LABEL"
-        fi
-    fi
+		ask_for_continue
+		if [[ $PROVISION_REPARTITION_TARGET == "y" ]]; then
+			if [[ "$column" = "UUID" ]]; then
+				uuid="$nilrt_id"
+			else
+				uuid=""
+			fi
+			restore_runmode_image "$nilrt_path" "$uuid" "$PROVISION_PART_NILRT_LABEL"
+		fi
+	fi
 
 elif [[ $restore == "migrate" ]]; then
-    PROVISION_REBOOT_METHOD="reboot"
-    provision_target onboard
+	PROVISION_REBOOT_METHOD="reboot"
+	provision_target onboard
 else
-    die "Invalid restore mode."
+	die "Invalid restore mode."
 fi
 
 if [[ "$ASK_BEFORE_REBOOT" -ne 0 ]] && [[ "${FORCE_PROVISIONING}" -ne 1 ]] ; then
-    prompt_user "Please eject the installation media and restart the system (Reboot, poweroff, shell)" "^(reboot|poweroff|shell)$" "reboot" PROVISION_REBOOT_METHOD
+	prompt_user "Please eject the installation media and restart the system (Reboot, poweroff, shell)" "^(reboot|poweroff|shell)$" "reboot" PROVISION_REBOOT_METHOD
 fi
 
 cleanup_and_exit 0

--- a/recipes-core/initrdscripts/files/ni_provisioning.common
+++ b/recipes-core/initrdscripts/files/ni_provisioning.common
@@ -26,651 +26,651 @@ MKFS_ARGS=${MKFS_ARGS:-"$VERBOSE_ARGS -F"}
 verbose_mode=${verbose_mode:-0}
 
 if [ "$verbose_mode" -eq 0 ]; then
-    do_silent() { "$@" &>/dev/null; };
+	do_silent() { "$@" &>/dev/null; };
 else
-    do_silent() { "$@"; }
+	do_silent() { "$@"; }
 fi
 
 # source reboot/poweroff functions since we don't have sysvinit in restore
 # tried adding in /init but the commands are not passed to /ni_provisioning context
 if [ -e /etc/profile.d/00-init-restore-mode.sh ]; then
-    source /etc/profile.d/00-init-restore-mode.sh
+	source /etc/profile.d/00-init-restore-mode.sh
 else
-    printf "\n***Error: File 00-init-restore-mode.sh not found!\n"
-    printf "Reboot/poweroff will not work automatically!"
+	printf "\n***Error: File 00-init-restore-mode.sh not found!\n"
+	printf "Reboot/poweroff will not work automatically!"
 fi
 
 get_image_info()
 {
-    TOKEN=$1
+	TOKEN=$1
 
-    grep -Po "(?<=${TOKEN}=).*" /payload/imageinfo
+	grep -Po "(?<=${TOKEN}=).*" /payload/imageinfo
 }
 
 ask_for_continue()
 {
-    type=${1:-"Recovery"}
-    variable=${2:-"PROVISION_REPARTITION_TARGET"}
+	type=${1:-"Recovery"}
+	variable=${2:-"PROVISION_REPARTITION_TARGET"}
 
-    BUILD_IDENTIFIER=$(get_image_info BUILD_IDENTIFIER)
-    IMAGE_DISPLAY_NAME=$(get_image_info IMAGE_DISPLAY_NAME)
+	BUILD_IDENTIFIER=$(get_image_info BUILD_IDENTIFIER)
+	IMAGE_DISPLAY_NAME=$(get_image_info IMAGE_DISPLAY_NAME)
 
-    printf "\nNI Linux Real-Time $type $BUILD_IDENTIFIER. \n\n"
-    printf "Continuing will partition the disk, format, and install $IMAGE_DISPLAY_NAME to the target.\n\n"
-    if [[ "$FORCE_PROVISIONING" -ne 1 ]];then
-        prompt_user "Do you want to continue? [y/N]" "^(y|n)$" "n" $variable
-    else
-        eval ${variable}="y"
-    fi
+	printf "\nNI Linux Real-Time $type $BUILD_IDENTIFIER. \n\n"
+	printf "Continuing will partition the disk, format, and install $IMAGE_DISPLAY_NAME to the target.\n\n"
+	if [[ "$FORCE_PROVISIONING" -ne 1 ]];then
+		prompt_user "Do you want to continue? [y/N]" "^(y|n)$" "n" $variable
+	else
+		eval ${variable}="y"
+	fi
 }
 
 provision_successfull()
 {
-    do_silent mount
-    echo -e ${GREEN}"PROVISIONING SUCCESSFUL!"${NC} 1>&3 2>&4
+	do_silent mount
+	echo -e ${GREEN}"PROVISIONING SUCCESSFUL!"${NC} 1>&3 2>&4
 }
 
 umount_partition()
 {
-    if [ ! -z "`mount | grep $1`" ]; then
-        umount $1 &>/dev/null
-    fi
+	if [ ! -z "`mount | grep $1`" ]; then
+		umount $1 &>/dev/null
+	fi
 }
 
 umount_partitions()
 {
-    for PART in `ls -1 ${TARGET_DISK}* | tail -n +2`
-    do
-        umount_partition $PART
-    done
+	for PART in `ls -1 ${TARGET_DISK}* | tail -n +2`
+	do
+		umount_partition $PART
+	done
 }
 
 cleanup_and_exit()
 {
-    echo $LOG_LEVEL > /proc/sys/kernel/printk
-    trap - ERR
+	echo $LOG_LEVEL > /proc/sys/kernel/printk
+	trap - ERR
 
-    sync
+	sync
 
-    if [ "$ARCH" = "armv7l" ]; then
-        #set the bootmode to default
-        echo -n 00 >  /sys/bus/i2c/devices/0-0040/scratch_hardreset
-    fi
+	if [ "$ARCH" = "armv7l" ]; then
+		#set the bootmode to default
+		echo -n 00 >  /sys/bus/i2c/devices/0-0040/scratch_hardreset
+	fi
 
-    if (( $1 == 0  && $ASK_BEFORE_REBOOT == 1 )); then
-        if [[ "${PROVISION_REBOOT_METHOD}" == "reboot" ]]; then
-            reboot
-        elif [[ "${PROVISION_REBOOT_METHOD}" == "poweroff" ]]; then
-            poweroff
-        else
-            echo "Unmounting all file systems"
-            # unmounting rootfs kills /ni_provisioning right here,
-            # sync and "Dropping to shell" message will be skipped
-            umount -a -r -t norootfs,noproc,nosysfs,noefivarfs,nodevtmpfs
-            sync
+	if (( $1 == 0  && $ASK_BEFORE_REBOOT == 1 )); then
+		if [[ "${PROVISION_REBOOT_METHOD}" == "reboot" ]]; then
+			reboot
+		elif [[ "${PROVISION_REBOOT_METHOD}" == "poweroff" ]]; then
+			poweroff
+		else
+			echo "Unmounting all file systems"
+			# unmounting rootfs kills /ni_provisioning right here,
+			# sync and "Dropping to shell" message will be skipped
+			umount -a -r -t norootfs,noproc,nosysfs,noefivarfs,nodevtmpfs
+			sync
 
-            echo "Dropping to shell"
-        fi
-    fi
+			echo "Dropping to shell"
+		fi
+	fi
 
-    exit $1
+	exit $1
 }
 
 die()
 {
-    echo -e "${RED}\n***Error: $1\nPROVISIONING FAILED!${NC}"
-    cleanup_and_exit 1
+	echo -e "${RED}\n***Error: $1\nPROVISIONING FAILED!${NC}"
+	cleanup_and_exit 1
 }
 
 if [ -e /disk_config ]; then
-    source /disk_config
+	source /disk_config
 else
-    die "disk_config not found!"
+	die "disk_config not found!"
 fi
 
 if [ "$ARCH" = "armv7l" ]; then
 
-    die "Architecture $ARCH not supported."
+	die "Architecture $ARCH not supported."
 
 elif [ "$ARCH" = "x86_64" ]; then
 
-    show_help()
-    {
-        >&3 echo -e "\nUsage: $0 [-hav] [-t DEVICE] [-r y|n] [-c y|n] [-b SECONDS] [-F RESTART_OPTION]\n"
-        >&3 echo -e "Options\n"
-        >&3 echo "   -h : Show help."
-        >&3 echo "   -a : Ask at every error if continue. Default is N, so at the first error abort."
-        >&3 echo "   -v : Verbose mode."
-        >&3 echo "   -t DEVICE : DEVICE is the device name for the disk to update. (e.g /dev/sda)"
-        >&3 echo "               If DEVICE is not specificed, the first non-removable block device"
-        >&3 echo "               that is not the recovery tool is used."
-        >&3 echo "   -r y|n : Force use of initramfs style boot for runmode (compatible 2018 and later)."
-        >&3 echo "            Also enables bootflag.d directory for bootmode selection. Determined"
-        >&3 echo "            automatically when unspecified."
-        >&3 echo "   -c y|n : Initial value of the console out enable flag."
-        >&3 echo "   -b SECONDS : Initial value of bootdelay -- how long (seconds) to show boot menu."
-        >&3 echo "   -F RESTART_OPTION : Force provisioning (surpress the promts). RESTART_OPTION specifies"
-        >&3 echo "                       what should be done after a succesful provisioning and can have the"
-        >&3 echo "                       following values: reboot, poweroff or shell."
-    }
+	show_help()
+	{
+		>&3 echo -e "\nUsage: $0 [-hav] [-t DEVICE] [-r y|n] [-c y|n] [-b SECONDS] [-F RESTART_OPTION]\n"
+		>&3 echo -e "Options\n"
+		>&3 echo "   -h : Show help."
+		>&3 echo "   -a : Ask at every error if continue. Default is N, so at the first error abort."
+		>&3 echo "   -v : Verbose mode."
+		>&3 echo "   -t DEVICE : DEVICE is the device name for the disk to update. (e.g /dev/sda)"
+		>&3 echo "               If DEVICE is not specificed, the first non-removable block device"
+		>&3 echo "               that is not the recovery tool is used."
+		>&3 echo "   -r y|n : Force use of initramfs style boot for runmode (compatible 2018 and later)."
+		>&3 echo "            Also enables bootflag.d directory for bootmode selection. Determined"
+		>&3 echo "            automatically when unspecified."
+		>&3 echo "   -c y|n : Initial value of the console out enable flag."
+		>&3 echo "   -b SECONDS : Initial value of bootdelay -- how long (seconds) to show boot menu."
+		>&3 echo "   -F RESTART_OPTION : Force provisioning (surpress the promts). RESTART_OPTION specifies"
+		>&3 echo "                       what should be done after a succesful provisioning and can have the"
+		>&3 echo "                       following values: reboot, poweroff or shell."
+	}
 
-    # For a given block device (represented by sysfs path $1 and block device path
-    # $2), return zero if suitable for provisioning. If $3 is not True, skip MMC
-    # block devices.
-    check_block_device () {
-        local path=$1
-        local block=$2
-        local mmc_ok=${3:-false}
+	# For a given block device (represented by sysfs path $1 and block device path
+	# $2), return zero if suitable for provisioning. If $3 is not True, skip MMC
+	# block devices.
+	check_block_device () {
+		local path=$1
+		local block=$2
+		local mmc_ok=${3:-false}
 
-        if ! (( $? == 0 )); then
-            (( verbose_mode )) && echo "SKIPPED $path_abbrev: udevadm failed" >&2
-            return 1
-        fi
+		if ! (( $? == 0 )); then
+			(( verbose_mode )) && echo "SKIPPED $path_abbrev: udevadm failed" >&2
+			return 1
+		fi
 
-        # Skip zero-size devices. This catches unattached loop*.
-        if ! (( $(<$path/size) > 0 )); then
-            (( verbose_mode )) && echo "SKIPPED $path_abbrev: size==0" >&2
-            return 1
-        fi
+		# Skip zero-size devices. This catches unattached loop*.
+		if ! (( $(<$path/size) > 0 )); then
+			(( verbose_mode )) && echo "SKIPPED $path_abbrev: size==0" >&2
+			return 1
+		fi
 
-        # Skip removable devices; we're only interested in internal disks. This
-        # catches USBs and CDs.
-        if ! (( $(<$path/removable) == 0 )); then
-            (( verbose_mode )) && echo "SKIPPED $path_abbrev: removable!=0" >&2
-            return 1
-        fi
+		# Skip removable devices; we're only interested in internal disks. This
+		# catches USBs and CDs.
+		if ! (( $(<$path/removable) == 0 )); then
+			(( verbose_mode )) && echo "SKIPPED $path_abbrev: removable!=0" >&2
+			return 1
+		fi
 
-        # Skip read-only devices. This catches mmcblk*boot*, but *not*
-        # CDs, unless a read-only CD is present in the drive.
-        if ! (( $(<$path/ro) == 0 )); then
-            (( verbose_mode )) && echo "SKIPPED $path_abbrev: ro!=0" >&2
-            return 1
-        fi
+		# Skip read-only devices. This catches mmcblk*boot*, but *not*
+		# CDs, unless a read-only CD is present in the drive.
+		if ! (( $(<$path/ro) == 0 )); then
+			(( verbose_mode )) && echo "SKIPPED $path_abbrev: ro!=0" >&2
+			return 1
+		fi
 
-        # Skip purely virtual devices. This catches zram* and loop* (again).
-        if ! [[ -d $path/device ]]; then
-            (( verbose_mode )) && echo "SKIPPED $path_abbrev: no device/" >&2
-            return 1
-        fi
+		# Skip purely virtual devices. This catches zram* and loop* (again).
+		if ! [[ -d $path/device ]]; then
+			(( verbose_mode )) && echo "SKIPPED $path_abbrev: no device/" >&2
+			return 1
+		fi
 
-        # $path/device/block must exist. This catches mmcblk*boot* (again).
-        if ! ( [[ -d $path/device/block/ ]] || [[ -d $path/device/${path##*/} ]] ); then
-            (( verbose_mode )) && echo "SKIPPED $path_abbrev: no device/block/" >&2
-            return 1
-        fi
+		# $path/device/block must exist. This catches mmcblk*boot* (again).
+		if ! ( [[ -d $path/device/block/ ]] || [[ -d $path/device/${path##*/} ]] ); then
+			(( verbose_mode )) && echo "SKIPPED $path_abbrev: no device/block/" >&2
+			return 1
+		fi
 
-        # Some devices have onboard or removable MMC devices which should be
-        # skipped, unless the system's architect has added it to the MMC
-        # whitelist.
-        if ! $mmc_ok; then
-                if [[ "${path##*/}" =~ ^mmc.* ]]; then
-                        (( verbose_mode )) && echo "SKIPPED: $path_abbrev: mmc block device && MMC provisioning is not permitted for this device." >&2
-                        return 1
-                fi
-        fi
+		# Some devices have onboard or removable MMC devices which should be
+		# skipped, unless the system's architect has added it to the MMC
+		# whitelist.
+		if ! $mmc_ok; then
+				if [[ "${path##*/}" =~ ^mmc.* ]]; then
+						(( verbose_mode )) && echo "SKIPPED: $path_abbrev: mmc block device && MMC provisioning is not permitted for this device." >&2
+						return 1
+				fi
+		fi
 
-        # Skip the recovery partition itself. Scan all partitions that might be present
-        # at/underneath the given block device.
-        if [[ "$restore" != "migrate" && "$restore" != "backward-migrate" ]] ; then
-            for p in ${block}*; do
-                local label=`lsblk $p -n -o LABEL 2>/dev/null`
-                if [[ "$label" == "NIRECOVERY" ]]; then
-                    (( verbose_mode )) && echo "SKIPPED $path_abbrev: contains NIRECOVERY" >&2
-                    return 1
-                fi
-                if [[ "$label" == "NIRECOVERY-CD" ]]; then
-                    (( verbose_mode )) && echo "SKIPPED $path_abbrev: contains NIRECOVERY-CD" >&2
-                    return 1
-                fi
-            done
-        fi
+		# Skip the recovery partition itself. Scan all partitions that might be present
+		# at/underneath the given block device.
+		if [[ "$restore" != "migrate" && "$restore" != "backward-migrate" ]] ; then
+			for p in ${block}*; do
+				local label=`lsblk $p -n -o LABEL 2>/dev/null`
+				if [[ "$label" == "NIRECOVERY" ]]; then
+					(( verbose_mode )) && echo "SKIPPED $path_abbrev: contains NIRECOVERY" >&2
+					return 1
+				fi
+				if [[ "$label" == "NIRECOVERY-CD" ]]; then
+					(( verbose_mode )) && echo "SKIPPED $path_abbrev: contains NIRECOVERY-CD" >&2
+					return 1
+				fi
+			done
+		fi
 
-        return 0
-    }
+		return 0
+	}
 
-    find_target_block_device()
-    {
-        local selected_block=""
-        local mmc_ok=false
+	find_target_block_device()
+	{
+		local selected_block=""
+		local mmc_ok=false
 
-        # Check if the machine's DeviceCode is in the MMC device whitelist.
-        if [ -e "${MMC_DEVICE_ALLOW_PATH}" ]; then
-                device_code=$(fw_printenv -n DeviceCode 2>/dev/null)
-                [ -n "$device_code" ] && \
-                        grep -iq -E "^\s*(0x)?${device_code}\s*(#.*)?$" "${MMC_DEVICE_ALLOW_PATH}" && \
-                        mmc_ok=true
-        else
-                (( verbose_mode )) && echo "Warning: eMMC device whitelist not found. eMMC block devices will be disqualified from provisioning." >&2
-        fi
+		# Check if the machine's DeviceCode is in the MMC device whitelist.
+		if [ -e "${MMC_DEVICE_ALLOW_PATH}" ]; then
+				device_code=$(fw_printenv -n DeviceCode 2>/dev/null)
+				[ -n "$device_code" ] && \
+						grep -iq -E "^\s*(0x)?${device_code}\s*(#.*)?$" "${MMC_DEVICE_ALLOW_PATH}" && \
+						mmc_ok=true
+		else
+				(( verbose_mode )) && echo "Warning: eMMC device whitelist not found. eMMC block devices will be disqualified from provisioning." >&2
+		fi
 
 
-        for path in /sys/block/*; do
-            path_abbrev=${path##/sys/block/}
-            local block=$(udevadm info -r --query=name --path=$path)
-            check_block_device $path $block $mmc_ok || continue
+		for path in /sys/block/*; do
+			path_abbrev=${path##/sys/block/}
+			local block=$(udevadm info -r --query=name --path=$path)
+			check_block_device $path $block $mmc_ok || continue
 
-            # Looks good. Select the first device we see.
-            if [[ $selected_block ]]; then
-                (( verbose_mode )) && echo "SKIPPED block device $path_abbrev" >&2
-            else
-                selected_block=$block
-                (( verbose_mode )) && echo "SELECTED block device $path_abbrev" >&2
-            fi
-        done
+			# Looks good. Select the first device we see.
+			if [[ $selected_block ]]; then
+				(( verbose_mode )) && echo "SKIPPED block device $path_abbrev" >&2
+			else
+				selected_block=$block
+				(( verbose_mode )) && echo "SELECTED block device $path_abbrev" >&2
+			fi
+		done
 
-        if [[ $selected_block ]]; then
-            echo "$selected_block"
-        else
-            return 1
-        fi
-    }
+		if [[ $selected_block ]]; then
+			echo "$selected_block"
+		else
+			return 1
+		fi
+	}
 
-    restore_runmode_image()
-    {
-        # TODO
-        die "Not supported yet"
+	restore_runmode_image()
+	{
+		# TODO
+		die "Not supported yet"
 
-        local nilrt_path="$1" uuid="$2" nilrt_label="$3"
+		local nilrt_path="$1" uuid="$2" nilrt_label="$3"
 
-        NILRT_MOUNTPOINT=/var/volatile/nilrt
-        mkdir -p $NILRT_MOUNTPOINT
-        if [[ -z "$nilrt_path" ]]; then
-            echo "Formatting $TARGET_DISK $NILRT_LABEL partition..."
-            do_silent partition_format $TARGET_DISK $NILRT_LABEL
-            nilrt_path=`lsblk -rpn $TARGET_DISK -o NAME,LABEL | grep " $NILRT_LABEL"'$'  | tail -1 | cut -d' ' -f1`
-        else
-            echo "Formatting $nilrt_path partition..."
-            existing_nilrt_partition_format "$nilrt_path" "$uuid" "$nilrt_label"
-        fi
+		NILRT_MOUNTPOINT=/var/volatile/nilrt
+		mkdir -p $NILRT_MOUNTPOINT
+		if [[ -z "$nilrt_path" ]]; then
+			echo "Formatting $TARGET_DISK $NILRT_LABEL partition..."
+			do_silent partition_format $TARGET_DISK $NILRT_LABEL
+			nilrt_path=`lsblk -rpn $TARGET_DISK -o NAME,LABEL | grep " $NILRT_LABEL"'$'  | tail -1 | cut -d' ' -f1`
+		else
+			echo "Formatting $nilrt_path partition..."
+			existing_nilrt_partition_format "$nilrt_path" "$uuid" "$nilrt_label"
+		fi
 
-        do_silent echo "Mounting $nilrt_path partition..."
-        NILRT_ERROR=`mount "$nilrt_path" $NILRT_MOUNTPOINT` || die "$NILRT_ERROR"
+		do_silent echo "Mounting $nilrt_path partition..."
+		NILRT_ERROR=`mount "$nilrt_path" $NILRT_MOUNTPOINT` || die "$NILRT_ERROR"
 
-        echo "Deploying $IMAGE_DISPLAY_NAME image..."
+		echo "Deploying $IMAGE_DISPLAY_NAME image..."
 
-        # NOTE: `--numeric-owner` option: always use numbers for user/group names (ignore symbolic names)
-        TAR_ERROR="`tar -x -j --numeric-owner -f /payload/factory-image.tar.bz2 -C $NILRT_MOUNTPOINT 2>&1`" || die "$TAR_ERROR"
+		# NOTE: `--numeric-owner` option: always use numbers for user/group names (ignore symbolic names)
+		TAR_ERROR="`tar -x -j --numeric-owner -f /payload/factory-image.tar.bz2 -C $NILRT_MOUNTPOINT 2>&1`" || die "$TAR_ERROR"
 
-        # Set hostname, if configured
-        if [ -n "$PROVISION_HOSTNAME" ]; then
-            echo "$PROVISION_HOSTNAME" >"$NILRT_MOUNTPOINT/etc/hostname"
-            chown 0:0 "$NILRT_MOUNTPOINT/etc/hostname"
-            chmod u=rw,go=r "$NILRT_MOUNTPOINT/etc/hostname"
-        fi
+		# Set hostname, if configured
+		if [ -n "$PROVISION_HOSTNAME" ]; then
+			echo "$PROVISION_HOSTNAME" >"$NILRT_MOUNTPOINT/etc/hostname"
+			chown 0:0 "$NILRT_MOUNTPOINT/etc/hostname"
+			chmod u=rw,go=r "$NILRT_MOUNTPOINT/etc/hostname"
+		fi
 
-        nilrt_part_uuid=`lsblk -rn $nilrt_path -o PARTUUID`
-        if [[ -n "$nilrt_part_uuid" ]]; then
-            # grub from nilrt partition needs PARTUUID to boot kernel from same partition
-            root_partition_value="PARTUUID=$nilrt_part_uuid"
-        else
-            root_partition_value="$nilrt_path"
-        fi
+		nilrt_part_uuid=`lsblk -rn $nilrt_path -o PARTUUID`
+		if [[ -n "$nilrt_part_uuid" ]]; then
+			# grub from nilrt partition needs PARTUUID to boot kernel from same partition
+			root_partition_value="PARTUUID=$nilrt_part_uuid"
+		else
+			root_partition_value="$nilrt_path"
+		fi
 
-        mkdir -p $NILRT_MOUNTPOINT/boot/grub
-        grub-editenv $NILRT_MOUNTPOINT/boot/grub/grubenv set root_partition_name="$root_partition_value"
-        sync
-        umount $NILRT_MOUNTPOINT || die "Failed to umount $NILRT_MOUNTPOINT"
+		mkdir -p $NILRT_MOUNTPOINT/boot/grub
+		grub-editenv $NILRT_MOUNTPOINT/boot/grub/grubenv set root_partition_name="$root_partition_value"
+		sync
+		umount $NILRT_MOUNTPOINT || die "Failed to umount $NILRT_MOUNTPOINT"
 
-        echo "Image deployed."
-        ASK_BEFORE_REBOOT=1
-    }
+		echo "Image deployed."
+		ASK_BEFORE_REBOOT=1
+	}
 
-    prune_efi_crash_vars()
-    {
-        # Previous kernels may have stored kernel crash information in EFI.
-        # Unfortunately if we have a backlog, this can prevent us from adding
-        # additional boot entries, since those are also EFI variables. Since
-        # we're (re)provisioning a target, we don't care about prior state,
-        # so just delete them.
-        LINUX_EFI_CRASH_GUID="cfc8fc79-be2e-4ddc-97f0-9f98bfe298a0"
-        find /sys/firmware/efi/efivars -name "*-${LINUX_EFI_CRASH_GUID}" -exec /bin/rm {} +
-    }
+	prune_efi_crash_vars()
+	{
+		# Previous kernels may have stored kernel crash information in EFI.
+		# Unfortunately if we have a backlog, this can prevent us from adding
+		# additional boot entries, since those are also EFI variables. Since
+		# we're (re)provisioning a target, we don't care about prior state,
+		# so just delete them.
+		LINUX_EFI_CRASH_GUID="cfc8fc79-be2e-4ddc-97f0-9f98bfe298a0"
+		find /sys/firmware/efi/efivars -name "*-${LINUX_EFI_CRASH_GUID}" -exec /bin/rm {} +
+	}
 
-    provision_target()
-    {
-        echo "Partitioning $TARGET_DISK..."
-        do_silent disk_setup "$TARGET_DISK"
+	provision_target()
+	{
+		echo "Partitioning $TARGET_DISK..."
+		do_silent disk_setup "$TARGET_DISK"
 
-        prune_efi_crash_vars
+		prune_efi_crash_vars
 
-        # XXX Find niboota and nibootb partlabels on TARGET_DISK and
-        # link as needed by RAUC
-        echo "Finding niboot partitions..."
-        local niboota_device=$(lsblk -rpn "$TARGET_DISK" -o NAME,PARTLABEL | grep " niboota$" | cut -d" " -f1)
-        local nibootb_device=$(lsblk -rpn "$TARGET_DISK" -o NAME,PARTLABEL | grep " nibootb$" | cut -d" " -f1)
-        mkdir -p /dev/niboot/
-        ln -sf "$niboota_device" "/dev/niboot/niboota"
-        ln -sf "$nibootb_device" "/dev/niboot/nibootb"
+		# XXX Find niboota and nibootb partlabels on TARGET_DISK and
+		# link as needed by RAUC
+		echo "Finding niboot partitions..."
+		local niboota_device=$(lsblk -rpn "$TARGET_DISK" -o NAME,PARTLABEL | grep " niboota$" | cut -d" " -f1)
+		local nibootb_device=$(lsblk -rpn "$TARGET_DISK" -o NAME,PARTLABEL | grep " nibootb$" | cut -d" " -f1)
+		mkdir -p /dev/niboot/
+		ln -sf "$niboota_device" "/dev/niboot/niboota"
+		ln -sf "$nibootb_device" "/dev/niboot/nibootb"
 
-        local run_rauc="rauc --no-signatures"
-        (( verbose_mode )) && run_rauc="$run_rauc --debug"
+		local run_rauc="rauc --no-signatures"
+		(( verbose_mode )) && run_rauc="$run_rauc --debug"
 
-        if [ "$PROVISION_BOOT_SCHEME" == "efi-ab" ]; then
-            echo "Configuring EFI for A/B image boot..."
+		if [ "$PROVISION_BOOT_SCHEME" == "efi-ab" ]; then
+			echo "Configuring EFI for A/B image boot..."
 
-            # Delete existing NILRT entries with "-B" option
-            for ENTRY in $(efibootmgr | egrep -i '(LabVIEW RT)|(niboota)|(nibootb)' | egrep -o '[0-9A-Fa-f]{4}' || true);
-            do
-                do_silent echo "Drop entry $ENTRY"
-                EFIMGR=$(efibootmgr -b "$ENTRY" -B 2>&1) || print_warning "efibootmgr -b $ENTRY -B failed with: $EFIMGR"
-            done
+			# Delete existing NILRT entries with "-B" option
+			for ENTRY in $(efibootmgr | egrep -i '(LabVIEW RT)|(niboota)|(nibootb)' | egrep -o '[0-9A-Fa-f]{4}' || true);
+			do
+				do_silent echo "Drop entry $ENTRY"
+				EFIMGR=$(efibootmgr -b "$ENTRY" -B 2>&1) || print_warning "efibootmgr -b $ENTRY -B failed with: $EFIMGR"
+			done
 
-            # Add nibootX entries with "-c" option
-            do_silent efibootmgr -c -d "$TARGET_DISK" -p 1 -L 'niboota' -l '\efi\nilrt\bootx64.efi'
-            do_silent efibootmgr -c -d "$TARGET_DISK" -p 2 -L 'nibootb' -l '\efi\nilrt\bootx64.efi'
+			# Add nibootX entries with "-c" option
+			do_silent efibootmgr -c -d "$TARGET_DISK" -p 1 -L 'niboota' -l '\efi\nilrt\bootx64.efi'
+			do_silent efibootmgr -c -d "$TARGET_DISK" -p 2 -L 'nibootb' -l '\efi\nilrt\bootx64.efi'
 
-            echo "Deploying bundles to niboota and nibootb slots..."
+			echo "Deploying bundles to niboota and nibootb slots..."
 
-            # Override niboota to install to nibootb slot
-            $run_rauc --override-boot-slot=niboota install /payload/niboot.raucb 2>&1 || die "RAUC failed to install bundle to nibootb"
-            # Mark-good nibootb to install them at front of EFI BootOrder
-            $run_rauc --override-boot-slot=nibootb status mark-good niboot.1 2>&1 || die "RAUC failed to mark-good niboot.1 (nibootb)"
+			# Override niboota to install to nibootb slot
+			$run_rauc --override-boot-slot=niboota install /payload/niboot.raucb 2>&1 || die "RAUC failed to install bundle to nibootb"
+			# Mark-good nibootb to install them at front of EFI BootOrder
+			$run_rauc --override-boot-slot=nibootb status mark-good niboot.1 2>&1 || die "RAUC failed to mark-good niboot.1 (nibootb)"
 
-            # Override nibootb to install to niboota slot
-            $run_rauc --override-boot-slot=nibootb install /payload/niboot.raucb 2>&1 || die "RAUC failed to install bundle to niboota"
-            # Mark-good niboota to install them at front of EFI BootOrder
-            $run_rauc --override-boot-slot=niboota status mark-good niboot.0 2>&1 || die "RAUC failed to mark-good niboot.0 (niboota)"
+			# Override nibootb to install to niboota slot
+			$run_rauc --override-boot-slot=nibootb install /payload/niboot.raucb 2>&1 || die "RAUC failed to install bundle to niboota"
+			# Mark-good niboota to install them at front of EFI BootOrder
+			$run_rauc --override-boot-slot=niboota status mark-good niboot.0 2>&1 || die "RAUC failed to mark-good niboot.0 (niboota)"
 
-            # Finally, mark-active niboota to ensure it's EFI BootNext
-            $run_rauc --override-boot-slot=niboota status mark-active niboot.0 2>&1 || die "RAUC failed to mark-active niboot.0 (niboota)"
+			# Finally, mark-active niboota to ensure it's EFI BootNext
+			$run_rauc --override-boot-slot=niboota status mark-active niboot.0 2>&1 || die "RAUC failed to mark-active niboot.0 (niboota)"
 
-            sync
+			sync
 
-            efi_boot_config=$(efibootmgr -v)
+			efi_boot_config=$(efibootmgr -v)
 
-            echo "EFI boot configuration:"
-            echo "$efi_boot_config"
-            echo "---"
+			echo "EFI boot configuration:"
+			echo "$efi_boot_config"
+			echo "---"
 
-            # Post install sanity check: Verify niboota and nibootb are
-            #  first two boot entries and niboota is BootNext
-            echo -n "Check EFI boot configuration: "
+			# Post install sanity check: Verify niboota and nibootb are
+			#  first two boot entries and niboota is BootNext
+			echo -n "Check EFI boot configuration: "
 
-            boot_order=$(echo "$efi_boot_config" | egrep "^BootOrder: [0-9,]+" | cut -d" " -f2)
-            boot_A_numb=$(echo "$boot_order" | cut -d"," -f1)
-            boot_B_numb=$(echo "$boot_order" | cut -d"," -f2)
+			boot_order=$(echo "$efi_boot_config" | egrep "^BootOrder: [0-9,]+" | cut -d" " -f2)
+			boot_A_numb=$(echo "$boot_order" | cut -d"," -f1)
+			boot_B_numb=$(echo "$boot_order" | cut -d"," -f2)
 
-            if ! echo "$efi_boot_config" | egrep -q "^Boot${boot_A_numb}.* niboota"$'\t'"+HD\(1,"; then
-                die "niboota is not at Boot${boot_A_numb}, boot_order=$boot_order"
-            fi
+			if ! echo "$efi_boot_config" | egrep -q "^Boot${boot_A_numb}.* niboota"$'\t'"+HD\(1,"; then
+				die "niboota is not at Boot${boot_A_numb}, boot_order=$boot_order"
+			fi
 
-            if ! echo "$efi_boot_config" | egrep -q "^Boot${boot_B_numb}.* nibootb"$'\t'"+HD\(2,"; then
-                die "nibootb is not at Boot${boot_B_numb}, boot_order=$boot_order"
-            fi
+			if ! echo "$efi_boot_config" | egrep -q "^Boot${boot_B_numb}.* nibootb"$'\t'"+HD\(2,"; then
+				die "nibootb is not at Boot${boot_B_numb}, boot_order=$boot_order"
+			fi
 
-            boot_next=$(echo "$efi_boot_config" | egrep "^BootNext: [0-9]+ *$" | cut -d" " -f2)
-            [ "$boot_next" == "$boot_A_numb" ] || die "BootNext=$boot_next, expecting niboota at $boot_A_numb"
+			boot_next=$(echo "$efi_boot_config" | egrep "^BootNext: [0-9]+ *$" | cut -d" " -f2)
+			[ "$boot_next" == "$boot_A_numb" ] || die "BootNext=$boot_next, expecting niboota at $boot_A_numb"
 
-            echo "OK"
+			echo "OK"
 
-        elif [ "$PROVISION_BOOT_SCHEME" == "efi-auto" ]; then
-            echo "Installing automatic EFI boot loader..."
+		elif [ "$PROVISION_BOOT_SCHEME" == "efi-auto" ]; then
+			echo "Installing automatic EFI boot loader..."
 
-            mkdir /mnt/efi-auto /mnt/efi-auto/bundle /mnt/efi-auto/niboota
+			mkdir /mnt/efi-auto /mnt/efi-auto/bundle /mnt/efi-auto/niboota
 
-            # Write image to slot 0 (niboota)
-            mount -o ro /payload/niboot.raucb /mnt/efi-auto/bundle
-            mount -o rw /dev/niboot/niboota /mnt/efi-auto/niboota
+			# Write image to slot 0 (niboota)
+			mount -o ro /payload/niboot.raucb /mnt/efi-auto/bundle
+			mount -o rw /dev/niboot/niboota /mnt/efi-auto/niboota
 
-            local img_written=false
-            for imgname in "minimal-nilrt-bundle-image-x64.tar.bz2" "lvcomms-nilrt-bundle-image-x64.tar.bz2"; do
-                local imgpath="/mnt/efi-auto/bundle/$imgname"
+			local img_written=false
+			for imgname in "minimal-nilrt-bundle-image-x64.tar.bz2" "lvcomms-nilrt-bundle-image-x64.tar.bz2"; do
+				local imgpath="/mnt/efi-auto/bundle/$imgname"
 
-                if [ -e "$imgpath" ]; then
-                    echo "Installing $imgpath"
-                    tar -xf "$imgpath" -C "/mnt/efi-auto/niboota/"
+				if [ -e "$imgpath" ]; then
+					echo "Installing $imgpath"
+					tar -xf "$imgpath" -C "/mnt/efi-auto/niboota/"
 
-                    img_written=true
-                    break
-                fi
-            done
-            if ! $img_written; then
-                die "Failed to find an image file in bundle"
-            fi
+					img_written=true
+					break
+				fi
+			done
+			if ! $img_written; then
+				die "Failed to find an image file in bundle"
+			fi
 
-            # Move boot loader image to auto-discoverable /efi/boot/
-            mkdir /mnt/efi-auto/niboota/efi/boot
-            mv /mnt/efi-auto/niboota/efi/nilrt/bootx64.efi /mnt/efi-auto/niboota/efi/boot/bootx64.efi
+			# Move boot loader image to auto-discoverable /efi/boot/
+			mkdir /mnt/efi-auto/niboota/efi/boot
+			mv /mnt/efi-auto/niboota/efi/nilrt/bootx64.efi /mnt/efi-auto/niboota/efi/boot/bootx64.efi
 
-            umount /mnt/efi-auto/niboota
-            umount /mnt/efi-auto/bundle
+			umount /mnt/efi-auto/niboota
+			umount /mnt/efi-auto/bundle
 
-            sync
+			sync
 
-        else
-            die "Invalid PROVISION_BOOT_SCHEME"
-        fi
+		else
+			die "Invalid PROVISION_BOOT_SCHEME"
+		fi
 
-        provision_successfull
-        ASK_BEFORE_REBOOT=1
-    }
+		provision_successfull
+		ASK_BEFORE_REBOOT=1
+	}
 fi
 
 #common functions for both architectures with little differences
 
 print_verbose()
 {
-    if [[ $verbose_mode -eq 1 ]]; then
-        echo -e $@
-    fi
+	if [[ $verbose_mode -eq 1 ]]; then
+		echo -e $@
+	fi
 }
 
 print_warning()
 {
-    print_verbose "${YELLOW}\n***Warning: $1\n${NC}"
+	print_verbose "${YELLOW}\n***Warning: $1\n${NC}"
 }
 
 install_default_error_handler()
 {
-    trap 'handle_err ${BASH_SOURCE} ${LINENO} ${FUNCNAME:-unknown} $? "$BASH_COMMAND"' ERR
+	trap 'handle_err ${BASH_SOURCE} ${LINENO} ${FUNCNAME:-unknown} $? "$BASH_COMMAND"' ERR
 }
 
 handle_err()
 {
-    TMP_EVAL=`eval echo $5`
-    die "$1:$2 (fn=$3): Unexpected status code $4, while running command: '$TMP_EVAL'"
+	TMP_EVAL=`eval echo $5`
+	die "$1:$2 (fn=$3): Unexpected status code $4, while running command: '$TMP_EVAL'"
 }
 
 get_time_delta()
 {
-    local offset="$1"
-    local timestamp=$(date +%s)
-    timestamp=$(( $timestamp - $offset ))
-    echo "$timestamp"
+	local offset="$1"
+	local timestamp=$(date +%s)
+	timestamp=$(( $timestamp - $offset ))
+	echo "$timestamp"
 }
 
 early_setup()
 {
-    install_default_error_handler
+	install_default_error_handler
 
-    exec 3>&1
-    exec 4>&2
+	exec 3>&1
+	exec 4>&2
 
-    LOG_LEVEL=`cut -f1 /proc/sys/kernel/printk`
+	LOG_LEVEL=`cut -f1 /proc/sys/kernel/printk`
 
-    OPTIND=1
+	OPTIND=1
 
-    while getopts "havt:r:c:b:F:" opt; do
-        case "$opt" in
-            h)  show_help
-                exit 1
-                ;;
-            a)  ask_at_every_error="y"
-                ;;
-            v)  verbose_mode=1
-                >&3 echo "Verbose mode..."
-                ;;
-            t)  TARGET_DISK="$OPTARG"
-                ;;
-            r)  if [ "$OPTARG" == "y" -o "$OPTARG" == "Y" ]; then
-                    use_ramfs=true
-                elif [ "$OPTARG" == "n" -o "$OPTARG" == "N" ]; then
-                    use_ramfs=false
-                else
-                    die "Must specify '-r y' or '-r n'"
-                fi
-                ;;
-            c)  if [ "$OPTARG" == "y" -o "$OPTARG" == "Y" ]; then
-                    grubenv_consoleoutenable="True"
-                elif [ "$OPTARG" == "n" -o "$OPTARG" == "N" ]; then
-                    grubenv_consoleoutenable="False"
-                else
-                    die "Must specify '-c y' or '-c n'"
-                fi
-                ;;
-            b)  grubenv_bootdelay="$OPTARG"
-                ;;
-            F)  FORCE_PROVISIONING=1
-                if [ $OPTARG == "reboot" -o  "$OPTARG" == "poweroff" -o "$OPTARG" == "shell" ]; then
-                    RESTART_OPTION="$OPTARG"
-                else
-                    die "RESTART_OPTION can have the following values: reboot, poweroff or shell"
-                fi
-                ;;
-            *)  show_help
-                exit 1
-                ;;
-        esac
-    done
+	while getopts "havt:r:c:b:F:" opt; do
+		case "$opt" in
+			h)  show_help
+				exit 1
+				;;
+			a)  ask_at_every_error="y"
+				;;
+			v)  verbose_mode=1
+				>&3 echo "Verbose mode..."
+				;;
+			t)  TARGET_DISK="$OPTARG"
+				;;
+			r)  if [ "$OPTARG" == "y" -o "$OPTARG" == "Y" ]; then
+					use_ramfs=true
+				elif [ "$OPTARG" == "n" -o "$OPTARG" == "N" ]; then
+					use_ramfs=false
+				else
+					die "Must specify '-r y' or '-r n'"
+				fi
+				;;
+			c)  if [ "$OPTARG" == "y" -o "$OPTARG" == "Y" ]; then
+					grubenv_consoleoutenable="True"
+				elif [ "$OPTARG" == "n" -o "$OPTARG" == "N" ]; then
+					grubenv_consoleoutenable="False"
+				else
+					die "Must specify '-c y' or '-c n'"
+				fi
+				;;
+			b)  grubenv_bootdelay="$OPTARG"
+				;;
+			F)  FORCE_PROVISIONING=1
+				if [ $OPTARG == "reboot" -o  "$OPTARG" == "poweroff" -o "$OPTARG" == "shell" ]; then
+					RESTART_OPTION="$OPTARG"
+				else
+					die "RESTART_OPTION can have the following values: reboot, poweroff or shell"
+				fi
+				;;
+			*)  show_help
+				exit 1
+				;;
+		esac
+	done
 
-    shift $((OPTIND-1))
+	shift $((OPTIND-1))
 
-    [ "$1" = "--" ] && shift
+	[ "$1" = "--" ] && shift
 
-    if [[ $verbose_mode -eq 1 ]]; then
-        VERBOSE_ARGS="-v"
-        MKFS_ARGS="$VERBOSE_ARGS -F"
-    fi
+	if [[ $verbose_mode -eq 1 ]]; then
+		VERBOSE_ARGS="-v"
+		MKFS_ARGS="$VERBOSE_ARGS -F"
+	fi
 
-    if [[ -z $TARGET_DISK ]]; then
-        local search_begin="`get_time_delta 0`"
-        while [ "`get_time_delta "$search_begin"`" -le "$TARGET_DISK_SEARCH_TIME" ]; do
-            (( verbose_mode )) && echo "Searching for TARGET_DISK..." >&2
-            TARGET_DISK="`find_target_block_device`" || TARGET_DISK=""
-            if [[ -z $TARGET_DISK ]]; then
-                (( verbose_mode )) && echo "not found" >&2
-                sleep 1
-            else
-                (( verbose_mode )) && echo "found TARGET_DISK=$TARGET_DISK" >&2
-                break
-            fi
-        done
+	if [[ -z $TARGET_DISK ]]; then
+		local search_begin="`get_time_delta 0`"
+		while [ "`get_time_delta "$search_begin"`" -le "$TARGET_DISK_SEARCH_TIME" ]; do
+			(( verbose_mode )) && echo "Searching for TARGET_DISK..." >&2
+			TARGET_DISK="`find_target_block_device`" || TARGET_DISK=""
+			if [[ -z $TARGET_DISK ]]; then
+				(( verbose_mode )) && echo "not found" >&2
+				sleep 1
+			else
+				(( verbose_mode )) && echo "found TARGET_DISK=$TARGET_DISK" >&2
+				break
+			fi
+		done
 
-        if [[ -z $TARGET_DISK ]]; then
-            die "No target device found for installation after $TARGET_DISK_SEARCH_TIME seconds."
-        fi
-    else
-        if [[ ! -e $TARGET_DISK ]]; then
-        >&4 echo -e ${red}"Error: DEVICE $TARGET_DISK does not exist."${NC}
-            show_help
-            exit 1
-        fi
-    fi
+		if [[ -z $TARGET_DISK ]]; then
+			die "No target device found for installation after $TARGET_DISK_SEARCH_TIME seconds."
+		fi
+	else
+		if [[ ! -e $TARGET_DISK ]]; then
+		>&4 echo -e ${red}"Error: DEVICE $TARGET_DISK does not exist."${NC}
+			show_help
+			exit 1
+		fi
+	fi
 
-    # separate partition number from block device names ending in a digit
-    PART_SEPARATOR=''
-    if [[ "${TARGET_DISK: -1}" =~ [0-9] ]]; then
-        PART_SEPARATOR='p'
-    fi
+	# separate partition number from block device names ending in a digit
+	PART_SEPARATOR=''
+	if [[ "${TARGET_DISK: -1}" =~ [0-9] ]]; then
+		PART_SEPARATOR='p'
+	fi
 
-    if [[ ! -d "/sys/firmware/efi" ]]; then
-        die "Legacy booting is not supported, please reboot and select UEFI instead."
-    fi
+	if [[ ! -d "/sys/firmware/efi" ]]; then
+		die "Legacy booting is not supported, please reboot and select UEFI instead."
+	fi
 }
 
 function read_file() {
-    local filename="$1"
-    local maxsize="$2"
-    local value=""
+	local filename="$1"
+	local maxsize="$2"
+	local value=""
 
-    if [ -e "$filename" ]; then
-        value=$(head -c "$maxsize" "$filename") || value=""
-    fi
+	if [ -e "$filename" ]; then
+		value=$(head -c "$maxsize" "$filename") || value=""
+	fi
 
-    echo "$value"
+	echo "$value"
 }
 
 in_recovery_mode()
 {
-    local res=false
+	local res=false
 
-    for file in /sys/bus/acpi/drivers/nirtfeatures/*/recovery_mode; do
-        status=$(read_file "$file" 10)
-        if [ "$status" == "1" ]; then
-            res=true
-        fi
-    done
+	for file in /sys/bus/acpi/drivers/nirtfeatures/*/recovery_mode; do
+		status=$(read_file "$file" 10)
+		if [ "$status" == "1" ]; then
+			res=true
+		fi
+	done
 
-    $res
+	$res
 }
 
 check_answer_file()
 {
-    local filePath="$1"
-    if [ -r "$filePath" ]; then
-        # Answer file may only contain lines beginning with '#' or 'PROVISION_*=' variables
-        if [ "`head -1 "$filePath"`" == "#NI_PROVISIONING_ANSWERS_V1" ]; then
-            if ! egrep -q -v '(^$|^#|^PROVISION_[A-Z0-9_]+=)' "$filePath"; then
-                return 0
-            fi
-        fi
-    fi
-    return 1
+	local filePath="$1"
+	if [ -r "$filePath" ]; then
+		# Answer file may only contain lines beginning with '#' or 'PROVISION_*=' variables
+		if [ "`head -1 "$filePath"`" == "#NI_PROVISIONING_ANSWERS_V1" ]; then
+			if ! egrep -q -v '(^$|^#|^PROVISION_[A-Z0-9_]+=)' "$filePath"; then
+				return 0
+			fi
+		fi
+	fi
+	return 1
 }
 
 source_default_answer_file()
 {
-    if ! check_answer_file "/ni_provisioning.answers.default"; then
-        die "Missing or corrupt file /ni_provisioning.answers.default"
-    fi
-    source "/ni_provisioning.answers.default"
+	if ! check_answer_file "/ni_provisioning.answers.default"; then
+		die "Missing or corrupt file /ni_provisioning.answers.default"
+	fi
+	source "/ni_provisioning.answers.default"
 }
 
 source_answer_file()
 {
-    print_verbose "Searching for answer files:"
+	print_verbose "Searching for answer files:"
 
-    # first check for embedded answer file on the boot disk
-    if check_answer_file "/ni_provisioning.answers"; then
-        print_verbose "Using embedded answer file at /ni_provisioning.answers"
-        source "/ni_provisioning.answers"
-        return
-    fi
+	# first check for embedded answer file on the boot disk
+	if check_answer_file "/ni_provisioning.answers"; then
+		print_verbose "Using embedded answer file at /ni_provisioning.answers"
+		source "/ni_provisioning.answers"
+		return
+	fi
 
-    mkdir -p "$ANSWER_FILE_DISK_MOUNTPOINT"
-    for devNode in `lsblk -rpn -o NAME,TYPE,RM | grep -E 'part|rom 1$' | cut -d' ' -f1 || true`; do
-        devNodeInfo="`lsblk -n -o 'FSTYPE,SERIAL,UUID,LABEL' "$devNode" | tr -s ' '`"
-        mount -o ro "$devNode"  "$ANSWER_FILE_DISK_MOUNTPOINT"
-        if check_answer_file    "$ANSWER_FILE_DISK_MOUNTPOINT/ni_provisioning.answers"; then
-            print_verbose "Using ni_provisioning.answers on $devNode ($devNodeInfo)"
-            source              "$ANSWER_FILE_DISK_MOUNTPOINT/ni_provisioning.answers"
-            return
-        else
-            umount              "$ANSWER_FILE_DISK_MOUNTPOINT"
-            print_verbose "Skipped $devNode ($devNodeInfo)"
-            # and keep going
-        fi
-    done
+	mkdir -p "$ANSWER_FILE_DISK_MOUNTPOINT"
+	for devNode in `lsblk -rpn -o NAME,TYPE,RM | grep -E 'part|rom 1$' | cut -d' ' -f1 || true`; do
+		devNodeInfo="`lsblk -n -o 'FSTYPE,SERIAL,UUID,LABEL' "$devNode" | tr -s ' '`"
+		mount -o ro "$devNode"  "$ANSWER_FILE_DISK_MOUNTPOINT"
+		if check_answer_file	"$ANSWER_FILE_DISK_MOUNTPOINT/ni_provisioning.answers"; then
+			print_verbose "Using ni_provisioning.answers on $devNode ($devNodeInfo)"
+			source "$ANSWER_FILE_DISK_MOUNTPOINT/ni_provisioning.answers"
+			return
+		else
+			umount "$ANSWER_FILE_DISK_MOUNTPOINT"
+			print_verbose "Skipped $devNode ($devNodeInfo)"
+			# and keep going
+		fi
+	done
 
-    print_verbose "No answer file found; using default configuration"
+	print_verbose "No answer file found; using default configuration"
 }
 
 prompt_user()
 {
-    local question="$1"
-    local answerPattern="$2"
-    local defaultAnswer="$3"
-    local -n var="$4"
-    if [[ $var == "?" ]]; then
-        while [[ ! $var =~ $answerPattern ]]; do
-            read -p "$question: " var
-            var="${var,,}"  #lowercase var
-            if [[ -z "$var" ]]; then
-                var="$defaultAnswer"
-            fi
-        done
-    else
-        echo "$question: $var (auto)"
-    fi
+	local question="$1"
+	local answerPattern="$2"
+	local defaultAnswer="$3"
+	local -n var="$4"
+	if [[ $var == "?" ]]; then
+		while [[ ! $var =~ $answerPattern ]]; do
+			read -p "$question: " var
+			var="${var,,}"  #lowercase var
+			if [[ -z "$var" ]]; then
+				var="$defaultAnswer"
+			fi
+		done
+	else
+		echo "$question: $var (auto)"
+	fi
 }
 

--- a/recipes-core/initrdscripts/files/ni_provisioning.safemode
+++ b/recipes-core/initrdscripts/files/ni_provisioning.safemode
@@ -22,119 +22,119 @@ PART4_NAME=$PART4_LABEL
 
 print_info()
 {
-    if [ $verbose_mode -eq 1 ]; then
-        >&3 echo $1
-    else
-        >&3 echo -n $1
-    fi
+	if [ $verbose_mode -eq 1 ]; then
+		>&3 echo $1
+	else
+		>&3 echo -n $1
+	fi
 }
 
 print_error()
 {
-    >&4 echo -e ${RED}"\n***Error: $1\n"${NC}
+	>&4 echo -e ${RED}"\n***Error: $1\n"${NC}
 	local continue_on_error="N"
-    if [[ "$ask_at_every_error" == "y" ]]; then
-        exec 2>&4
-        read -p "Do you want to ignore this error?[y/N]" continue_on_error
+	if [[ "$ask_at_every_error" == "y" ]]; then
+		exec 2>&4
+		read -p "Do you want to ignore this error?[y/N]" continue_on_error
 		exec 4>&2
 	fi
 	if [[ "$continue_on_error" == "N" || "$continue_on_error" == "n" || "$continue_on_error" == "" ]]; then
-        >&4 echo -e ${RED}"PROVISIONING FAILED!"${NC}
-        cleanup_and_exit 1
-    fi
+		>&4 echo -e ${RED}"PROVISIONING FAILED!"${NC}
+		cleanup_and_exit 1
+	fi
 }
 
 die()
 {
-    >&4 echo -e ${RED}"\n***Fatal Error: $1"${NC}
-    >&4 echo -e ${RED}"PROVISIONING FAILED!"${NC}
-    cleanup_and_exit 1
+	>&4 echo -e ${RED}"\n***Fatal Error: $1"${NC}
+	>&4 echo -e ${RED}"PROVISIONING FAILED!"${NC}
+	cleanup_and_exit 1
 }
 
 print_done()
 {
-    if [ $verbose_mode -eq 0 ]; then
-        >&3 echo "Done"
-    fi
+	if [ $verbose_mode -eq 0 ]; then
+		>&3 echo "Done"
+	fi
 }
 
 disable_automount()
 {
-    echo -e $TARGET_DISK >> /etc/udev/mount.blacklist
-    AUTOMOUNT_DISABLED=1
+	echo -e $TARGET_DISK >> /etc/udev/mount.blacklist
+	AUTOMOUNT_DISABLED=1
 }
 
 enable_automount()
 {
-    sed -ie "\#$TARGET_DISK#d" /etc/udev/mount.blacklist
-    AUTOMOUNT_DISABLED=0
+	sed -ie "\#$TARGET_DISK#d" /etc/udev/mount.blacklist
+	AUTOMOUNT_DISABLED=0
 }
 #waits until the four partitions are visible
 wait_for_partitions()
 {
-    DEVICE_TMP=$1
-    for i in 1 2 3 4
-    do
-        #wait max 3 seconds for each partition
-        print_verbose "Waiting for $DEVICE_TMP$i "
-        MaxTries=30
-        while [ ! -b ${DEVICE_TMP}${PART_SEPARATOR}$i -a $MaxTries -gt 0 ];
-        do
-            print_verbose "."
-            #sleep 0.1 seconds
-            usleep 100000
-            MaxTries=$(($MaxTries - 1))
-        done
-        if [ $MaxTries -eq 0 ]; then
-            return 1
-        fi
-    done
+	DEVICE_TMP=$1
+	for i in 1 2 3 4
+	do
+		#wait max 3 seconds for each partition
+		print_verbose "Waiting for $DEVICE_TMP$i "
+		MaxTries=30
+		while [ ! -b ${DEVICE_TMP}${PART_SEPARATOR}$i -a $MaxTries -gt 0 ];
+		do
+			print_verbose "."
+			#sleep 0.1 seconds
+			usleep 100000
+			MaxTries=$(($MaxTries - 1))
+		done
+		if [ $MaxTries -eq 0 ]; then
+			return 1
+		fi
+	done
 }
 
 handle_err()
 {
-    TMP_EVAL=`eval echo $5`
-    print_error "$1:$2 (fn=$3): Unexpected status code $4, while running command: '$TMP_EVAL'" ${NC}
+	TMP_EVAL=`eval echo $5`
+	print_error "$1:$2 (fn=$3): Unexpected status code $4, while running command: '$TMP_EVAL'" ${NC}
 }
 
 check_all_used_binaries()
 {
-    commands=(awk dmidecode e2label hexdump lsblk mkfs.ext4 mkfs.vfat parted sed sfdisk sgdisk udevadm modprobe dd)
-    for ind_command in ${commands[@]}; do
-        one_command=`command -v ${ind_command}`
-        if [[ -z $one_command ]]; then
-            die "Command \"${ind_command}\" not found. Please install ${ind_command}."
-        fi
-    done
+	commands=(awk dmidecode e2label hexdump lsblk mkfs.ext4 mkfs.vfat parted sed sfdisk sgdisk udevadm modprobe dd)
+	for ind_command in ${commands[@]}; do
+		one_command=`command -v ${ind_command}`
+		if [[ -z $one_command ]]; then
+			die "Command \"${ind_command}\" not found. Please install ${ind_command}."
+		fi
+	done
 
 }
 
 override_primaryport_grubenv()
 {
-    # Add target-specific override of primary ethernet port if the lowest ifIndex is not to be used
-    local device_code=$(get_target_id)
-    # CVS-1458RT
-    if [[ x"$device_code" == x"77AA" ]]; then
-        # Set eth0 (note: renamed to eth0 via udev) as the primary port. Do not let the primary
-        # port selection logic decide since it selects the 'eth' port with the lowest ifIndex
-        # value. (Renaming the port via udev does not alter ifIndex, so eth0 is not the lowest)
-        grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv set "ethaddr=`cat /sys/class/net/eth0/address`"
-    fi
+	# Add target-specific override of primary ethernet port if the lowest ifIndex is not to be used
+	local device_code=$(get_target_id)
+	# CVS-1458RT
+	if [[ x"$device_code" == x"77AA" ]]; then
+		# Set eth0 (note: renamed to eth0 via udev) as the primary port. Do not let the primary
+		# port selection logic decide since it selects the 'eth' port with the lowest ifIndex
+		# value. (Renaming the port via udev does not alter ifIndex, so eth0 is not the lowest)
+		grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv set "ethaddr=`cat /sys/class/net/eth0/address`"
+	fi
 }
 
 add_USB_gadget_args_to_grubenv()
 {
-    local MAC=$(get_usbdev_mac)
-    local VID=$(get_usbdev_vid)
-    local PID=$(get_usbdev_pid)
-    local SN=$(get_serial_number)
-    local TID=$(get_target_id)
-    local PROD=$(get_target_name)
+	local MAC=$(get_usbdev_mac)
+	local VID=$(get_usbdev_vid)
+	local PID=$(get_usbdev_pid)
+	local SN=$(get_serial_number)
+	local TID=$(get_target_id)
+	local PROD=$(get_target_name)
 
-    if is_usbdev_target; then
+	if is_usbdev_target; then
 
-        if [ -n "$MAC" -a -n "$VID" -a -n "$PID" -a -n "$SN" -a -n "$TID" -a -n "$PROD" ]; then
-            cat << EOF > $GRUB_MOUNTPOINT/grubvar_readonly
+		if [ -n "$MAC" -a -n "$VID" -a -n "$PID" -a -n "$SN" -a -n "$TID" -a -n "$PROD" ]; then
+			cat << EOF > $GRUB_MOUNTPOINT/grubvar_readonly
 set usbgadgetethaddr=$MAC
 set USBVendorID=$VID
 set USBProductID=$PID
@@ -142,314 +142,314 @@ set SerialNum=$SN
 set USBDevice=$TID
 set USBProduct=$PROD
 EOF
-        else
-            print_error "Details required for USB device mode are missing from SMBIOS! UPGRADE your BIOS if using NI Target. USB Gadget will not be functional."
-            return
-        fi
-    fi
+		else
+			print_error "Details required for USB device mode are missing from SMBIOS! UPGRADE your BIOS if using NI Target. USB Gadget will not be functional."
+			return
+		fi
+	fi
 }
 
 set_serial_port()
 {
-    if [ -d /sys/class/tty/ttyS0 ] && [ -f /sys/class/tty/ttyS0/type ] && [ `cat /sys/class/tty/ttyS0/type` -ne 0 ]; then
-        echo "set serial_port="`cat /sys/class/tty/ttyS0/port` >> $GRUB_MOUNTPOINT/grubvar_readonly
+	if [ -d /sys/class/tty/ttyS0 ] && [ -f /sys/class/tty/ttyS0/type ] && [ `cat /sys/class/tty/ttyS0/type` -ne 0 ]; then
+		echo "set serial_port="`cat /sys/class/tty/ttyS0/port` >> $GRUB_MOUNTPOINT/grubvar_readonly
 
-        local base_clock
-        if base_clock=$(get_serial_base_clock); then
-            echo "set GRUB_SERIAL_BASE_CLOCK=$base_clock" >> $GRUB_MOUNTPOINT/grubvar_readonly
-        fi
-    fi
+		local base_clock
+		if base_clock=$(get_serial_base_clock); then
+			echo "set GRUB_SERIAL_BASE_CLOCK=$base_clock" >> $GRUB_MOUNTPOINT/grubvar_readonly
+		fi
+	fi
 
 }
 
 # Load necessary kernel modules needed to inspect the system's hardware
 load_kernel_modules ()
 {
-    for modname in "tpm_tis"; do
-        if modprobe "$modname"; then
-            print_verbose "Loaded $modname"
-        else
-            print_error "Failed to load $modname"
-        fi
-    done
+	for modname in "tpm_tis"; do
+		if modprobe "$modname"; then
+			print_verbose "Loaded $modname"
+		else
+			print_error "Failed to load $modname"
+		fi
+	done
 }
 
 # Is true if system has a TPM chip. Must not be used before
 #  load_kernel_modules() runs.
 has_tpm_chip ()
 {
-    [ -e "/dev/tpm0" ]
+	[ -e "/dev/tpm0" ]
 }
 
 check_for_tpm_chip()
 {
-    # If use_ramfs was unspecified by user, set it based on
-    #  presence of TPM chip
-    if [ -z "$use_ramfs" ]; then
-        if has_tpm_chip; then
-            use_ramfs=true
-        else
-            use_ramfs=false
-        fi
-    fi
+	# If use_ramfs was unspecified by user, set it based on
+	#  presence of TPM chip
+	if [ -z "$use_ramfs" ]; then
+		if has_tpm_chip; then
+			use_ramfs=true
+		else
+			use_ramfs=false
+		fi
+	fi
 }
 
 partitioning_disk()
 {
-    umount "$TARGET_DISK"? 2>/dev/null || true
-    print_info "Partitioning TARGET_DISK=$TARGET_DISK (PART_STYLE=$PART_STYLE)..."
-    PARTED_ERROR=`parted -s $TARGET_DISK mklabel $PART_STYLE 2>&1` || die "$PARTED_ERROR"
-    PARTED_ERROR=`parted -s --align optimal $TARGET_DISK mkpart $PART1_NAME 1MB 16MB 2>&1` || die "$PARTED_ERROR"
-    PARTED_ERROR=`parted -s --align optimal $TARGET_DISK mkpart $PART2_NAME 16MB 200MB 2>&1` || die "$PARTED_ERROR"
-    PARTED_ERROR=`parted -s --align optimal $TARGET_DISK mkpart $PART3_NAME 200MB 216MB 2>&1` || die "$PARTED_ERROR"
-    PARTED_ERROR=`parted -s --align optimal $TARGET_DISK mkpart $PART4_NAME 216MB 100% 2>&1` || die "$PARTED_ERROR"
-    print_done
+	umount "$TARGET_DISK"? 2>/dev/null || true
+	print_info "Partitioning TARGET_DISK=$TARGET_DISK (PART_STYLE=$PART_STYLE)..."
+	PARTED_ERROR=`parted -s $TARGET_DISK mklabel $PART_STYLE 2>&1` || die "$PARTED_ERROR"
+	PARTED_ERROR=`parted -s --align optimal $TARGET_DISK mkpart $PART1_NAME 1MB 16MB 2>&1` || die "$PARTED_ERROR"
+	PARTED_ERROR=`parted -s --align optimal $TARGET_DISK mkpart $PART2_NAME 16MB 200MB 2>&1` || die "$PARTED_ERROR"
+	PARTED_ERROR=`parted -s --align optimal $TARGET_DISK mkpart $PART3_NAME 200MB 216MB 2>&1` || die "$PARTED_ERROR"
+	PARTED_ERROR=`parted -s --align optimal $TARGET_DISK mkpart $PART4_NAME 216MB 100% 2>&1` || die "$PARTED_ERROR"
+	print_done
 
-    print_info "Assigning EFI System Partition..."
-    # Per https://www.freedesktop.org/wiki/Specifications/DiscoverablePartitionsSpec/
-    #  C12A7328-F81F-11D2-BA4B-00A0C93EC93B -- EFI System Partition
-    sgdisk --typecode="1:C12A7328-F81F-11D2-BA4B-00A0C93EC93B" $TARGET_DISK
-    print_done
+	print_info "Assigning EFI System Partition..."
+	# Per https://www.freedesktop.org/wiki/Specifications/DiscoverablePartitionsSpec/
+	#  C12A7328-F81F-11D2-BA4B-00A0C93EC93B -- EFI System Partition
+	sgdisk --typecode="1:C12A7328-F81F-11D2-BA4B-00A0C93EC93B" $TARGET_DISK
+	print_done
 
-    print_info "Probing partitions of TARGET_DISK=$TARGET_DISK ..."
-    partprobe -s "$TARGET_DISK"
-    print_done
+	print_info "Probing partitions of TARGET_DISK=$TARGET_DISK ..."
+	partprobe -s "$TARGET_DISK"
+	print_done
 }
 
 create_filesystems()
 {
-    print_info "Creating filesystems ..."
+	print_info "Creating filesystems ..."
 
-    MKFS_ERROR=`mkfs.vfat -n $PART1_LABEL ${TARGET_DISK}${PART_SEPARATOR}1 2>&1` || die "$MKFS_ERROR"
-    do_silent mkfs.ext4 $MKFS_ARGS ${TARGET_DISK}${PART_SEPARATOR}2 || die "Format failed!"
-    do_silent mkfs.ext4 $MKFS_ARGS ${TARGET_DISK}${PART_SEPARATOR}3 || die "Format failed!"
-    do_silent mkfs.ext4 $MKFS_ARGS ${TARGET_DISK}${PART_SEPARATOR}4 || die "Format failed!"
+	MKFS_ERROR=`mkfs.vfat -n $PART1_LABEL ${TARGET_DISK}${PART_SEPARATOR}1 2>&1` || die "$MKFS_ERROR"
+	do_silent mkfs.ext4 $MKFS_ARGS ${TARGET_DISK}${PART_SEPARATOR}2 || die "Format failed!"
+	do_silent mkfs.ext4 $MKFS_ARGS ${TARGET_DISK}${PART_SEPARATOR}3 || die "Format failed!"
+	do_silent mkfs.ext4 $MKFS_ARGS ${TARGET_DISK}${PART_SEPARATOR}4 || die "Format failed!"
 
-    LABEL_ERROR=`e2label ${TARGET_DISK}${PART_SEPARATOR}2 $PART2_LABEL 2>&1` || die "$LABEL_ERROR"
-    LABEL_ERROR=`e2label ${TARGET_DISK}${PART_SEPARATOR}3 $PART3_LABEL 2>&1` || die "$LABEL_ERROR"
-    LABEL_ERROR=`e2label ${TARGET_DISK}${PART_SEPARATOR}4 $PART4_LABEL 2>&1` || die "$LABEL_ERROR"
+	LABEL_ERROR=`e2label ${TARGET_DISK}${PART_SEPARATOR}2 $PART2_LABEL 2>&1` || die "$LABEL_ERROR"
+	LABEL_ERROR=`e2label ${TARGET_DISK}${PART_SEPARATOR}3 $PART3_LABEL 2>&1` || die "$LABEL_ERROR"
+	LABEL_ERROR=`e2label ${TARGET_DISK}${PART_SEPARATOR}4 $PART4_LABEL 2>&1` || die "$LABEL_ERROR"
 
-    print_done
+	print_done
 }
 
 install_grub()
 {
-    GRUB_MOUNTPOINT=/var/volatile/grub
-    mkdir $GRUB_MOUNTPOINT -p
-    MOUNT_ERROR=`mount -L $PART1_LABEL $GRUB_MOUNTPOINT 2>&1` || die "$MOUNT_ERROR"
+	GRUB_MOUNTPOINT=/var/volatile/grub
+	mkdir $GRUB_MOUNTPOINT -p
+	MOUNT_ERROR=`mount -L $PART1_LABEL $GRUB_MOUNTPOINT 2>&1` || die "$MOUNT_ERROR"
 
-    print_info "Configuring EFI grub2..."
-    GRUB_TARGET_DIR=$GRUB_MOUNTPOINT/efi/boot
-    mkdir -p $GRUB_TARGET_DIR
-    GRUB_TARGET=$(uname -m)
-    cp /boot/EFI/BOOT/bootx64.efi $GRUB_TARGET_DIR
-    # Delete existing NILRT entries with "-B" option
-    for ENTRY in $(efibootmgr | egrep -i '(LabVIEW RT)|(niboota)|(nibootb)' | egrep -o '[0-9A-Fa-f]{4}' || true);
-    do
-        print_info " Drop entry $ENTRY."
-        EFIMGR=$(efibootmgr -b "$ENTRY" -B 2>&1) || print_warning "efibootmgr -b $ENTRY -B failed with: $EFIMGR"
-    done
-    efibootmgr $VERBOSE_ARGS -c -d ${TARGET_DISK} -p 1 -L 'LabVIEW RT' -l '\efi\boot\bootx64.efi'
-    print_done
+	print_info "Configuring EFI grub2..."
+	GRUB_TARGET_DIR=$GRUB_MOUNTPOINT/efi/boot
+	mkdir -p $GRUB_TARGET_DIR
+	GRUB_TARGET=$(uname -m)
+	cp /boot/EFI/BOOT/bootx64.efi $GRUB_TARGET_DIR
+	# Delete existing NILRT entries with "-B" option
+	for ENTRY in $(efibootmgr | egrep -i '(LabVIEW RT)|(niboota)|(nibootb)' | egrep -o '[0-9A-Fa-f]{4}' || true);
+	do
+		print_info " Drop entry $ENTRY."
+		EFIMGR=$(efibootmgr -b "$ENTRY" -B 2>&1) || print_warning "efibootmgr -b $ENTRY -B failed with: $EFIMGR"
+	done
+	efibootmgr $VERBOSE_ARGS -c -d ${TARGET_DISK} -p 1 -L 'LabVIEW RT' -l '\efi\boot\bootx64.efi'
+	print_done
 
-    print_info "Installing grub.cfg..."
+	print_info "Installing grub.cfg..."
 
-    cp $SOURCE_DIR/grub.cfg $GRUB_TARGET_DIR/grub.cfg
-    mkdir -p $GRUB_TARGET_DIR/fonts
-    cp $SOURCE_DIR/fonts/unicode.pf2 $GRUB_TARGET_DIR/fonts/
-    print_done
+	cp $SOURCE_DIR/grub.cfg $GRUB_TARGET_DIR/grub.cfg
+	mkdir -p $GRUB_TARGET_DIR/fonts
+	cp $SOURCE_DIR/fonts/unicode.pf2 $GRUB_TARGET_DIR/fonts/
+	print_done
 }
 
 install_safemode()
 {
-    print_info "Installing safemode kernel and ramdisk..."
+	print_info "Installing safemode kernel and ramdisk..."
 
-    BOOTFS_MOUNTPOINT=/var/volatile/bootfs
-    mkdir $BOOTFS_MOUNTPOINT -p
-    BOOTFS_ERROR=`mount -L $PART2_LABEL $BOOTFS_MOUNTPOINT 2>&1` || die "$BOOTFS_ERROR"
-    mkdir -p $BOOTFS_MOUNTPOINT/.safe
+	BOOTFS_MOUNTPOINT=/var/volatile/bootfs
+	mkdir $BOOTFS_MOUNTPOINT -p
+	BOOTFS_ERROR=`mount -L $PART2_LABEL $BOOTFS_MOUNTPOINT 2>&1` || die "$BOOTFS_ERROR"
+	mkdir -p $BOOTFS_MOUNTPOINT/.safe
 
-    cp "$SOURCE_DIR"/*Image       "$BOOTFS_MOUNTPOINT/.safe/"
-    cp "$SOURCE_DIR"/ramdisk.*    "$BOOTFS_MOUNTPOINT/.safe/"
-    cp "$SOURCE_DIR"/bootimage.*  "$BOOTFS_MOUNTPOINT/.safe/"
+	cp "$SOURCE_DIR"/*Image	   "$BOOTFS_MOUNTPOINT/.safe/"
+	cp "$SOURCE_DIR"/ramdisk.*	"$BOOTFS_MOUNTPOINT/.safe/"
+	cp "$SOURCE_DIR"/bootimage.*  "$BOOTFS_MOUNTPOINT/.safe/"
 
-    print_done
+	print_done
 }
 
 install_bootmode_file()
 {
-    if $use_ramfs; then
-        # create boot flags dir and configure initially for safemode boot
-        print_info "Installing bootflags.d..."
-        mkdir $BOOTFS_MOUNTPOINT/bootflags.d
-        echo -n "" >$BOOTFS_MOUNTPOINT/bootflags.d/safemode
-        print_done
-    else
-        # write initial bootmode file
-        print_info "Installing bootmode file..."
-        echo "set BOOT_MODE=safemode" >$BOOTFS_MOUNTPOINT/bootmode
-        print_done
-    fi
+	if $use_ramfs; then
+		# create boot flags dir and configure initially for safemode boot
+		print_info "Installing bootflags.d..."
+		mkdir $BOOTFS_MOUNTPOINT/bootflags.d
+		echo -n "" >$BOOTFS_MOUNTPOINT/bootflags.d/safemode
+		print_done
+	else
+		# write initial bootmode file
+		print_info "Installing bootmode file..."
+		echo "set BOOT_MODE=safemode" >$BOOTFS_MOUNTPOINT/bootmode
+		print_done
+	fi
 }
 
 install_grubenv()
 {
-    NI_TARGET="false"
+	NI_TARGET="false"
 
-    mkdir $BOOTFS_MOUNTPOINT/grub
-    touch $BOOTFS_MOUNTPOINT/grub/grubenv
-    touch $BOOTFS_MOUNTPOINT/.safe/SMBIOS_NI_vars
-    touch $BOOTFS_MOUNTPOINT/.safe/EFI_NI_vars
-    touch $BOOTFS_MOUNTPOINT/.safe/GRUB_NI_readonly_vars
-    if is_ni_device ; then
-        NI_TARGET="true"
-        cp $SOURCE_DIR/grubenv $BOOTFS_MOUNTPOINT/grub
-        cp $SOURCE_DIR/SMBIOS_NI_vars $BOOTFS_MOUNTPOINT/.safe
-        cp $SOURCE_DIR/EFI_NI_vars $BOOTFS_MOUNTPOINT/.safe
-        add_USB_gadget_args_to_grubenv
-        override_primaryport_grubenv
-    else
-        cp $SOURCE_DIR/grubenv_non_ni_target $BOOTFS_MOUNTPOINT/grub/grubenv
-    fi
+	mkdir $BOOTFS_MOUNTPOINT/grub
+	touch $BOOTFS_MOUNTPOINT/grub/grubenv
+	touch $BOOTFS_MOUNTPOINT/.safe/SMBIOS_NI_vars
+	touch $BOOTFS_MOUNTPOINT/.safe/EFI_NI_vars
+	touch $BOOTFS_MOUNTPOINT/.safe/GRUB_NI_readonly_vars
+	if is_ni_device ; then
+		NI_TARGET="true"
+		cp $SOURCE_DIR/grubenv $BOOTFS_MOUNTPOINT/grub
+		cp $SOURCE_DIR/SMBIOS_NI_vars $BOOTFS_MOUNTPOINT/.safe
+		cp $SOURCE_DIR/EFI_NI_vars $BOOTFS_MOUNTPOINT/.safe
+		add_USB_gadget_args_to_grubenv
+		override_primaryport_grubenv
+	else
+		cp $SOURCE_DIR/grubenv_non_ni_target $BOOTFS_MOUNTPOINT/grub/grubenv
+	fi
 
-    set_serial_port
+	set_serial_port
 
-    grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv set "BIOSBootMode=efi"
-    grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv set "NITarget=$NI_TARGET"
+	grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv set "BIOSBootMode=efi"
+	grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv set "NITarget=$NI_TARGET"
 
-    # If target has a TPM chip, we need to enable an alternate boot flow
-    #  involving initramfs and bootflags dir
-    if $use_ramfs; then
-        grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv set "enable_initramfs=1"
-    fi
+	# If target has a TPM chip, we need to enable an alternate boot flow
+	#  involving initramfs and bootflags dir
+	if $use_ramfs; then
+		grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv set "enable_initramfs=1"
+	fi
 
-    # Mark aforementioned grub vars read-only
-    for varname in "BIOSBootMode" "NITarget" "enable_initramfs"; do
-        echo "$varname" >> "$BOOTFS_MOUNTPOINT/.safe/GRUB_NI_readonly_vars"
-    done
+	# Mark aforementioned grub vars read-only
+	for varname in "BIOSBootMode" "NITarget" "enable_initramfs"; do
+		echo "$varname" >> "$BOOTFS_MOUNTPOINT/.safe/GRUB_NI_readonly_vars"
+	done
 
-    # save rootfs UUID for grub to reference
-    ROOTUUID=`lsblk ${TARGET_DISK}${PART_SEPARATOR}4 -n -o PARTUUID`
-    echo set rootuuid=$ROOTUUID >> $GRUB_MOUNTPOINT/grubvar_readonly
+	# save rootfs UUID for grub to reference
+	ROOTUUID=`lsblk ${TARGET_DISK}${PART_SEPARATOR}4 -n -o PARTUUID`
+	echo set rootuuid=$ROOTUUID >> $GRUB_MOUNTPOINT/grubvar_readonly
 
-    # set proper permissions on and backup firmware variable files
-    chown 0:500 $BOOTFS_MOUNTPOINT/grub/grubenv
-    chmod ug=rw,o=r $BOOTFS_MOUNTPOINT/grub/grubenv
-    cp -p $BOOTFS_MOUNTPOINT/grub/grubenv $BOOTFS_MOUNTPOINT/grub/grubenv.bak
-    chmod a=r $BOOTFS_MOUNTPOINT/.safe/SMBIOS_NI_vars
-    chmod a=r $BOOTFS_MOUNTPOINT/.safe/EFI_NI_vars
-    chmod a=r $BOOTFS_MOUNTPOINT/.safe/GRUB_NI_readonly_vars
+	# set proper permissions on and backup firmware variable files
+	chown 0:500 $BOOTFS_MOUNTPOINT/grub/grubenv
+	chmod ug=rw,o=r $BOOTFS_MOUNTPOINT/grub/grubenv
+	cp -p $BOOTFS_MOUNTPOINT/grub/grubenv $BOOTFS_MOUNTPOINT/grub/grubenv.bak
+	chmod a=r $BOOTFS_MOUNTPOINT/.safe/SMBIOS_NI_vars
+	chmod a=r $BOOTFS_MOUNTPOINT/.safe/EFI_NI_vars
+	chmod a=r $BOOTFS_MOUNTPOINT/.safe/GRUB_NI_readonly_vars
 
-    # Additional grubenv configuration, _NOT_ mirrored in grubenv.bak
+	# Additional grubenv configuration, _NOT_ mirrored in grubenv.bak
 
-    # If the target is a qemu vm, enable consoleout
-    if dmidecode |grep -qi "virtual machine" ; then
-        grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv set "consoleoutenable=True"
-    fi
+	# If the target is a qemu vm, enable consoleout
+	if dmidecode |grep -qi "virtual machine" ; then
+		grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv set "consoleoutenable=True"
+	fi
 
-    # If an initial value for console out was specified, write it to grubenv
-    if [ -n "$grubenv_consoleoutenable" ]; then
-        grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv set "consoleoutenable=$grubenv_consoleoutenable"
-    fi
+	# If an initial value for console out was specified, write it to grubenv
+	if [ -n "$grubenv_consoleoutenable" ]; then
+		grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv set "consoleoutenable=$grubenv_consoleoutenable"
+	fi
 
-    # Set quietbootdelay to show the boot menu on PXI controllers
-    #
-    # The reasoning behind this is that, for NI Linux RT support, Controller
-    # Software (the BIOS team) wants to keep the business logic out of
-    # BIOS as much as possible, and make the BIOS agnostic of the actual
-    # OS it is booting as much as possible (one exception being setting
-    # HT based on the EFI variable since this can only, practically, be
-    # handled in BIOS).
+	# Set quietbootdelay to show the boot menu on PXI controllers
+	#
+	# The reasoning behind this is that, for NI Linux RT support, Controller
+	# Software (the BIOS team) wants to keep the business logic out of
+	# BIOS as much as possible, and make the BIOS agnostic of the actual
+	# OS it is booting as much as possible (one exception being setting
+	# HT based on the EFI variable since this can only, practically, be
+	# handled in BIOS).
 
-    if [ "`get_target_class`" == "PXI" ]; then
-        grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv set "quietbootdelay=3"
-    fi
+	if [ "`get_target_class`" == "PXI" ]; then
+		grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv set "quietbootdelay=3"
+	fi
 
-    # If an initial value for bootdelay was specified, write it to grubenv
-    if [ -n "$grubenv_bootdelay" ]; then
-        grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv set "bootdelay=$grubenv_bootdelay"
-    fi
+	# If an initial value for bootdelay was specified, write it to grubenv
+	if [ -n "$grubenv_bootdelay" ]; then
+		grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv set "bootdelay=$grubenv_bootdelay"
+	fi
 }
 
 set_versions()
 {
-    BUILD_IDENTIFIER=$(get_image_info BUILD_IDENTIFIER)
-    GRUB_IDENTIFIER=$(get_image_info GRUB_VERSION)
+	BUILD_IDENTIFIER=$(get_image_info BUILD_IDENTIFIER)
+	GRUB_IDENTIFIER=$(get_image_info GRUB_VERSION)
 
-    echo "set ni_grub_version=${GRUB_IDENTIFIER}" > $BOOTFS_MOUNTPOINT/grub/grub-ni-version
-    echo "set ni_recoverytool_version=${BUILD_IDENTIFIER}" > $BOOTFS_MOUNTPOINT/grub/recoverytool-ni-version
+	echo "set ni_grub_version=${GRUB_IDENTIFIER}" > $BOOTFS_MOUNTPOINT/grub/grub-ni-version
+	echo "set ni_recoverytool_version=${BUILD_IDENTIFIER}" > $BOOTFS_MOUNTPOINT/grub/recoverytool-ni-version
 
-    chmod 444 $BOOTFS_MOUNTPOINT/grub/grub-ni-version $BOOTFS_MOUNTPOINT/grub/recoverytool-ni-version
+	chmod 444 $BOOTFS_MOUNTPOINT/grub/grub-ni-version $BOOTFS_MOUNTPOINT/grub/recoverytool-ni-version
 }
 
 fixup_configfs()
 {
-    CONFIG_MOUNTPOINT=/var/volatile/configfs
+	CONFIG_MOUNTPOINT=/var/volatile/configfs
 
-    mkdir -p $CONFIG_MOUNTPOINT
-    mount -L $PART3_LABEL $CONFIG_MOUNTPOINT
+	mkdir -p $CONFIG_MOUNTPOINT
+	mount -L $PART3_LABEL $CONFIG_MOUNTPOINT
 
-    # Set root dir ownership to lvuser:ni
-    chown 500:500 $CONFIG_MOUNTPOINT
-    chmod ug=rwx,o=rx $CONFIG_MOUNTPOINT
+	# Set root dir ownership to lvuser:ni
+	chown 500:500 $CONFIG_MOUNTPOINT
+	chmod ug=rwx,o=rx $CONFIG_MOUNTPOINT
 
-    # Set hostname, if configured
-    if [ -n "$PROVISION_HOSTNAME" ]; then
-        print_info "Setting hostname=\"$PROVISION_HOSTNAME\" in ni-rt.ini..."
+	# Set hostname, if configured
+	if [ -n "$PROVISION_HOSTNAME" ]; then
+		print_info "Setting hostname=\"$PROVISION_HOSTNAME\" in ni-rt.ini..."
 
-        echo  >$CONFIG_MOUNTPOINT/ni-rt.ini "[systemsettings]"
-        echo >>$CONFIG_MOUNTPOINT/ni-rt.ini "Host_Name=\"$PROVISION_HOSTNAME\""
+		echo  >$CONFIG_MOUNTPOINT/ni-rt.ini "[systemsettings]"
+		echo >>$CONFIG_MOUNTPOINT/ni-rt.ini "Host_Name=\"$PROVISION_HOSTNAME\""
 
-        # Set ownership to lvuser:ni
-        chown 500:500 $CONFIG_MOUNTPOINT/ni-rt.ini
-        chmod ug=rw,o=r $CONFIG_MOUNTPOINT/ni-rt.ini
+		# Set ownership to lvuser:ni
+		chown 500:500 $CONFIG_MOUNTPOINT/ni-rt.ini
+		chmod ug=rw,o=r $CONFIG_MOUNTPOINT/ni-rt.ini
 
-        print_done
-    fi
+		print_done
+	fi
 
-    umount $CONFIG_MOUNTPOINT
+	umount $CONFIG_MOUNTPOINT
 }
 
 sanity_check()
 {
-    print_info "Sanity check TARGET_DISK=$TARGET_DISK..."
+	print_info "Sanity check TARGET_DISK=$TARGET_DISK..."
 
-    # correct partition table type
-    parted -s --list "$TARGET_DISK" | grep -q "^Partition Table: $PART_STYLE" || die "Wrong partition style reported"
+	# correct partition table type
+	parted -s --list "$TARGET_DISK" | grep -q "^Partition Table: $PART_STYLE" || die "Wrong partition style reported"
 
-    attrib_list="NAME KNAME PARTUUID UUID LABEL"
-    if [[ "$PART_STYLE" == "gpt" ]]; then
-        attrib_list="$attrib_list PARTLABEL"
-    fi
+	attrib_list="NAME KNAME PARTUUID UUID LABEL"
+	if [[ "$PART_STYLE" == "gpt" ]]; then
+		attrib_list="$attrib_list PARTLABEL"
+	fi
 
-    # unique attributes
-    for attrib_name in $attrib_list; do
-        sanity_list="`lsblk -nro "$attrib_name" "$TARGET_DISK"`"
-        sanity_list_len="`echo "$sanity_list" | wc -l`"
-        sanity_list_uniq_len="`echo "$sanity_list" | uniq | wc -l`"
-        [ "$sanity_list_len" -eq 5 ] || die "There should be 4 $attrib_name's (+1 blank line) on TARGET_DISK=$TARGET_DISK; found $sanity_list_len"
-        [ "$sanity_list_len" -eq "$sanity_list_uniq_len" ] || die "$attrib_name's not unique on TARGET_DISK=$TARGET_DISK; $sanity_list_len != $sanity_list_uniq_len"
-    done
+	# unique attributes
+	for attrib_name in $attrib_list; do
+		sanity_list="`lsblk -nro "$attrib_name" "$TARGET_DISK"`"
+		sanity_list_len="`echo "$sanity_list" | wc -l`"
+		sanity_list_uniq_len="`echo "$sanity_list" | uniq | wc -l`"
+		[ "$sanity_list_len" -eq 5 ] || die "There should be 4 $attrib_name's (+1 blank line) on TARGET_DISK=$TARGET_DISK; found $sanity_list_len"
+		[ "$sanity_list_len" -eq "$sanity_list_uniq_len" ] || die "$attrib_name's not unique on TARGET_DISK=$TARGET_DISK; $sanity_list_len != $sanity_list_uniq_len"
+	done
 
-    # can search by file system label
-    for fs_label in "$PART1_LABEL" "$PART2_LABEL" "$PART3_LABEL" "$PART4_LABEL"; do
-        fs_node_name="`lsblk -nro LABEL,NAME "$TARGET_DISK" | grep "^$fs_label " | cut -d" " -f2`"
-        [ "`echo "$fs_node_name" | wc -l`" -eq 1 ] || die "Invalid number of devnodes found"
-        [ -e "/dev/$fs_node_name" ] || die "No devnode for LABEL $fs_label"
-    done
+	# can search by file system label
+	for fs_label in "$PART1_LABEL" "$PART2_LABEL" "$PART3_LABEL" "$PART4_LABEL"; do
+		fs_node_name="`lsblk -nro LABEL,NAME "$TARGET_DISK" | grep "^$fs_label " | cut -d" " -f2`"
+		[ "`echo "$fs_node_name" | wc -l`" -eq 1 ] || die "Invalid number of devnodes found"
+		[ -e "/dev/$fs_node_name" ] || die "No devnode for LABEL $fs_label"
+	done
 
-    # can search by partition label, on gpt only
-    if [ "$PART_STYLE" == "gpt" ]; then
-        for part_label in "$PART1_NAME" "$PART2_NAME" "$PART3_NAME" "$PART4_NAME"; do
-            part_node_name="`lsblk -nro PARTLABEL,NAME "$TARGET_DISK" | grep "^$part_label " | cut -d" " -f2`"
-            [ "`echo "$part_node_name" | wc -l`" -eq 1 ] || die "Invalid number of devnodes found"
-            [ -e "/dev/$part_node_name" ] || die "No devnode for PARTLABEL $part_label"
-        done
-    fi
+	# can search by partition label, on gpt only
+	if [ "$PART_STYLE" == "gpt" ]; then
+		for part_label in "$PART1_NAME" "$PART2_NAME" "$PART3_NAME" "$PART4_NAME"; do
+			part_node_name="`lsblk -nro PARTLABEL,NAME "$TARGET_DISK" | grep "^$part_label " | cut -d" " -f2`"
+			[ "`echo "$part_node_name" | wc -l`" -eq 1 ] || die "Invalid number of devnodes found"
+			[ -e "/dev/$part_node_name" ] || die "No devnode for PARTLABEL $part_label"
+		done
+	fi
 
-    # just in case meta-data is updated
-    sync
-    print_done
+	# just in case meta-data is updated
+	sync
+	print_done
 }
 
 check_all_used_binaries

--- a/scripts/lib/wic/canned-wks/grub_old.cfg
+++ b/scripts/lib/wic/canned-wks/grub_old.cfg
@@ -1,3 +1,5 @@
+set linux_console="console=tty0 console=ttyS0,115200n8"
+
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 default='Default Provisioning'
 timeout=1
@@ -5,12 +7,12 @@ timeout=1
 search --set=root --label NIRECOVERY-CD
 
 menuentry 'Default Provisioning' {
-	linux /bzImage rootwait restore=provision-safe quiet loglevel=1
+	linux /bzImage rootwait restore=provision-safe $linux_console quiet loglevel=1
 	initrd /initrd
 }
 
 menuentry 'Verbose Provisioning' {
-	linux /bzImage rootwait restore=provision-safe verbose_mode=1
+	linux /bzImage rootwait restore=provision-safe $linux_console verbose_mode=1
 	initrd /initrd
 }
 

--- a/scripts/lib/wic/canned-wks/grub_old.cfg
+++ b/scripts/lib/wic/canned-wks/grub_old.cfg
@@ -12,7 +12,9 @@ menuentry 'Default Provisioning' {
 }
 
 menuentry 'Verbose Provisioning' {
+	echo 'Loading Linux ...'
 	linux /bzImage rootwait restore=provision-safe $linux_console verbose_mode=1
+	echo 'Loading initial ramdisk ...'
 	initrd /initrd
 }
 


### PR DESCRIPTION
This patchset is a subset of a larger set of refactoring I was working on, to the ni_provisioning scripts. I decided to stop work on that larger set, because it was becoming overly complicated, and because it became clear that the provisioning scripts justify a more focused re-implementation effort.

In the mean time, I'd like to pull this selection of simple updates to the scripts. Review-by-patch.

The most impactful change here is that I fixed serial output on VMs. Previously, the provisioning script output was blind in QEMU, since the kernel wasn't binding the QEMU serial output device to the virtual console. Provisioning-by-answer-file always worked, but interactive provisioning required you to pkill the provisioning script and re-run it in the QEMU serial TTY connection. Now, the consoles are bound correctly, and you can interact with the script in QEMU, just as with a real machine.

## Testing

Built the `standard_x64_recovery` target in os-common/8.8 with this change. Booted the resulting QEMU VM and verified that the provisioning state looked OK. Also, manually ran the recovery ISO on a QEMU VM and verified the "more-verbose verbose menuentry" and serial console changes are in-effect.

@ni/rtos 