### PR TITLE
linux-nilrt-nohz: Add README.nohz

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-nohz_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-nohz_git.bb
@@ -7,7 +7,15 @@ require linux-nilrt-alternate.inc
 
 SRC_URI += "\
 	file://no_hz_full.cfg \
+	file://README.nohz \
 "
+
+FILES_${KERNEL_PACKAGE_NAME} += "${docdir}/*"
+
+do_install_append() {
+        install -d -m 755 ${D}${docdir}/${KERNEL_PACKAGE_NAME}
+        install -p -m 644 ${WORKDIR}/README.nohz ${D}${docdir}/${KERNEL_PACKAGE_NAME}/
+}
 
 # This is the place to overwrite the source AUTOREV from linux-nilrt.inc, if
 # the kernel recipe requires a particular ref.

--- a/recipes-kernel/linux/nilrt-nohz/README.nohz
+++ b/recipes-kernel/linux/nilrt-nohz/README.nohz
@@ -39,8 +39,8 @@ Application Design Considerations
 
   * Isolate the CPUs reserved for critical RT threads, and mark them available
     for adaptive-ticks by setting the 'isolcpus' and 'nohz_full' kernel boot
-    parameters.[2]
-    e.g.
+    parameters[2]. For example:
+
       fw_setenv othbootargs isolcpus=6,7 nohz_full=6,7
 
     Note: On NI Linux Real-Time (NILRT) systems, CPU 0 is configured to handle
@@ -55,41 +55,43 @@ Application Design Considerations
 
       - when designing RT applications that are not LabVIEW based this can be
         accomplished by setting the CPU mask of the 'system_set' and
-        'LabVIEW_tl_set'.
-	e.g.
-	  echo 0-5 > /dev/cgroup/cpuset/system_set/cpus
+        'LabVIEW_tl_set'. For example:
+
+          echo 0-5 > /dev/cgroup/cpuset/system_set/cpus
           echo 6-7 > /dev/cgroup/cpuset/LabVIEW_tl_set/cpus
 
-  * Set the CPU mask for kernel work queues /sys/devices/virtual/workqueue/*
-    e.g.
+  * Set the CPU mask for kernel work queues /sys/devices/virtual/workqueue/*.
+    Example follows,
+
 	for file in `find /sys/devices/virtual/workqueue -name "cpumask"`; do
 		echo 1 > "$file" 2>/dev/null
 	done
 
-  * Delay the VM statistics timer.
-    e.g.
+  * Delay the VM statistics timer. For example:
+
 	sysctl vm.stat_interval=120
 
     Note: This operation requires the full-featured sysctl utility which can be
     installed with 'opkg install procps'.
 
-  * Disable any tracing that might be active.
-    e.g.
+  * Disable any tracing that might be active. Example follows,
+
 	echo 0 > "/sys/kernel/debug/tracing/tracing_on"
 
 
 Additional considerations for C applications:
 
-  * For each RT thread, set the RT scheduler and priority to use
-    e.g.
+  * For each RT thread, set the RT scheduler and priority to use. Example
+    follows,
+
 	struct sched_param schedp;
 	memset(&schedp, 0, sizeof(schedp));
 	schedp.sched_priority = priority;
 	return sched_setscheduler(0, SCHED_FIFO, &schedp);
 
   * Lock current and future memory allocations in RAM to prevent page faults and
-    the associated slow disk access.
-    e.g.
+    the associated slow disk access. For example:
+
 	mlockall(MCL_CURRENT | MCL_FUTURE);
 
 --

--- a/recipes-kernel/linux/nilrt-nohz/README.nohz
+++ b/recipes-kernel/linux/nilrt-nohz/README.nohz
@@ -1,0 +1,98 @@
+==============================
+NI Linux Real-Time NOHZ Kernel
+==============================
+
+This document describes the recommended application design, configuration
+options and boot parameters required for obtaining increased real-time (RT)
+performance when using the NILRT nohz kernel.
+
+The nohz kernel provided by 'packagegroup-ni-nohz-kernel' is a Linux kernel
+configured to omit scheduling-clock interrupts on CPUs that are either idle or
+that have only one runnable task (CONFIG_NO_HZ_FULL=y). This avoids the OS
+induced jitter caused by processing scheduling interrupts at the cost of
+increased user/kernel transitions among other things.
+
+Using this kernel configuration is advantageous for application designs where RT
+threads are assigned to dedicated CPU cores and spend most of their execution
+time in user-space running polling loops. Consult the full kernel
+documentation on this topic[1] for a list of pros/cons.
+
+
+Installation
+============
+
+Using a terminal console (serial, ssh):
+
+  * opkg update
+
+  * opkg packagegroup-ni-nohz-kernel
+
+
+Application Design Considerations
+=================================
+
+  * Use a single RT thread per reserved CPU.
+
+  * Use warm-up interrations. These are "dry-run" iterations where the
+    processing done by the RT threads is disregarded. This allows the kernel to
+    load all the data and code from disk into RAM and warm-up the CPU caches.
+
+  * Isolate the CPUs reserved for critical RT threads and mark them available
+    for adaptive-ticks by setting the 'isolcpus' and 'nohz_full' kernel boot
+    parameters.[2]
+    e.g.
+      fw_setenv othbootargs isolcpus=6,7 nohz_full=6,7
+
+    Note: On NI Linux Real-Time (NILRT) systems CPU 0 is configured to handle
+    general interrupts, kernel, and system tasks and should not be reserved for
+    critical RT tasks.
+
+  * Use CPU pools (also known as cgroup cpu sets) to configure CPUs reserved for
+    critical RT threads versus general system threads:
+
+      - in LabVIEW use the "Real-Time->RT SMP CPU Utilities" palette to
+        configure the CPU pools appropriately;
+
+      - when designing RT applications that are not LabVIEW based this can be
+        accomplished by setting the CPU mask of the 'system_set' and
+        'LabVIEW_tl_set'.
+	e.g.
+	  echo 0-5 > /dev/cgroup/cpuset/system_set/cpus
+          echo 6-7 > /dev/cgroup/cpuset/LabVIEW_tl_set/cpus
+
+  * Set the CPU mask for kernel work queues /sys/devices/virtual/workqueue/*
+    e.g.
+	for file in `find /sys/devices/virtual/workqueue -name "cpumask"`; do
+		echo 1 > "$file" 2>/dev/null
+	done
+
+  * Delay the VM statistics timer.
+    e.g.
+	sysctl vm.stat_interval=120
+
+    Note: This operation requires the full-featured sysctl utility which can be
+    installed with 'opkg install procps'.
+
+  * Disable any tracing that might be active.
+    e.g.
+	echo 0 > "/sys/kernel/debug/tracing/tracing_on"
+
+
+Additional considerations for C applications:
+
+  * For each RT thread set the RT scheduler and priority to use
+    e.g.
+	struct sched_param schedp;
+	memset(&schedp, 0, sizeof(schedp));
+	schedp.sched_priority = priority;
+	return sched_setscheduler(0, SCHED_FIFO, &schedp);
+
+  * Lock current and future memory allocations in RAM to prevent page faults and
+    the associated slow disk access.
+    e.g.
+	mlockall(MCL_CURRENT | MCL_FUTURE);
+
+--
+
+[1] https://www.kernel.org/doc/html/latest/timers/no_hz.html
+[2] https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html

--- a/recipes-kernel/linux/nilrt-nohz/README.nohz
+++ b/recipes-kernel/linux/nilrt-nohz/README.nohz
@@ -3,19 +3,19 @@ NI Linux Real-Time NOHZ Kernel
 ==============================
 
 This document describes the recommended application design, configuration
-options and boot parameters required for obtaining increased real-time (RT)
-performance when using the NILRT nohz kernel.
+options, and boot parameters required for optimizing real-time (RT) performance
+when using the NILRT nohz kernel.
 
 The nohz kernel provided by 'packagegroup-ni-nohz-kernel' is a Linux kernel
 configured to omit scheduling-clock interrupts on CPUs that are either idle or
 that have only one runnable task (CONFIG_NO_HZ_FULL=y). This avoids the OS
-induced jitter caused by processing scheduling interrupts at the cost of
-increased user/kernel transitions among other things.
+jitter caused by processing scheduling interrupts at the cost of slower
+user/kernel transitions, among other things.
 
-Using this kernel configuration is advantageous for application designs where RT
-threads are assigned to dedicated CPU cores and spend most of their execution
-time in user-space running polling loops. Consult the full kernel
-documentation on this topic[1] for a list of pros/cons.
+Using this kernel configuration is advantageous for application designs in which
+RT threads are assigned to dedicated CPU cores and spend most of their execution
+time in user-space running polling loops. Consult the full kernel documentation
+on this topic[1] for a list of pros/cons.
 
 
 Installation
@@ -33,18 +33,18 @@ Application Design Considerations
 
   * Use a single RT thread per reserved CPU.
 
-  * Use warm-up interrations. These are "dry-run" iterations where the
+  * Use warm-up iterations. These are "dry-run" iterations in which the
     processing done by the RT threads is disregarded. This allows the kernel to
     load all the data and code from disk into RAM and warm-up the CPU caches.
 
-  * Isolate the CPUs reserved for critical RT threads and mark them available
+  * Isolate the CPUs reserved for critical RT threads, and mark them available
     for adaptive-ticks by setting the 'isolcpus' and 'nohz_full' kernel boot
     parameters.[2]
     e.g.
       fw_setenv othbootargs isolcpus=6,7 nohz_full=6,7
 
-    Note: On NI Linux Real-Time (NILRT) systems CPU 0 is configured to handle
-    general interrupts, kernel, and system tasks and should not be reserved for
+    Note: On NI Linux Real-Time (NILRT) systems, CPU 0 is configured to handle
+    general interrupts, kernel and system tasks, and should not be reserved for
     critical RT tasks.
 
   * Use CPU pools (also known as cgroup cpu sets) to configure CPUs reserved for
@@ -80,7 +80,7 @@ Application Design Considerations
 
 Additional considerations for C applications:
 
-  * For each RT thread set the RT scheduler and priority to use
+  * For each RT thread, set the RT scheduler and priority to use
     e.g.
 	struct sched_param schedp;
 	memset(&schedp, 0, sizeof(schedp));


### PR DESCRIPTION
Add a README that briefly explains what the nohz kernel is and
provides application design considerations.

Signed-off-by: Gratian Crisan <gratian.crisan@ni.com>