### PR TITLE
kernel-test-nohz: Fix detection of CPUs in postinst script

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-test-nohz.bb
+++ b/recipes-kernel/kernel-tests/kernel-test-nohz.bb
@@ -10,7 +10,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-files:"
 
 S = "${WORKDIR}"
 
-RDEPENDS_${PN}-ptest += "bash procps rt-tests"
+RDEPENDS_${PN}-ptest += "bash coreutils procps rt-tests"
 RDEPENDS_${PN}-ptest_append_x64 += "packagegroup-ni-nohz-kernel"
 ALLOW_EMPTY_${PN} = "1"
 
@@ -32,7 +32,7 @@ do_install_ptest_append() {
 }
 
 pkg_postinst_ontarget_${PN}-ptest_append() {
-    CPUS=`nproc`
+    CPUS=`nproc --all`
     ISOLATED_CPU=$((CPUS - 1))
     OTHBOOTARGS=`fw_printenv othbootargs 2>/dev/null | sed -e "s/^othbootargs=//g" | sed -e "s/isolcpus=[^ ]*[ ]*\|nohz_full=[^ ]*[ ]*//g"`
 


### PR DESCRIPTION
The `nproc` utility by default returns the number of CPUs available to the
current (nproc) process.  When cgroup CPU sets are used to set the CPU mask
for system processes (like the nohz test does) this number can be less than
the total number of CPUs available.  This messes up the logic for setting
kernel boot parameters for CPU isolation and nohz functionality during the
post-install step.

Fix it by using `nproc --all` which returns the total number of CPUs
installed.  This option is not supported by the BusyBox version of `nproc`
so we also need to add a run-time dependency on coreutils.

Fixes: 1ac78688b87e ("kernel-test-nohz: Add postinst/postrm script fragments for configuring CPU isolation")
Signed-off-by: Gratian Crisan <gratian.crisan@ni.com>