### PR TITLE
linux: upgrade kernel and debug kernel to 5.10

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-debug_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-debug_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NILRT linux kernel debug build"
 NI_RELEASE_VERSION = "master"
-LINUX_VERSION = "4.14"
+LINUX_VERSION = "5.10"
 LINUX_KERNEL_TYPE = "debug"
 
 require linux-nilrt-alternate.inc

--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -46,6 +46,8 @@ SRC_URI = "\
 SRCREV ?= "${AUTOREV}"
 PV = "${LINUX_VERSION}+git${SRCPV}"
 
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+
 # This checks ${PV} == version from kernel sources which our PV/AUTOREV breaks, so skip it.
 KERNEL_VERSION_SANITY_SKIP="1"
 

--- a/recipes-kernel/linux/linux-nilrt_git.bb
+++ b/recipes-kernel/linux/linux-nilrt_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Linux kernel based on nilrt branch"
 NI_RELEASE_VERSION = "master"
-LINUX_VERSION = "4.14"
+LINUX_VERSION = "5.10"
 
 require linux-nilrt.inc
 


### PR DESCRIPTION
Signed-off-by: Alex Stewart <alex.stewart@ni.com>

---

Service for the 21Q3 release.

Also see [OE-core PR #27](https://github.com/ni/openembedded-core/pull/27) for a sibling commit which fixes a warning with the 5.10 kernel build on sumo.

## Testing
Builds on my dev machine. @gratian; should I hand-validate these new IPKs. Or are we reasonably sure that they won't break downstream clients?

@ni/rtos 