### PR TITLE
Upgrade linux-nilrt x64 to 5.10

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-debug_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-debug_git.bb
@@ -1,6 +1,7 @@
 DESCRIPTION = "NILRT linux kernel debug build"
 NI_RELEASE_VERSION = "master"
 LINUX_VERSION = "5.10"
+LINUX_VERSION_xilinx-zynq = "4.14"
 LINUX_KERNEL_TYPE = "debug"
 
 require linux-nilrt-alternate.inc

--- a/recipes-kernel/linux/linux-nilrt-debug_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-debug_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NILRT linux kernel debug build"
 NI_RELEASE_VERSION = "master"
-LINUX_VERSION = "4.14"
+LINUX_VERSION = "5.10"
 LINUX_KERNEL_TYPE = "debug"
 
 require linux-nilrt-alternate.inc

--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -47,6 +47,7 @@ SRCREV ?= "${AUTOREV}"
 PV = "${LINUX_VERSION}+git${SRCPV}"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+LIC_FILES_CHKSUM_xilinx-zynq = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 
 # This checks ${PV} == version from kernel sources which our PV/AUTOREV breaks, so skip it.
 KERNEL_VERSION_SANITY_SKIP="1"

--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -46,6 +46,8 @@ SRC_URI = "\
 SRCREV ?= "${AUTOREV}"
 PV = "${LINUX_VERSION}+git${SRCPV}"
 
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+
 # This checks ${PV} == version from kernel sources which our PV/AUTOREV breaks, so skip it.
 KERNEL_VERSION_SANITY_SKIP="1"
 

--- a/recipes-kernel/linux/linux-nilrt_git.bb
+++ b/recipes-kernel/linux/linux-nilrt_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Linux kernel based on nilrt branch"
 NI_RELEASE_VERSION = "master"
-LINUX_VERSION = "4.14"
+LINUX_VERSION = "5.10"
 
 require linux-nilrt.inc
 

--- a/recipes-kernel/linux/linux-nilrt_git.bb
+++ b/recipes-kernel/linux/linux-nilrt_git.bb
@@ -1,6 +1,7 @@
 DESCRIPTION = "Linux kernel based on nilrt branch"
 NI_RELEASE_VERSION = "master"
 LINUX_VERSION = "5.10"
+LINUX_VERSION_xilinx-zynq = "4.14"
 
 require linux-nilrt.inc
 


### PR DESCRIPTION
The x64 distro is moving to linux 5.10 for 21Q3. ARM will remain on 4.14 for the time being.

This patchset uses machine overrides to affect the upgrade on `x64`, but not on `xilinx-zynq`.

[OE-core PR #27](https://github.com/ni/openembedded-core/pull/27) fixes a warning with the 5.10 kernel build.

## Testing
Built the kernel recipes for both machines. Confirmed that ARM stayed on 4.14, and x64 progressed to 5.10.