### PR TITLE
perf: disable perf scripting on ARM

### DIFF
--- a/recipes-kernel/perf/perf.bbappend
+++ b/recipes-kernel/perf/perf.bbappend
@@ -1,0 +1,5 @@
+
+# NILRT ARM images use linux kernel 4.14 - which does not support perf
+# scripting using python3. Disable `scripting` PACKAGECONFIG in that case, to
+# keep python3 out of the perf config.
+PACKAGECONFIG_remove_xilinx-zynq += "scripting"


### PR DESCRIPTION
NILRT x64 is moving to kernel 5.10, which requires upgrading perf. New
versions of perf use python3 for scripting, and rely on python3 support
in the 5.X kernel source.

NIRLT ARM is staying on 4.14, which cannot support those scripting
options.

Disable `scripting` in the PACKAGECONFIG, for xilinx-zynq builds only.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

This issue is introduced by [this perf commit](https://github.com/ni/openembedded-core/pull/28/commits/db60a0a7c284af240582c93d437b8a1365d4e6e6). I believe that 4.X kernel's don't have the native python3 support necessary to support new perf scripting.

This patchset depends on [OE-core PR #28](https://github.com/ni/openembedded-core/pull/28).


## Testing
Without this change, building `perf` with `MACHINE=xilinx-zynq` throws a do_compile error saying that python3 is unsupported. With this patch, it builds completely.

@ni/rtos 