### PR TITLE
Update u-boot LIC_FILES_CHKSUM

### DIFF
--- a/recipes-bsp/u-boot/nilrt-u-boot.inc
+++ b/recipes-bsp/u-boot/nilrt-u-boot.inc
@@ -2,3 +2,16 @@ UBOOT_BRANCH ?= "nizynq/21.0/v2017.03"
 UBOOT_MACHINE ?= "ni_elvisiii_defconfig"
 
 SRCREV = "653fc09e01ff78e08f9683e1585f4fac05f289d9"
+
+LIC_FILES_CHKSUM = "\
+	file://Licenses/bsd-2-clause.txt;md5=6a31f076f5773aabd8ff86191ad6fdd5; \
+	file://Licenses/bsd-3-clause.txt;md5=4a1190eac56a9db675d58ebe86eaf50c; \
+	file://Licenses/eCos-2.0.txt;md5=b338cb12196b5175acd3aa63b0a0805c; \
+	file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263; \
+	file://Licenses/ibm-pibs.txt;md5=c49502a55e35e0a8a1dc271d944d6dba; \
+	file://Licenses/isc.txt;md5=ec65f921308235311f34b79d844587eb; \
+	file://Licenses/lgpl-2.0.txt;md5=5f30f0716dfdd0d91eb439ebec522ec2; \
+	file://Licenses/lgpl-2.1.txt;md5=4fbd65380cdd255951079008b364516c; \
+	file://Licenses/OFL.txt;md5=33b7c08863f9722a012141a11fb0e40a; \
+	file://Licenses/x11.txt;md5=b46f176c847b8742db02126fb8af92e2; \
+"

--- a/recipes-bsp/u-boot/nilrt-u-boot.inc
+++ b/recipes-bsp/u-boot/nilrt-u-boot.inc
@@ -1,8 +1,6 @@
 UBOOT_BRANCH ?= "nizynq/21.0/v2017.03"
 UBOOT_MACHINE ?= "ni_elvisiii_defconfig"
 
-SRCREV = "653fc09e01ff78e08f9683e1585f4fac05f289d9"
-
 LIC_FILES_CHKSUM = "\
 	file://Licenses/bsd-2-clause.txt;md5=6a31f076f5773aabd8ff86191ad6fdd5; \
 	file://Licenses/bsd-3-clause.txt;md5=4a1190eac56a9db675d58ebe86eaf50c; \
@@ -15,3 +13,6 @@ LIC_FILES_CHKSUM = "\
 	file://Licenses/OFL.txt;md5=33b7c08863f9722a012141a11fb0e40a; \
 	file://Licenses/x11.txt;md5=b46f176c847b8742db02126fb8af92e2; \
 "
+
+SRC_URI = "${NILRT_GIT}/u-boot.git;protocol=git;branch=${UBOOT_BRANCH}"
+SRCREV = "653fc09e01ff78e08f9683e1585f4fac05f289d9"

--- a/recipes-bsp/u-boot/u-boot-fw-utils_2018.%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-fw-utils_2018.%.bbappend
@@ -1,7 +1,6 @@
 require nilrt-u-boot.inc
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
-LIC_FILES_CHKSUM = "file://COPYING;md5=1707d6db1d42237583f50183a5651ecb"
 
 SRC_URI = "\
         ${NILRT_GIT}/u-boot.git;protocol=git;branch=${UBOOT_BRANCH} \

--- a/recipes-bsp/u-boot/u-boot-fw-utils_2018.%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-fw-utils_2018.%.bbappend
@@ -2,10 +2,6 @@ require nilrt-u-boot.inc
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI = "\
-        ${NILRT_GIT}/u-boot.git;protocol=git;branch=${UBOOT_BRANCH} \
-"
-
 SRC_URI_append_arm = "\
         file://fw_env-${MACHINE}.config \
 "

--- a/recipes-bsp/u-boot/u-boot_2018.%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_2018.%.bbappend
@@ -1,3 +1,1 @@
 require nilrt-u-boot.inc
-
-SRC_URI = "${NILRT_GIT}/u-boot.git;protocol=git;branch=${UBOOT_BRANCH}"


### PR DESCRIPTION
meta-nilrt #194 upgraded the u-boot source from from 2012 to 2017. Over that timeframe, u-boot upstream changed the location and architecture of their license files. `u-boot-fw-utils:do_populate_lic` fails because the license file is no longer at `:COPYING`.

This PR updates the license files' locations and md5sums to match what ships with 2017. As a nice side-effect, we're now packaging *all* of the licenses which ship with u-boot, rather than just u-boot's COPYING. :)

This PR also compresses the source meta-data into the includes file - which should be a little easier to maintain.

## Testing
Rebuilt all the `u-boot*.bbappend` recipes in the recipe directory. `u-boot-fw-utils` now builds correctly. `u-boot_2018` fails do_compile - but I think it has always failed. And `-mkimage` still passes (I don't think we use that one anyway).

FYI @kimkhiam 