### PR TITLE
Revert "grub_old.cfg: make provisioning IO use ttyS0"

### DIFF
--- a/scripts/lib/wic/canned-wks/grub_old.cfg
+++ b/scripts/lib/wic/canned-wks/grub_old.cfg
@@ -1,5 +1,3 @@
-set linux_console="console=tty0 console=ttyS0,115200n8"
-
 serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 default='Default Provisioning'
 timeout=1
@@ -7,13 +5,13 @@ timeout=1
 search --set=root --label NIRECOVERY-CD
 
 menuentry 'Default Provisioning' {
-	linux /bzImage rootwait restore=provision-safe $linux_console quiet loglevel=1
+	linux /bzImage rootwait restore=provision-safe quiet loglevel=1
 	initrd /initrd
 }
 
 menuentry 'Verbose Provisioning' {
 	echo 'Loading Linux ...'
-	linux /bzImage rootwait restore=provision-safe $linux_console verbose_mode=1
+	linux /bzImage rootwait restore=provision-safe verbose_mode=1
 	echo 'Loading initial ramdisk ...'
 	initrd /initrd
 }


### PR DESCRIPTION
This reverts commit 4c61fd5c2ee0d71ed0ef59d0499029ff074ea5bf.

The reverted commit breaks provisioning script output on at least the
PXIe-8881.

----

I'm not sure why this grub config broke script output on 8881s, but the safemode grub.cfg doesn't. I'm still investigating; but I'll revert the change for now, since it isn't required.

## Testing
None; revert to old behavior.

@ni/rtos 