### PR TITLE
kernel-test-nohz: add logging

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-test-nohz-files/run-ptest
+++ b/recipes-kernel/kernel-tests/kernel-test-nohz-files/run-ptest
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+LOG_DIR="/var/local/ptest-results/kernel-test-nohz"
+
 # redirect all stderr to stdout to maintain ordering of output
 exec 2>&1
 
@@ -15,14 +17,14 @@ done
 sysctl vm.stat_interval=999
 
 # create local results directory
-mkdir -p "/var/local/ptest-results/kernel-test-nohz"
+mkdir -p "$LOG_DIR"
 
 # start background scheduler load
 hackbench -l 36000000 -g 10 > /dev/null &
 
 # run test
-./nohz_test --max=6000 --p3nines=250 --p4nines=3000 --duration=24h
-RESULT="$?"
+./nohz_test --max=6000 --p3nines=250 --p4nines=3000 --duration=24h | tee "$LOG_DIR/output-`date +'%Y_%m_%d-%H_%M_%S'`.log"
+RESULT=${PIPESTATUS[0]}
 
 # cleanup
 killall -INT hackbench > /dev/null

--- a/recipes-kernel/kernel-tests/kernel-test-nohz-files/run-ptest
+++ b/recipes-kernel/kernel-tests/kernel-test-nohz-files/run-ptest
@@ -14,6 +14,9 @@ done
 # delay the vmstat timer far away
 sysctl vm.stat_interval=999
 
+# create local results directory
+mkdir -p "/var/local/ptest-results/kernel-test-nohz"
+
 # start background scheduler load
 hackbench -l 36000000 -g 10 > /dev/null &
 

--- a/recipes-kernel/kernel-tests/kernel-test-nohz.bb
+++ b/recipes-kernel/kernel-tests/kernel-test-nohz.bb
@@ -2,7 +2,7 @@ SUMMARY = "Linux kernel NO_HZ_FULL polling test"
 HOMEPAGE = "https://kernel.org"
 SECTION = "tests"
 LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://nohz_test.c;md5=d25cf78b2ec478f88868ccbc1967e9da"
+LIC_FILES_CHKSUM = "file://nohz_test.c;md5=e1d351b1ee60ef935ff16c7c0c0de455"
 
 inherit ptest
 

--- a/recipes-kernel/kernel-tests/kernel-test-nohz.bb
+++ b/recipes-kernel/kernel-tests/kernel-test-nohz.bb
@@ -2,7 +2,7 @@ SUMMARY = "Linux kernel NO_HZ_FULL polling test"
 HOMEPAGE = "https://kernel.org"
 SECTION = "tests"
 LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://nohz_test.c;md5=e1d351b1ee60ef935ff16c7c0c0de455"
+LIC_FILES_CHKSUM = "file://nohz_test.c;beginline=1;endline=2;md5=9e3e9401383732750e93a18064dc9493"
 
 inherit ptest
 


### PR DESCRIPTION
Change the nohz_test ptest to log results, including histogram data,
to '/var/local/ptest-results/kernel-test-nohz/' to aid debugging test
failures.

This required a slight refactoring of the code that checked for test
failures to allow for logging before exiting with an error.

Signed-off-by: Gratian Crisan <gratian.crisan@ni.com>