### PR TITLE
ni-grpc-device: pin version to v1.1.0 tag

### DIFF
--- a/recipes-ni/ni-grpc-device/ni-grpc-device_git.bb
+++ b/recipes-ni/ni-grpc-device/ni-grpc-device_git.bb
@@ -17,8 +17,7 @@ DEPENDS += "\
 	python3-native \
 "
 
-BPV = "1.1"
-PV = "${BPV}+git${SRCPV}"
+PV = "1.1.0"
 
 SRC_URI = "\
 	git://github.com/ni/grpc-device.git;name=grpc-device;branch=${SRCBRANCH} \
@@ -27,7 +26,7 @@ SRC_URI = "\
 "
 
 SRCBRANCH = "main"
-SRCREV_grpc-device = "${AUTOREV}"
+SRCREV_grpc-device = "15508bba63a6c289a32445ffb7f8986c99a2f286"
 
 SRCREV_FORMAT = "grpc-device"
 


### PR DESCRIPTION
Recent commits to the ni/grpc-device repo have upgraded its `grpc`
dependency to 1.39 - which our dunfell branch cannot provide. Pin the
ni-grpc-device repo to the src-rev of the upstream v1.1.0 release tag,
which is the latest full release which this recipe supports.

Also assert the package version more firmly, so that opkg can perform
version compares more accurately.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

This is in response to [this PR](https://github.com/ni/grpc-device/pull/281) that astarche put into the ni/grpc-device repo - and the subsequent build failure that it caused on the dunfell pipeline.

## Testing
* Built the `ni-grpc-device` recipe on my dev machine *without* this patch and confirmed that I could reproduce the build machine, error. With this PR applied, the recipe compiles correctly.
* Verified that the produced .ipk files have a more reasonable version string ...
  ```bash
  (bb) usr0@41d17:/mnt/workspace/build$ find ./tmp-glibc/deploy/ipk/ -name 'ni-grpc-device*'
  ./tmp-glibc/deploy/ipk/core2-64/ni-grpc-device-lic_1.1.0-r0_core2-64.ipk
  ./tmp-glibc/deploy/ipk/core2-64/ni-grpc-device-ptest_1.1.0-r0_core2-64.ipk
  ./tmp-glibc/deploy/ipk/core2-64/ni-grpc-device-src_1.1.0-r0_core2-64.ipk
  ./tmp-glibc/deploy/ipk/core2-64/ni-grpc-device-dbg_1.1.0-r0_core2-64.ipk
  ./tmp-glibc/deploy/ipk/core2-64/ni-grpc-device-dev_1.1.0-r0_core2-64.ipk
  ./tmp-glibc/deploy/ipk/core2-64/ni-grpc-device_1.1.0-r0_core2-64.ipk
  ```
  
  @ni/rtos 