### PR TITLE
Move GRUB_BRANCH var to the grub recipe directory

### DIFF
--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -2,8 +2,6 @@ MAINTAINER = "NI Linux Real-Time Maintainers <nilrt@ni.com>"
 
 TARGET_VENDOR = "-nilrt"
 
-GRUB_BRANCH = "nilrt/19.0"
-
 # Inherit the default LIBC features superset from OE-core
 DISTRO_FEATURES += "${DISTRO_FEATURES_LIBC}"
 

--- a/recipes-bsp/grub/grub-nilrt.inc
+++ b/recipes-bsp/grub/grub-nilrt.inc
@@ -11,6 +11,7 @@ SRC_URI = "\
 "
 
 S = "${WORKDIR}/git"
+GRUB_BRANCH = "nilrt/19.0"
 
 # Grub always try to force soft float in recent grub versions, even on x64, and this
 # conflicts with how the x64 OE toolchain is set up. The only solution is to cache

--- a/recipes-org/images/safemode-image.bb
+++ b/recipes-org/images/safemode-image.bb
@@ -39,10 +39,7 @@ do_install() {
 	cp ${WORKDIR}/grubenv_non_ni_target	${D}/payload
 	cp ${WORKDIR}/unicode.pf2		${D}/payload/fonts
 
-	GRUB_VERSION=$(echo ${GRUB_BRANCH} | cut -d "/" -f 2)
-
 	echo "BUILD_IDENTIFIER=${BUILD_IDENTIFIER}" > ${D}/payload/imageinfo
-	echo "GRUB_VERSION=${GRUB_VERSION}.0" >> ${D}/payload/imageinfo
 }
 
 sysroot_stage_all_append() {


### PR DESCRIPTION
The `GRUB_BRANCH` variable is used by (a) our `grub*` recipes and (b) the `safemode-image` recipe in `recipes-org/`.

The safemode-image recipe only uses it to write its value into the `/payload/imageinfo` file. But a search of the codebase suggests that no one actually uses that key-value pair, and the [original commit](https://github.com/ni/meta-orgconf/commit/a6a70ead04e5c2b37b2fb62493fe3162fe86be06) doesn't provide any more context.

So remove the KVP from the imageinfo file, and move the GRUB_BRANCH variable from the distro.conf, back into the grub recipes.

## Testing
* Rebuilt the grub recipes and verified that they still work.
* I can't rebuild the safemode-image recipe on my dev machine, but it's very unlikely that the lines I removed could break the recipe build anyway. And that recipe is also unlikely to be seriously used for a while yet.

@ni/rtos 