### PR TITLE
Revert "Move GRUB_BRANCH var to the grub recipe directory"

### DIFF
--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -2,6 +2,8 @@ MAINTAINER = "NI Linux Real-Time Maintainers <nilrt@ni.com>"
 
 TARGET_VENDOR = "-nilrt"
 
+GRUB_BRANCH = "nilrt/19.0"
+
 # Inherit the default LIBC features superset from OE-core
 DISTRO_FEATURES += "${DISTRO_FEATURES_LIBC}"
 

--- a/recipes-bsp/grub/grub-nilrt.inc
+++ b/recipes-bsp/grub/grub-nilrt.inc
@@ -11,7 +11,6 @@ SRC_URI = "\
 "
 
 S = "${WORKDIR}/git"
-GRUB_BRANCH = "nilrt/19.0"
 
 # Grub always try to force soft float in recent grub versions, even on x64, and this
 # conflicts with how the x64 OE toolchain is set up. The only solution is to cache

--- a/recipes-org/images/safemode-image.bb
+++ b/recipes-org/images/safemode-image.bb
@@ -39,7 +39,10 @@ do_install() {
 	cp ${WORKDIR}/grubenv_non_ni_target	${D}/payload
 	cp ${WORKDIR}/unicode.pf2		${D}/payload/fonts
 
+	GRUB_VERSION=$(echo ${GRUB_BRANCH} | cut -d "/" -f 2)
+
 	echo "BUILD_IDENTIFIER=${BUILD_IDENTIFIER}" > ${D}/payload/imageinfo
+	echo "GRUB_VERSION=${GRUB_VERSION}.0" >> ${D}/payload/imageinfo
 }
 
 sysroot_stage_all_append() {


### PR DESCRIPTION
Reverts ni/meta-nilrt#218

Somehow, my codesearch missed [this ni_provisioning.safemode](https://github.com/ni/meta-nilrt/blob/nilrt/master/sumo/recipes-core/initrdscripts/files/ni_provisioning.safemode#L377) script call, which tests the `GRUB_VERSION` string in `/payload/imageinfo`. Without the string, the provisioning scripts error during provisioning. So it isn't safe and trivial to drop this variable from the safemode recipes. :(

@ni/rtos