### PR TITLE
pkggrps: move perf from -extra to -desirable

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-desirable.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-desirable.bb
@@ -39,6 +39,7 @@ RDEPENDS_${PN} += "\
 	ltrace \
 	ntpdate \
 	openssl-dev \
+	perf \
 	python3-nose \
 	python3-pip \
 	python3-psutil \

--- a/recipes-core/packagegroups/packagegroup-ni-extra.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-extra.bb
@@ -230,7 +230,6 @@ RDEPENDS_${PN} += "\
 	linux-firmware \
 	makedumpfile \
 	oprofile \
-	perf \
 	powertop \
 	sysprof \
 	systemtap \


### PR DESCRIPTION
With newer kernel recipes, the `perf` package is now buildable. Move it
to packagegroup-ni-desirable to assert that we always want it to build.

See meta-nilrt commit [909d5b480b4eac11843920c0baf1324ae6544b7c](https://github.com/ni/meta-nilrt/commit/909d5b480b4eac11843920c0baf1324ae6544b7c).

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

## Testing
Rebuilt `perf` on my dev machine and verified that the recipe works with the new kernel.

@ni/rtos 