### PR TITLE
nisystemformat: flesh out partial recovery of failed reformats

### DIFF
--- a/recipes-ni/ni-systemformat/files/nisystemformat
+++ b/recipes-ni/ni-systemformat/files/nisystemformat
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2021 National Instruments
+# Copyright (c) 2013-2021 National Instruments
 # For grub and u-boot targets, format rootfs and the config volumes and delete the runmode kernel
 # For RAUC targets, write init-action.cfg to format or boot into safemode on next boot.
 
@@ -102,20 +102,6 @@ with_retry()
 	return 1
 }
 
-services_stop()
-{
-	/etc/init.d/systemWebServer stop || true
-	/etc/init.d/sshd stop || true
-	/etc/init.d/niauth stop || true
-}
-
-services_start()
-{
-	/etc/init.d/niauth start || true
-	/etc/init.d/sshd start || true
-	/etc/init.d/systemWebServer start || true
-}
-
 install_default_err_handler()
 {
 	trap 'handle_err ${BASH_SOURCE} ${LINENO} ${FUNCNAME:-unknown} $?' ERR
@@ -161,64 +147,11 @@ print_config_fstype()
 	grep " $CONFIG_MOUNT_POINT " /proc/mounts | awk '{print $3}'
 }
 
-umount_config()
-{
-	with_retry /etc/init.d/populateconfig stop
-	with_retry /etc/init.d/mountconfig stop
-}
-
-umount_rootfs()
-{
-	with_retry /etc/init.d/mountcompatibility stop
-	with_retry /etc/init.d/mountuserfs stop
-}
-
-# restore config partition after format
-# $1: exit code
-# $2: line number of trap (if failing)
-mount_config()
-{
-	with_retry /etc/init.d/mountconfig start
-	with_retry /etc/init.d/populateconfig start
-
-	if (( $1 != 0 )); then
-		die UNKNOWN_ERROR "Format failed, line $2, status code $1"
-	fi
-}
-
-# restore root partition after format
-# $1: exit code
-# $2: line number of trap (if failing)
-mount_rootfs()
-{
-	with_retry /etc/init.d/mountuserfs start
-	with_retry /etc/init.d/mountcompatibility start
-
-	# Move the restore files back to the rootfs
-	if [ -e /tmp/restore ]; then
-		mkdir -p "$ROOTFS_MOUNT_POINT/.restore"
-		mv /tmp/restore/* "$ROOTFS_MOUNT_POINT/.restore"
-		rmdir /tmp/restore
-	fi
-
-	if (( $1 != 0 )); then
-		die UNKNOWN_ERROR "Format failed, line $2, status code $1"
-	fi
-}
-
 # Format the rootfs volume
 # $1: filesystem to use (currently "ubifs" or "ext4")
 # $2: root device (defaults to $ROOTFS_DEV, only works for x86_64 on ARM is ignored)
 format_rootfs()
 {
-	trap 'mount_rootfs $? $LINENO' ERR
-
-	# Backup the restore files to the tmp dir
-	if [ -e "$ROOTFS_MOUNT_POINT/.restore" ]; then
-		mkdir -p /tmp/restore
-		cp -R "$ROOTFS_MOUNT_POINT"/.restore/* /tmp/restore/
-	fi
-
 	# remove Zynq kernel
 	rm -f /boot/linux_runmode.itb
 
@@ -250,8 +183,6 @@ format_rootfs()
 		mkfs.ext4 -q -F -L $volume_label $options ${2:-$ROOTFS_DEV}
 		;;
 	esac
-
-	install_default_err_handler
 }
 
 # Format the config volume
@@ -259,8 +190,6 @@ format_rootfs()
 # $2: configfs device (defaults to $CONFIGFS_DEV, only works for x86_64 on ARM is ignored)
 format_config()
 {
-	trap 'mount_config $? $LINENO' ERR
-
 	# fstype is validated before calling format_config
 	case "$1" in
 	  ubifs)
@@ -278,8 +207,6 @@ format_config()
 		mkfs.ext4 -q -F -L $volume_label $options ${2:-$CONFIGFS_DEV}
 		;;
 	esac
-
-	install_default_err_handler
 }
 
 usage()
@@ -408,13 +335,104 @@ targetinfo_restore()
 	EOF
 }
 
+# Top-level entry point for reformats. Stop storage-sensitive system services
+# prior to the format attempt. Restart services on success if requested, or on
+# failure if appropriate.
 format_rootfs_or_userfs()
 {
-	netconfig_pre
-	services_stop
+	/etc/init.d/systemWebServer stop ||:
+	/etc/init.d/sshd stop ||:
+	/etc/init.d/niauth stop ||:
 
-	umount_config
-	umount_rootfs
+	# ABORTED_ATTEMPT=yes means something went wrong before we actually reformatted
+	# anything: go ahead and restart all services. We set it at the outset,
+	# so that any premature failure will set it by default, and unset it once it
+	# is no longer applicable.
+	ABORTED_ATTEMPT=yes
+	local ret=0
+	format_rootfs_or_userfs_nosvc || ret=$?
+	if (( ! ret )) && [ "$RELAUNCH" = yes ] || [ "$ABORTED_ATTEMPT" = yes ]
+	then
+		/etc/init.d/niauth start ||:
+		/etc/init.d/sshd start ||:
+		/etc/init.d/systemWebServer start ||:
+	fi
+	return $ret
+}
+
+# Format operation, assuming all impacted services are shut down. Saves and
+# restores system configuration, if necessary.
+format_rootfs_or_userfs_nosvc()
+{
+	netconfig_pre || return $?
+
+	# Backup the restore files to the tmp dir. Do this even if we're only
+	# reformatting the configfs, because under some configurations,
+	# reformatting the configfs may also trigger reformatting the userfs.
+	# (And it doesn't cost us anything to do the copy)
+	if [ -e "$ROOTFS_MOUNT_POINT/.restore" ]; then
+		mkdir -p /tmp/restore &&
+			cp -R "$ROOTFS_MOUNT_POINT"/.restore/* /tmp/restore/ ||
+			return $?
+	fi
+
+	# If we errored out, either the error was unrecoverable (in which case
+	# the rest of this should be skipped), or recoverable (in which case no
+	# reformat happened and there is no need to restore configurations)
+	format_rootfs_or_userfs_nosvc_noconf || return $?
+
+	local ret=0
+
+	# Move the restore files back to the rootfs. Only do this if the
+	# reformat actually happened, i.e. /.restore doesn't exist. In order to
+	# make a best-effort attempt at recovery, try to move restore files back
+	# to the rootfs (if it exists) even if mountconfig failed.
+	if [ -e /tmp/restore -a ! -e "$ROOTFS_MOUNT_POINT/.restore" ] &&
+		   mountpoint -q "$ROOTFS_MOUNT_POINT"
+	then
+		mkdir -p "$ROOTFS_MOUNT_POINT/.restore" &&
+			mv /tmp/restore/* "$ROOTFS_MOUNT_POINT/.restore" &&
+			rmdir /tmp/restore || (( ret )) || ret=$?
+	fi
+
+	netconfig_post || (( ret )) || ret=$?
+	# targetinfo.ini needs to be restored or it will not be recreated until a reboot into safemode
+	targetinfo_restore || (( ret )) || ret=$?
+	return $ret
+}
+
+# Format operation, assuming all impacted services are shut down, and all
+# impacted system configuration has been saved off.
+format_rootfs_or_userfs_nosvc_noconf() {
+	local ret=0
+	if \
+		with_retry /etc/init.d/populateconfig stop &&
+		with_retry /etc/init.d/mountconfig stop &&
+		with_retry /etc/init.d/mountcompatibility stop &&
+		with_retry /etc/init.d/mountuserfs stop
+	then
+		format_rootfs_or_userfs_nomount || (( ret )) || ret=$?
+	else
+		ret=$?
+	fi
+	# If we are erroring out unrecoverably, skip the rest of this function
+	(( ret )) && ! [ "$ABORTED_ATTEMPT" = yes ] && return $ret
+
+	# configfs needs to be mounted before rootfs otherwise only one
+	# *etc/natinst/share will be mounted. (This may be a bug in the mount*
+	# initscripts.)
+	with_retry /etc/init.d/mountconfig start &&
+		with_retry /etc/init.d/populateconfig start || (( ret )) || ret=$?
+	with_retry /etc/init.d/mountuserfs start &&
+		with_retry /etc/init.d/mountcompatibility start || (( ret )) || ret=$?
+	return $ret
+}
+
+# Format operation, assuming all impacted mountpoints are unmounted. This is
+# what actually does the formatting.
+format_rootfs_or_userfs_nomount()
+{
+	ABORTED_ATTEMPT=	# After this point, failures are unrecoverable
 
 	configfs_dev="$CONFIGFS_DEV"
 	rootfs_dev="$ROOTFS_DEV"
@@ -457,20 +475,6 @@ format_rootfs_or_userfs()
 			format_config "$TYPE" "$configfs_dev"
 		fi
 		format_rootfs "$TYPE" "$rootfs_dev"
-	fi
-
-	# configfs needs to be mounted before rootfs otherwise only one *etc/natinst/share will be mounted
-	# (this may be a bug in the mount* initscripts - Ionel)
-	mount_config 0
-	mount_rootfs 0
-
-	netconfig_post
-
-	# targetinfo.ini needs to be restored or it will not be recreated until a reboot into safemode
-	targetinfo_restore
-
-	if [ "$RELAUNCH" = yes ]; then
-		services_start
 	fi
 }
 


### PR DESCRIPTION
Previously, the only recovery that occurred here was that rootfs format
failures would mount_rootfs on exit. Here, we extend that to the entire
configuration/service management stack surrounding the format operation, so
that nondestructive failures are generally fully recovered from To simplify the
cleanup logic, we break format_rootfs_or_userfs() into a chain of smaller
functions, each of which is responsible for setup/cleanup of a specific layer
of the stack.

Copyright bump.

Natinst-AzDO-ID: 1505704
Signed-off-by: Richard Tollerton <rich.tollerton@ni.com>