### PR TITLE
openssl: drop bbappend

### DIFF
--- a/recipes-connectivity/openssl/openssl_1.1.1g.bbappend
+++ b/recipes-connectivity/openssl/openssl_1.1.1g.bbappend
@@ -1,8 +1,0 @@
-# Remove Debian's pic.patch from NILRT's build of OpenSSL. The
-# changes are not properly scoped to Linux only and break
-# Windows/msvc builds which consume NILRT/OE source packages. The
-# modified perl scripts are also not called during either the x64 or
-# xilinx-zynqhf builds of NILRT, so there's no real value in
-# improving the change.
-
-SRC_URI_remove = "file://debian/pic.patch"


### PR DESCRIPTION
The meta-nilrt bbappend for openssl only removes the `pic.patch` file
from upstream's recipe. But as of openssl_1.1.1k, `pic.patch` is no
longer in the sources.

Drop the bbappend, because it is no longer required.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

## Testing
`openssl` recipe still builds. `pic.patch` wasn't in the `SRC_URI` previously, and still isn't.

@ni/rtos 