### PR TITLE
Drop the meta-nilrt libnss-mdns bbappend

### DIFF
--- a/recipes-connectivity/libnss-mdns/libnss-mdns_0.%.bbappend
+++ b/recipes-connectivity/libnss-mdns/libnss-mdns_0.%.bbappend
@@ -1,4 +1,2 @@
-EXTRA_OECONF = "--libdir=${base_libdir} --disable-lynx --enable-legacy"
-
 DEPENDS = ""
 RDEPENDS_${PN} = ""

--- a/recipes-connectivity/libnss-mdns/libnss-mdns_0.%.bbappend
+++ b/recipes-connectivity/libnss-mdns/libnss-mdns_0.%.bbappend
@@ -1,2 +1,0 @@
-DEPENDS = ""
-RDEPENDS_${PN} = ""


### PR DESCRIPTION
The contents of the `libnss-mdns` bbappend are outdated. The make configuration options it asserts were deprecated by upstream, and we no longer need to drop its avahi dependencies - since we ship avahi in the base images now.

I'm not 100% sure that we still don't need whatever `legacy` mode was enabled by the configuration, so I created [AZDO-1585850](https://dev.azure.com/ni/DevCentral/_workitems/edit/1585850) to track checking that the bug which motivated that config doesn't reproduce.

For now, I'm dropping the whole of the bbappend.

## Testing
`libnss-mdns` now builds without error.

@ni/rtos 