### PR TITLE
packagegroup-ni-desirable: Remove ni-grpc-device

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-desirable.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-desirable.bb
@@ -18,7 +18,6 @@ RDEPENDS_${PN}_append_x64 = "\
 	packagegroup-ni-mono-extra \
 	kernel-test-nohz \
 	florence \
-	ni-grpc-device \
 "
 
 RDEPENDS_${PN} += "\


### PR DESCRIPTION
Moved ni-grpc-device to NIOpenEmbedded to satisfy a dependency in
ni-sync-remote-config that depends on ni-grpc-device and needed it
in the main feed instead of the extras feed.

Signed-off-by: Bill Pittman <bill.pittman@ni.com>