### PR TITLE
pkggrp-ni-base: remove dhcp-client

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -93,7 +93,6 @@ RDEPENDS_${PN} = "\
 	cronie \
 	curl \
 	daemonize \
-	dhcp-client \
 	dpkg-start-stop \
 	ethtool \
 	gptfdisk-sgdisk \


### PR DESCRIPTION
The `dhcp` family of recipes has been dropped by OE upstream.

Until we can reconcile meta-nilrt, remove packagegroup-ni-base's RDEPENDS
on dhcp-client, so that it doesn't break the build.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

-----

Reconciling the `dhcp` package family is tracked by [AZDO-1580270](https://dev.azure.com/ni/DevCentral/_workitems/edit/1580270).

@ni/rtos 