### PR TITLE
pkggrp-ni-extra: remove pkggrp-core-device-devel

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-extra.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-extra.bb
@@ -60,7 +60,6 @@ RDEPENDS_${PN} = "\
 	packagegroup-core-sdk \
 	packagegroup-core-standalone-sdk-target \
 	packagegroup-core-basic \
-	packagegroup-core-device-devel \
 	packagegroup-core-buildessential \
 	packagegroup-core-tools-debug \
 	packagegroup-core-security \


### PR DESCRIPTION
packagegroup-core-device-devel was removed from OE-core by upstream
commit 910e26321f6d7583ae68dafafffe2040ca9cfa70. They removed it because
it's purpose and contents were "unclear". I agree.

Meta-nilrt only added this packagegroup as part of a vague merge of the
x11 and non-x11 distro images.

Remove this packagegroup because it is obsolete and probably
unnecessary.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

## Testing
None; trivial removal.

@ni/rtos 