### PR TITLE
pkggrps: remove hwclock-init

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -132,7 +132,6 @@ RDEPENDS_${PN} = "\
 	eudev \
 	udev-extraconf \
 	util-linux-agetty \
-	hwclock-init \
 	util-linux-hwclock \
 	util-linux-mount \
 	util-linux-umount \

--- a/recipes-core/packagegroups/packagegroup-ni-ptest-smoke.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-ptest-smoke.bb
@@ -14,7 +14,6 @@ RDEPENDS_${PN} = "ptest-runner"
 # ptest packages
 RDEPENDS_${PN}_append = "\
     glibc-tests-ptest \
-    hwclock-init-ptest \
     kernel-tests-ptest \
     opkg-ptest \
     pstore-save-ptest \


### PR DESCRIPTION
The hwclock-init recipe was broken by the hardknott rebase. Until we
commit to fixing the recipe, it will block building the base
packagegroup.

Remove references to hwclock-init from packagegroup-ni-base and
-ptest-smoke, until it is fixed.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

## Testing
Rebuilt `packagegroup-ni-base`. This recipe no longer blocks the build.

@ni/rtos 