### PR TITLE
pstore-save: add bash to -ptest RDEPENDS

### DIFF
--- a/recipes-ni/pstore-save/pstore-save_1.0.bb
+++ b/recipes-ni/pstore-save/pstore-save_1.0.bb
@@ -30,7 +30,7 @@ do_install () {
 
 inherit ptest
 
-RDEPENDS_${PN}-ptest += "${PN}"
+RDEPENDS_${PN}-ptest += "${PN} bash"
 
 do_install_ptest_append () {
     install -d ${D}${PTEST_PATH}/src


### PR DESCRIPTION
Newer OE package QA checks will error when building pstore-save. OE
detects that the run-ptest script in the pstore-save-ptest subpackage
uses a /bin/bash shebang line, but that the -ptest subpackage doesn't
declare an dependency on any package which provides /bin/bash.

Give the -ptest subpackage an RDEPENDS on `bash` to provide the bash
binary.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

OE error looks like this:

```make
ERROR: pstore-save-1.0-r0 do_package_qa: QA Issue: /usr/lib/pstore-save/ptest/run-ptest contained in package pstore-save-ptest requires /bin/bash, but no providers found in RDEPENDS_pstore-save-ptest? [file-rdeps]
```

And it's actually kinda' neat that OE detected this.

## Testing
`pstore-save` now builds without error.

@ni/rtos 