### PR TITLE
pciutils: remove custom SRC package declaration

### DIFF
--- a/recipes-bsp/pciutils/pciutils_%.bbappend
+++ b/recipes-bsp/pciutils/pciutils_%.bbappend
@@ -1,1 +1,0 @@
-ENABLE_SRC_INSTALL_${PN} = "1"


### PR DESCRIPTION
Back in 2015, there was a need to consume pciutils-ids content for
nibuild, directly from the OE sources. To accomplish that, we enabled
a -src subpackage via a custom source package creation mechanism. Since
then, upstream has implemented their own mechanism which conflicts with
ours, and the workflow to use the pciutils source is no longer
supported in this branch.

Remove the custom source subpackage declaration, as part of deprecating
our mechanism. Remove the now-empty bbappend entirely.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

This commit is related to [ni/OE-core #31](https://github.com/ni/openembedded-core/pull/31), but is not dependent upon it.

## Testing
The important part of making this recipe work was disabling the custom -src subpackage mechanism. This change is inconsequential, and mostly just for cleanup.

@ni/rtos 