### PR TITLE
linux-nilrt-debug: Move debug vmlinux out of /boot

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-debug_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-debug_git.bb
@@ -13,3 +13,14 @@ SRC_URI += "\
 # This is the place to overwrite the source AUTOREV from linux-nilrt.inc, if
 # the kernel recipe requires a particular ref.
 #SRCREV = ""
+
+# Move vmlinux-${KERNEL_VERSION_NAME} from /boot to /lib/modules/${KERNEL_VERSION}/build/
+# to avoid filling the /boot partition.
+FILES_${KERNEL_PACKAGE_NAME}-vmlinux_remove = "/boot/vmlinux-${KERNEL_VERSION_NAME}"
+FILES_${KERNEL_PACKAGE_NAME}-vmlinux += "${nonarch_base_libdir}/modules/${KERNEL_VERSION}/build/vmlinux-${KERNEL_VERSION_NAME}"
+
+do_install_append(){
+    install -d "${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/build"
+    mv ${D}/boot/vmlinux-${KERNEL_VERSION} "${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/build/"
+}
+

--- a/recipes-kernel/linux/linux-nilrt-debug_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-debug_git.bb
@@ -16,11 +16,12 @@ SRC_URI += "\
 
 # Move vmlinux-${KERNEL_VERSION_NAME} from /boot to /lib/modules/${KERNEL_VERSION}/build/
 # to avoid filling the /boot partition.
+VMLINUX_DIR = "${nonarch_base_libdir}/modules/${KERNEL_VERSION}/build"
 FILES_${KERNEL_PACKAGE_NAME}-vmlinux_remove = "/boot/vmlinux-${KERNEL_VERSION_NAME}"
-FILES_${KERNEL_PACKAGE_NAME}-vmlinux += "${nonarch_base_libdir}/modules/${KERNEL_VERSION}/build/vmlinux-${KERNEL_VERSION_NAME}"
+FILES_${KERNEL_PACKAGE_NAME}-vmlinux += "${VMLINUX_DIR}/vmlinux-${KERNEL_VERSION_NAME}"
 
 do_install_append(){
-    install -d "${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/build"
-    mv ${D}/boot/vmlinux-${KERNEL_VERSION} "${D}${nonarch_base_libdir}/modules/${KERNEL_VERSION}/build/"
+    install -d "${D}/${VMLINUX_DIR}"
+    mv ${D}/boot/vmlinux-${KERNEL_VERSION} "${D}/${VMLINUX_DIR}/"
 }
 


### PR DESCRIPTION
The debug vmlinux file is significantly larger than the entire boot
partition. As a result, installing it was causing errors.

This file is not actually used by the target, but is intended to be
copied to a host machine running kgdb. Therefore it does not need to be
installed on the boot partition. This change moves it out of the boot
partition and into /lib/modules/<kernel-version>/build.

Signed-off-by: Jeffrey Pautler <jeffrey.pautler@ni.com>