### PR TITLE
mesa: remove invalid PACKAGECONFIGs

### DIFF
--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -1,9 +1,5 @@
-PACKAGECONFIG_append = " \
-    swrast \
-    nouveau_vieux \
-    i915 \
-    radeon \
-    gallium \
-    r200 \
-    r600 \
-    "
+# PXIe-88XX series hardware requires the r600_dri driver for hardware rendering
+PACKAGECONFIG_append = "\
+	gallium \
+	r600 \
+"


### PR DESCRIPTION
The mesa recipe asserts several PACKAGECONFIG values which are not
supported by the OE-core/hardknott version of the mesa recipe includes.
Their original function is dubious and, in all the cases I could verify,
already the default behavior in the mesa.inc.

Remove the invalid PACKAGECONFIG entries, to satisfy the sanity checkers
in OE.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

These values were originally added in response to [AZDO-69664](https://dev.azure.com/ni/DevCentral/_workitems/edit/69664). It seems like the r600 `PACKAGECONFIG` is the main thrust of the bug fix, and the other options were added to try and create a stable default.

## Testing
* `mesa` still builds correctly, and without warnings about invalid PACKAGECONFIGs.

@ni/rtos @harisokanovic 