### PR TITLE
linux: really staple kernel recipes for release

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-debug_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-debug_git.bb
@@ -12,7 +12,8 @@ SRC_URI += "\
 
 # This is the place to overwrite the source AUTOREV from linux-nilrt.inc, if
 # the kernel recipe requires a particular ref.
-#SRCREV = ""
+SRCREV = "4de019e72df37f49e08f352a835cf5779d57fac2"
+SRCREV_xilinx-zynq = "cf7239e5a7055e3a3f19b40d83347ccbe70b44e7"
 
 # Move vmlinux-${KERNEL_VERSION_NAME} from /boot to /lib/modules/${KERNEL_VERSION}/build/
 # to avoid filling the /boot partition.

--- a/recipes-kernel/linux/linux-nilrt-next_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-next_git.bb
@@ -7,4 +7,4 @@ require linux-nilrt-alternate.inc
 
 # This is the place to overwrite the source AUTOREV from linux-nilrt.inc, if
 # the kernel recipe requires a particular ref.
-#SRCREV = ""
+SRCREV = "4de019e72df37f49e08f352a835cf5779d57fac2"

--- a/recipes-kernel/linux/linux-nilrt-nohz_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-nohz_git.bb
@@ -19,4 +19,4 @@ do_install_append() {
 
 # This is the place to overwrite the source AUTOREV from linux-nilrt.inc, if
 # the kernel recipe requires a particular ref.
-#SRCREV = ""
+SRCREV = "4de019e72df37f49e08f352a835cf5779d57fac2"

--- a/recipes-kernel/linux/linux-nilrt_git.bb
+++ b/recipes-kernel/linux/linux-nilrt_git.bb
@@ -7,4 +7,5 @@ require linux-nilrt.inc
 
 # This is the place to overwrite the source AUTOREV from linux-nilrt.inc, if
 # the kernel recipe requires a particular ref.
-#SRCREV = ""
+SRCREV = "4de019e72df37f49e08f352a835cf5779d57fac2"
+SRCREV_xilinx-zynq = "cf7239e5a7055e3a3f19b40d83347ccbe70b44e7"


### PR DESCRIPTION
Service for the LV 21Q3 release.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

---

The previous 21.3/sumo branch PR to staple these recipes (#242) didn't *actually* staple the recipes to a source-rev, but rather set them to `AUTOREV` from the upstream ni/linux release branch. This PR does the actual stapling.

4.14 kernel SRCREV set to here: https://github.com/ni/linux/commit/cf7239e5a7055e3a3f19b40d83347ccbe70b44e7
5.10 kernel SRCREV set to here: https://github.com/ni/linux/commit/4de019e72df37f49e08f352a835cf5779d57fac2

## Testing
* Checked that `linux-nilrt:do_fetch` still works.
* Verified that the SRCREV values look sane in the bitbake environment, for both `x64` and `xilinx-zynq`.