### PR TITLE
opencv: Overwrite PV so that it isn't too long

### DIFF
--- a/recipes-support/opencv/opencv_3.3.bbappend
+++ b/recipes-support/opencv/opencv_3.3.bbappend
@@ -1,3 +1,5 @@
 EXTRA_OECMAKE =+ "-DWITH_GPHOTO2=OFF"
 
 ALLOW_EMPTY_${PN}-java = "1"
+
+PV="3.3"


### PR DESCRIPTION
PV of opencv from openembedded-core contains git hashes of [5 repos](https://github.com/ni/meta-openembedded/blob/nilrt/master/sumo/meta-oe/recipes-support/opencv/opencv_3.3.bb#:~:text=SRCREV_opencv%20%3D%20%2287c27a074db9f6d9d60513f351daa903606ca370%22,SRCREV_vgg%20%3D%20%22fccf7cd6a4b12079f73bbfb21745f9babcd4eb1d%22).
This causes package name and thereby the export path to be too long
causing build failure in nibuild. Overwriting PV here to avoid this.

### Testing
Verified locally built ipks don't have git hashes anymore

### Note
If we are able to fix the max path length at source, will revert this change.
This is a hot fix to get CI passing.