### PR TITLE
grub: Include Tiger Lake changes for console

### DIFF
--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -2,7 +2,7 @@ MAINTAINER = "NI Linux Real-Time Maintainers <nilrt@ni.com>"
 
 TARGET_VENDOR = "-nilrt"
 
-GRUB_BRANCH = "nilrt/19.0"
+GRUB_BRANCH = "main"
 
 # Inherit the default LIBC features superset from OE-core
 DISTRO_FEATURES += "${DISTRO_FEATURES_LIBC}"

--- a/recipes-bsp/grub/grub-nilrt.inc
+++ b/recipes-bsp/grub/grub-nilrt.inc
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/grub:"
 
 PV = "2.02+git${SRCPV}"
-SRCREV = "832e7862089a7cbc985ae09a17f6827de6c85bf8"
+SRCREV = "61a02ce279575ea846e6ee7f8c9fb686fd54328c"
 
 SRC_URI = "\
 	${NILRT_GIT}/grub.git;branch=${GRUB_BRANCH} \


### PR DESCRIPTION
Include the Tiger Lake changes that allow the console to work
on these targets when they are being provisioned.

Signed-off-by: Bill Pittman <bill.pittman@ni.com>