### PR TITLE
nilrt-image-common: Build images into tar.gz files

### DIFF
--- a/recipes-core/images/nilrt-image-common.inc
+++ b/recipes-core/images/nilrt-image-common.inc
@@ -1,7 +1,7 @@
 DESCRIPTION ?= "Base image setup used in all NILRT images"
 LICENSE = "MIT"
 
-IMAGE_FSTYPES = "${INITRAMFS_FSTYPES} tar.bz2 ext2"
+IMAGE_FSTYPES = "${INITRAMFS_FSTYPES} tar.bz2 tar.gz ext2"
 
 IMAGE_FEATURES ??= ""
 IMAGE_LINGUAS ??= ""


### PR DESCRIPTION
Added the tar.gz type so images will be built into tar.gz files
from bitbake.

Signed-off-by: Bill Pittman <bill.pittman@ni.com>