### PR TITLE
Some changes for building compatible runmode. Part 2 of 2

### DIFF
--- a/recipes-core/images/files/nilrt-runmode-system-image.cdf
+++ b/recipes-core/images/files/nilrt-runmode-system-image.cdf
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?CDF VERSION="7.0"?>
+<DEFINITION>
+  <SOFTPKG NAME="%guid%" VERSION="%version%" OLDESTCOMPATIBLEVERSION="%version%" PROVIDESOS="YES" TYPE="HIDDEN">
+    <TITLE>SystemLink Base Image</TITLE>
+    <IMPLEMENTATION>
+      <OS VALUE="NI-Linux x64"><OSVERSION VALUE="7.0"/></OS>
+      <CODEBASE FILENAME="%filename%" TYPE="TAR" />
+    </IMPLEMENTATION>
+  </SOFTPKG>
+</DEFINITION>

--- a/recipes-core/images/files/nilrt-runmode-system-image.postinst
+++ b/recipes-core/images/files/nilrt-runmode-system-image.postinst
@@ -1,0 +1,107 @@
+#!/bin/bash
+#
+# Copyright (c) 2013,2017 National Instruments
+#
+
+# Something in base is installing /etc/natinst/share/uninstall that may not be
+# getting installed for SystemLink. nisid will fail if this directory doesn't
+# install, so this component ought to install /etc/natinst/share/uninstall
+# itself, regardless of if some other component ultimately will too.
+mkdir -p -m 755 /mnt/userfs/etc/natinst/share/uninstall
+
+# Enable ssh by default when installing SystemLink.
+/usr/local/natinst/bin/nirtcfg -s section=systemsettings,token=sshd.enabled,value=True
+
+# Add the memory reservation for Base. We assert that if the section exists,
+# it's already been added.
+if ! grep -q 'RtLinuxMemReserve' /mnt/userfs/etc/natinst/share/ni-rt.ini; then
+	cat >> /mnt/userfs/etc/natinst/share/ni-rt.ini <<EOF
+[RtLinuxMemReserve]
+Base=24
+EOF
+fi
+
+# Artemis introduced a new type of design which combined the use of zynq with an
+# ext4 filesystem drive as its main disk. Hence, some configurations are needed
+# for the systemlink software installation to be executed properly.
+
+# check for artemis compatibility from devicetree
+if grep -qs artemis /sys/firmware/devicetree/base/compatible ; then
+
+    # configure the partitions to mount by label in fstab
+    sed -i '/ubifs/d' /mnt/userfs/etc/fstab
+    echo LABEL=nibootfs         /boot                ext4       sync           0  0 >>/mnt/userfs/etc/fstab
+    echo LABEL=niconfig         /etc/natinst/share   ext4       sync           0  0 >>/mnt/userfs/etc/fstab
+    mkdir -p /etc/natinst/share
+
+    # configure the path for fw_printenv to read environmental variables from u-boot
+    # replace /dev/mtd4 and /dev/mtd5 with /boot/uboot/uboot.env
+    sed -i '/mtd/d' /mnt/userfs/etc/fw_env.config
+    echo /boot/uboot/uboot.env         0x0000         0x20000 >>/mnt/userfs/etc/fw_env.config
+
+fi
+
+arch="`uname -m`"
+mount_point="/boot"
+class="`/sbin/fw_printenv -n TargetClass`"
+
+if [ "$arch" = "armv7l" ]; then
+	kernel="/mnt/userfs/boot/tmp/linux_runmode.itb"
+elif [ "$arch" = "x86_64" ]; then
+	kernel="/mnt/userfs/boot/tmp/runmode"
+else
+	echo >&2 "ERROR: Unsupported platform"
+	exit 1
+fi
+
+# in normal operation, /boot better exist
+awk '{print $2;}' < /proc/mounts | grep -q /boot || exit 1
+
+# Remove OE getty lines for serial terminal and replace with consolegetty
+sed -i'' -e"s/\/s\?bin\/\(start_\)\?getty \(-L \)\?[0-9]\+ tty[OPS]\+[0-9]\+/\/etc\/init.d\/consolegetty tty2/g" /mnt/userfs/etc/inittab
+grep -q "/etc/init.d/consolegetty" /mnt/userfs/etc/inittab || exit 1
+
+# Give hwclock CAP_SYS_TIME capabilties
+/usr/sbin/setcap CAP_SYS_TIME+ep /mnt/userfs/sbin/hwclock.util-linux
+
+# install the kernel
+[ "$arch" = "x86_64" ] && rm -rf /boot/runmode
+if mv "$kernel" "$mount_point"; then
+	# Remove the tmp path from the rootfs
+	rmdir "`dirname "$kernel"`"
+else
+	exit 1
+fi
+
+# Use persistent names on PXI, not on any other targets
+[ "$class" = "PXI" ] || touch /mnt/userfs/etc/udev/rules.d/80-net-name-slot.rules
+
+# Enable core dumps on PXI, not on any other targets
+[ "$class" = "PXI" ] && echo "* soft core unlimited" > /etc/security/limits.d/allow-core-dumps.conf
+
+# update module dependencies
+RUNMODE_KERNEL_VERSION=$(/bin/ls -1 /mnt/userfs/lib/modules | head -n 1)
+if ! /usr/sbin/chroot /mnt/userfs /sbin/depmod -a "${RUNMODE_KERNEL_VERSION}"; then
+	exit 1
+fi
+
+# select the system settings for this target (only on install for persisted files)
+/usr/sbin/chroot /mnt/userfs /etc/natinst/niselectsystemsettings postinst
+
+# Hack for bug 975962, put /boot back to a+rw
+if [ "$arch" = "armv7l" ]; then
+	chmod 0777 /boot
+fi
+
+# Import NI signing key for subsequent opkg operations
+/usr/sbin/chroot /mnt/userfs/ opkg-key populate
+
+# Find the gpg-agent process launched as a result of the previous command under
+# /mnt/userfs and kill it to prevent a lock on the root file system (BUG 1107561)
+for pid in $(pidof gpg-agent); do
+	root_dir=$(readlink "/proc/${pid}/root")
+	if [ "$root_dir" = "/mnt/userfs" ]; then
+		kill ${pid}
+		break
+	fi
+done

--- a/recipes-core/images/files/nilrt-runmode-system-image.postinst
+++ b/recipes-core/images/files/nilrt-runmode-system-image.postinst
@@ -30,15 +30,21 @@ if grep -qs artemis /sys/firmware/devicetree/base/compatible ; then
 
     # configure the partitions to mount by label in fstab
     sed -i '/ubifs/d' /mnt/userfs/etc/fstab
-    echo LABEL=nibootfs         /boot                ext4       sync           0  0 >>/mnt/userfs/etc/fstab
-    echo LABEL=niconfig         /etc/natinst/share   ext4       sync           0  0 >>/mnt/userfs/etc/fstab
+    echo LABEL=nibootfs         /boot                ext4       sync           0  0 >> /mnt/userfs/etc/fstab
+    echo LABEL=niconfig         /etc/natinst/share   ext4       sync           0  0 >> /mnt/userfs/etc/fstab
     mkdir -p /etc/natinst/share
 
     # configure the path for fw_printenv to read environmental variables from u-boot
     # replace /dev/mtd4 and /dev/mtd5 with /boot/uboot/uboot.env
     sed -i '/mtd/d' /mnt/userfs/etc/fw_env.config
-    echo /boot/uboot/uboot.env         0x0000         0x20000 >>/mnt/userfs/etc/fw_env.config
+    echo /boot/uboot/uboot.env         0x0000         0x20000 >> /mnt/userfs/etc/fw_env.config
 
+fi
+
+if [ "$arch" = "x86_64" ]; then
+    echo "" >> /mnt/userfs/etc/fstab
+    echo LABEL=nibootfs         /boot                ext4       sync           0  0 >> /mnt/userfs/etc/fstab
+    echo LABEL=niconfig         /etc/natinst/share   ext4       sync           0  0 >> /mnt/userfs/etc/fstab
 fi
 
 arch="`uname -m`"

--- a/recipes-core/images/niconsole-image.inc
+++ b/recipes-core/images/niconsole-image.inc
@@ -52,8 +52,4 @@ ROOTFS_POSTPROCESS_COMMAND += "\
     install_additional_feeds; \
 "
 
-# on older NILRT distro flavors the kernel is installed in non-standard paths
-# for backward compatibility
-CUSTOM_KERNEL_PATH ?= "/boot/tmp/runmode/"
-
 require nilrt-image-common.inc

--- a/recipes-core/images/nilrt-dkms-image.bb
+++ b/recipes-core/images/nilrt-dkms-image.bb
@@ -21,4 +21,12 @@ IMAGE_INSTALL_NODEPS += "\
 # Ensure that rauc does not end up in this image.
 PACKAGE_EXCLUDE += "rauc rauc-mark-good"
 
+bootimg_fixup() {
+	# Postinst script is going to want this all in /boot/tmp/runmode
+	install -d `dirname "${IMAGE_ROOTFS}/${CUSTOM_KERNEL_PATH}"`
+	mv "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}" "${IMAGE_ROOTFS}/${CUSTOM_KERNEL_PATH}"
+}
+
+IMAGE_PREPROCESS_COMMAND += " bootimg_fixup; "
+
 IMAGE_FSTYPES += "squashfs tar.gz"

--- a/recipes-core/images/nilrt-dkms-image.bb
+++ b/recipes-core/images/nilrt-dkms-image.bb
@@ -21,6 +21,10 @@ IMAGE_INSTALL_NODEPS += "\
 # Ensure that rauc does not end up in this image.
 PACKAGE_EXCLUDE += "rauc rauc-mark-good"
 
+# on older NILRT distro flavors the kernel is installed in non-standard paths
+# for backward compatibility
+CUSTOM_KERNEL_PATH ?= "/boot/tmp/runmode"
+
 bootimg_fixup() {
 	# Postinst script is going to want this all in /boot/tmp/runmode
 	install -d `dirname "${IMAGE_ROOTFS}/${CUSTOM_KERNEL_PATH}"`

--- a/recipes-core/images/nilrt-dkms-image.bb
+++ b/recipes-core/images/nilrt-dkms-image.bb
@@ -18,4 +18,7 @@ IMAGE_INSTALL_NODEPS += "\
 	${NI_PROPRIETARY_RUNMODE_PACKAGES} \
 "
 
+# Ensure that rauc does not end up in this image.
+PACKAGE_EXCLUDE += "rauc rauc-mark-good"
+
 IMAGE_FSTYPES += "squashfs tar.gz"

--- a/recipes-core/images/nilrt-initramfs.inc
+++ b/recipes-core/images/nilrt-initramfs.inc
@@ -3,9 +3,9 @@ INITRAMFS_IMAGE = "niconsole-initramfs"
 do_rootfs[depends] += "${INITRAMFS_IMAGE}:do_image_complete"
 
 install_initramfs() {
-	install -d ${IMAGE_ROOTFS}${CUSTOM_KERNEL_PATH}
+	install -d ${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}
 	install -m 0644 ${DEPLOY_DIR_IMAGE}/${INITRAMFS_IMAGE}-${MACHINE}.cpio.gz \
-		${IMAGE_ROOTFS}${CUSTOM_KERNEL_PATH}/runmode_initramfs.gz
+		${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/runmode_initramfs.gz
 }
 
 ROOTFS_POSTPROCESS_COMMAND += "install_initramfs;"

--- a/recipes-core/images/nilrt-runmode-system-image.bb
+++ b/recipes-core/images/nilrt-runmode-system-image.bb
@@ -1,0 +1,49 @@
+DESCRIPTION = "NI LinuxRT Legacy-installed Image for x64 Targets"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+IMAGE_FSTYPES = "tar"
+IMAGE_NAME_SUFFIX = ""
+
+SRC_URI += " \
+    file://${BPN}.postinst \
+    file://${BPN}.cdf \
+"
+
+PV = "${DISTRO_VERSION}"
+
+CDFGUID = "4C0005F7-54D1-492B-A7E7-C1E58BD9B972"
+
+RAMDISK_IMAGE = "nilrt-dkms-image"
+do_rootfs[depends] += "${RAMDISK_IMAGE}:do_image_complete"
+
+bootimg_fixup() {
+	install -m 0644 "${DEPLOY_DIR_IMAGE}/${RAMDISK_IMAGE}-${MACHINE}.tar.gz" "${IMAGE_ROOTFS}/data.tar.gz"
+	install -m 0755 "${THISDIR}/files/${BPN}.postinst" "${IMAGE_ROOTFS}/postinst"
+
+	# Remove everything that is not data.tar.gz nor the postinst
+	find "${IMAGE_ROOTFS}" -mindepth 1 \
+		-not -path "${IMAGE_ROOTFS}/data.tar.gz" \
+		-a -not -path "${IMAGE_ROOTFS}/postinst" \
+		-delete
+}
+
+# TODO: We're doing CDF generation here. The CDF encodes the filename of the
+#       .tar. However, we're not generating it with the same name that we
+#       used to ("systemlink-linux-x64-dkms.tar"); is having these artifacts
+#       with a new name fine?
+create_cdf() {
+	CDFOUT="${DEPLOY_DIR_IMAGE}/${IMAGE_BASENAME}-${MACHINE}${IMAGE_NAME_SUFFIX}.cdf"
+	install -m 0644 "${THISDIR}/files/${BPN}.cdf" $CDFOUT
+
+	GUID="{${CDFGUID}}"
+	SHORTVER=$(echo ${BUILDNAME} | sed 's/^\([0-9.]*\).*/\1/;')
+	TARFILE="${IMAGE_BASENAME}-${MACHINE}${IMAGE_NAME_SUFFIX}.tar"
+
+	sed -i "s/%guid%/$GUID/g; s/%version%/$SHORTVER/g; s/%filename%/$TARFILE/g;" $CDFOUT
+}
+
+IMAGE_PREPROCESS_COMMAND += "bootimg_fixup;"
+IMAGE_POSTPROCESS_COMMAND += "create_cdf;"
+
+inherit image

--- a/recipes-core/images/nilrt-safemode-image.bb
+++ b/recipes-core/images/nilrt-safemode-image.bb
@@ -23,8 +23,6 @@ IMAGE_INSTALL += "\
 RAMDISK_IMAGE = "nilrt-safemode-ramdisk"
 do_rootfs[depends] += "${RAMDISK_IMAGE}:do_image_complete"
 
-CUSTOM_KERNEL_PATH ?= "/boot/runmode"
-
 bootimg_fixup() {
 	install -m 0644 "${DEPLOY_DIR_IMAGE}/${RAMDISK_IMAGE}-${MACHINE}.cpio.xz" "${IMAGE_ROOTFS}/boot/ramdisk.xz"
 
@@ -42,9 +40,9 @@ bootimg_fixup() {
 	# The kernel was installed with a symbolic link from 'bzImage'
 	# to the actual versioned file. Remove the redirection so that
 	# we just have a 'bzImage'
-	mv "$(realpath ${IMAGE_ROOTFS}/${CUSTOM_KERNEL_PATH}/bzImage)" "${IMAGE_ROOTFS}/${CUSTOM_KERNEL_PATH}/bzImage.real"
+	mv "$(realpath ${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/bzImage)" "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/bzImage.real"
 	rm -f "${IMAGE_ROOTFS}/boot/bzImage"
-	mv "${IMAGE_ROOTFS}/${CUSTOM_KERNEL_PATH}/bzImage.real" "${IMAGE_ROOTFS}/boot/bzImage"
+	mv "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/bzImage.real" "${IMAGE_ROOTFS}/boot/bzImage"
 
 	install -m 0644 "${THISDIR}/files/bootimage.ini" "${IMAGE_ROOTFS}/boot/bootimage.ini"
 	sed -i "s/%component_version%/${BUILDNAME}/" "${IMAGE_ROOTFS}/boot/bootimage.ini"


### PR DESCRIPTION
This contains remaining changes from Brenda's branch with some modifications.
Also moved CUSTOM_KERNEL_PATH into nilrt-dkms-image and replaced it in nilrt-safemode-image.

### Testing
Built nilrt_dkms_image and /boot directory structure of the image looks good (all runmode files end up in /boot/tmp/runmode). Image itself wasn't tested.

![image](https://user-images.githubusercontent.com/8194523/138322713-7c262e10-143c-441b-bfb8-f189b81c2eeb.png)


@ni/rtos 
