### PR TITLE
Move bootimage.ini into its own recipe

### DIFF
--- a/recipes-core/images/nilrt-dkms-image.bb
+++ b/recipes-core/images/nilrt-dkms-image.bb
@@ -1,5 +1,9 @@
 DESCRIPTION = "Runmode image for ethernet-based NI Linux Real-Time targets running XFCE (DKMS)."
 
+SRC_URI += "\
+	file://bootimage.ini \
+"
+
 IMAGE_INSTALL = "\
 	packagegroup-ni-runmode \
 	packagegroup-ni-wifi \
@@ -26,6 +30,9 @@ PACKAGE_EXCLUDE += "rauc rauc-mark-good"
 CUSTOM_KERNEL_PATH ?= "/boot/tmp/runmode"
 
 bootimg_fixup() {
+	install -m 0644 "${THISDIR}/files/bootimage.ini" "${IMAGE_ROOTFS}/boot/runmode/bootimage.ini"
+	sed -i "s/%component_version%/${BUILDNAME}/" "${IMAGE_ROOTFS}/boot/runmode/bootimage.ini"
+
 	# Postinst script is going to want this all in /boot/tmp/runmode
 	install -d `dirname "${IMAGE_ROOTFS}/${CUSTOM_KERNEL_PATH}"`
 	mv "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}" "${IMAGE_ROOTFS}/${CUSTOM_KERNEL_PATH}"


### PR DESCRIPTION
Add bootimage.ini to nilrt-dkms-image

### Testing
Verified `nilrt-dkms-image` contains `bootimage.ini` in `/boot/tmp/runmode`
Verified `nilrt-runmode-system-image.tar` can be installed from MAX and we can boot into runmode

@ni/rtos 