### PR TITLE
runmode.postinst: Move fstab related code

### DIFF
--- a/recipes-core/images/files/nilrt-runmode-system-image.postinst
+++ b/recipes-core/images/files/nilrt-runmode-system-image.postinst
@@ -41,15 +41,15 @@ if grep -qs artemis /sys/firmware/devicetree/base/compatible ; then
 
 fi
 
+arch="`uname -m`"
+mount_point="/boot"
+class="`/sbin/fw_printenv -n TargetClass`"
+
 if [ "$arch" = "x86_64" ]; then
     echo "" >> /mnt/userfs/etc/fstab
     echo LABEL=nibootfs         /boot                ext4       sync           0  0 >> /mnt/userfs/etc/fstab
     echo LABEL=niconfig         /etc/natinst/share   ext4       sync           0  0 >> /mnt/userfs/etc/fstab
 fi
-
-arch="`uname -m`"
-mount_point="/boot"
-class="`/sbin/fw_printenv -n TargetClass`"
 
 if [ "$arch" = "armv7l" ]; then
 	kernel="/mnt/userfs/boot/tmp/linux_runmode.itb"


### PR DESCRIPTION
Some fstab code that was arch dependent was being run before $arch was
defined. Moved after the definition.

### Testing
Verified fstab on VM provisioned with runmode contains arch-dependent code.

@ni/rtos 