### PR TITLE
Update git:// fetch GitHub URLs to https:// URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,42 +5,42 @@ This layer provides support for the NI Linux Real-Time distribution. The NI Linu
 
 This layer depends on:
 
-URI: git://github.com/ni/openembedded-core.git
+URI: https://github.com/ni/openembedded-core.git
 branch: nilrt/comms-2.0/fido
 revision: HEAD
 
-URI: git://github.com/ni/meta-oe.git
+URI: https://github.com/ni/meta-oe.git
 layers: meta-oe, meta-gnome, meta-xfce, meta-networking, meta-webserver, meta-filesystems,
 meta-perl, meta-python
 branch: nilrt/comms-2.0/fido
 revision: HEAD
 
-URI: git://github.com/ni/meta-cloud-services.git
+URI: https://github.com/ni/meta-cloud-services.git
 layers: meta-openstack
 branch: nilrt/comms-2.0/fido
 revision: HEAD
 
-URI: git://github.com/ni/meta-selinux.git
+URI: https://github.com/ni/meta-selinux.git
 branch: nilrt/comms-2.0/fido
 revision: HEAD
 
-URI: git://github.com/ni/meta-virtualization.git
+URI: https://github.com/ni/meta-virtualization.git
 branch: nilrt/comms-2.0/fido
 revision: HEAD
 
-URI: git://github.com/ni/meta-mono.git
+URI: https://github.com/ni/meta-mono.git
 branch: nilrt/comms-2.0/fido
 revision: HEAD
 
-URI: git://github.com/ni/meta-security.git
+URI: https://github.com/ni/meta-security.git
 branch: nilrt/comms-2.0/fido
 revision: HEAD
 
-URI: git://github.com/ni/meta-sdr.git
+URI: https://github.com/ni/meta-sdr.git
 branch: nilrt/comms-2.0/fido
 revision: HEAD
 
-URI: git://github.com/ni/meta-java.git
+URI: https://github.com/ni/meta-java.git
 branch: nilrt/comms-2.0/fido
 revision: HEAD
 

--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -129,7 +129,7 @@ RRECOMMENDS_libdevmapper_remove_class-target = "lvm2-udevrules"
 BBMASK += "meta-cloud-services/meta-openstack/recipes-kernel"
 
 # Base URI to NI Linux RT's Git repository
-NILRT_GIT ?= "git://github.com/ni"
+NILRT_GIT ?= "https://github.com/ni"
 
 # Creates ``*-lic`` subpackages for all OE recipes if enabled
 LICENSE_CREATE_PACKAGE ?= "1"

--- a/recipes-connectivity/crda/crda_1.1.3.bb
+++ b/recipes-connectivity/crda/crda_1.1.3.bb
@@ -12,7 +12,7 @@ RDEPENDS_${PN} = "\
 
 S = "${WORKDIR}/git"
 
-SRC_URI = "git://github.com/mcgrof/crda.git;protocol=git;tag=v1.1.3"
+SRC_URI = "https://github.com/mcgrof/crda.git;protocol=git;tag=v1.1.3"
 
 CFLAGS_append =" -DCONFIG_LIBNL32 -I${STAGING_INCDIR}/libnl3"
 LDFLAGS_append =" -lnl-3 -lnl-genl-3 -lm"

--- a/recipes-connectivity/salt/salt_2018.3.%.bbappend
+++ b/recipes-connectivity/salt/salt_2018.3.%.bbappend
@@ -2,7 +2,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=c996f5a78d858a52c894fa3f4bec68c1"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI = "git://github.com/ni/salt.git;branch=ni/master/2018.3 \
+SRC_URI = "https://github.com/ni/salt.git;branch=ni/master/2018.3 \
            file://set_python_location_hashbang.patch \
            file://minion \
            file://salt-minion \

--- a/recipes-devtools/libfmi/libfmi_git.bb
+++ b/recipes-devtools/libfmi/libfmi_git.bb
@@ -2,7 +2,7 @@ DESCRIPTION="FMI Library (FMIL) is a software package written in C that enables 
 HOMEPAGE = "https://github.com/svn2github/FMILibrary"
 SECTION = "libs"
 
-SRC_URI = "git://github.com/svn2github/FMILibrary.git"
+SRC_URI = "https://github.com/svn2github/FMILibrary.git"
 SRCREV = "d49ed3ff2dabc6e17cc4a0c6f3fa6d2ae64a1683"
 
 S = "${WORKDIR}/git"

--- a/recipes-rt/librtpi/librtpi_0.0.1.bb
+++ b/recipes-rt/librtpi/librtpi_0.0.1.bb
@@ -6,7 +6,7 @@ LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1803fa9c2c3ce8cb06b4861d75310742"
 
 SRC_URI = "\
-	git://github.com/gratian/librtpi.git;branch=ni/latest \
+	https://github.com/gratian/librtpi.git;branch=ni/latest \
 	file://librtpi-use-serial-tests-config-needed-by-ptest.patch \
 	file://run-ptest \
 "


### PR DESCRIPTION
GitHub is deprecating the git:// fetch protocol and is currently
enforcing a brownout causing all git:// fetches to fail.
https://github.blog/2021-09-01-improving-git-protocol-security-github/
@ni/rtos 