### PR TITLE
fixup! Update git:// fetch GitHub URLs to https:// URLs

### DIFF
--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -125,7 +125,7 @@ RRECOMMENDS_libdevmapper_remove_class-target = "lvm2-udevrules"
 BBMASK += "meta-cloud-services/meta-openstack/recipes-kernel"
 
 # Base URI to NI Linux RT's Git repository
-NILRT_GIT ?= "https://github.com/ni"
+NILRT_GIT ?= "git://github.com/ni"
 
 # Creates ``*-lic`` subpackages for all OE recipes if enabled
 LICENSE_CREATE_PACKAGE ?= "1"

--- a/recipes-connectivity/crda/crda_1.1.3.bb
+++ b/recipes-connectivity/crda/crda_1.1.3.bb
@@ -12,7 +12,7 @@ RDEPENDS_${PN} = "\
 
 S = "${WORKDIR}/git"
 
-SRC_URI = "https://github.com/mcgrof/crda.git;protocol=git;tag=v1.1.3"
+SRC_URI = "git://github.com/mcgrof/crda.git;protocol=https;tag=v1.1.3"
 
 CFLAGS_append =" -DCONFIG_LIBNL32 -I${STAGING_INCDIR}/libnl3"
 LDFLAGS_append =" -lnl-3 -lnl-genl-3 -lm"

--- a/recipes-devtools/libfmi/libfmi_git.bb
+++ b/recipes-devtools/libfmi/libfmi_git.bb
@@ -2,7 +2,7 @@ DESCRIPTION="FMI Library (FMIL) is a software package written in C that enables 
 HOMEPAGE = "https://github.com/svn2github/FMILibrary"
 SECTION = "libs"
 
-SRC_URI = "https://github.com/svn2github/FMILibrary.git"
+SRC_URI = "git://github.com/svn2github/FMILibrary.git;protocol=https"
 SRCREV = "d49ed3ff2dabc6e17cc4a0c6f3fa6d2ae64a1683"
 
 S = "${WORKDIR}/git"

--- a/recipes-extended/lsb/lsbinitscripts_10.04.bb
+++ b/recipes-extended/lsb/lsbinitscripts_10.04.bb
@@ -11,7 +11,7 @@ RCONFLICTS_${PN} = "initscripts-functions"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 S = "${WORKDIR}/git"
-SRC_URI = "https://github.com/fedora-sysv/initscripts"
+SRC_URI = "git://github.com/fedora-sysv/initscripts;protocol=https"
 SRCREV = "d2243a0912bbad57b1b413f2c15599341cb2aa76"
 UPSTREAM_CHECK_GITTAGREGEX = "^(?P<pver>\d+(\.\d+)+)"
 

--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -38,7 +38,7 @@ INHIBIT_PACKAGE_DEBUG_SPLIT="1"
 do_kernel_configme[depends] += "libgcc:do_populate_sysroot"
 
 SRC_URI = "\
-	${NILRT_GIT}/${GIT_KERNEL_REPO};protocol=git;nocheckout=1;branch=${KBRANCH} \
+	${NILRT_GIT}/${GIT_KERNEL_REPO};protocol=https;nocheckout=1;branch=${KBRANCH} \
 	file://export-kernel-headers.sh \
 "
 # Generically use the *latest* rev from the kernel source branch, if none is

--- a/recipes-ni/ni-grpc-device/ni-grpc-device_git.bb
+++ b/recipes-ni/ni-grpc-device/ni-grpc-device_git.bb
@@ -20,7 +20,7 @@ DEPENDS += "\
 PV = "1.1.0"
 
 SRC_URI = "\
-	https://github.com/ni/grpc-device.git;name=grpc-device;branch=${SRCBRANCH} \
+	git://github.com/ni/grpc-device.git;name=grpc-device;branch=${SRCBRANCH};protocol=https \
 	file://0001-CMakeLists.txt-remove-local-protobuf-includes.patch \
 	file://ptest \
 "

--- a/recipes-rt/librtpi/librtpi_0.0.1.bb
+++ b/recipes-rt/librtpi/librtpi_0.0.1.bb
@@ -6,7 +6,7 @@ LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1803fa9c2c3ce8cb06b4861d75310742"
 
 SRC_URI = "\
-	https://github.com/gratian/librtpi.git;branch=ni/latest \
+	git://github.com/gratian/librtpi.git;protocol=https;branch=ni/latest \
 	file://librtpi-use-serial-tests-config-needed-by-ptest.patch \
 	file://run-ptest \
 "

--- a/recipes-security/refpolicy/refpolicy-ni.inc
+++ b/recipes-security/refpolicy/refpolicy-ni.inc
@@ -1,4 +1,4 @@
-SRC_URI = "${NILRT_GIT}/ni-refpolicy.git;branch=nilrt/17.0/krogoth \
+SRC_URI = "${NILRT_GIT}/ni-refpolicy.git;branch=nilrt/17.0/krogoth;protocol=https \
            file://customizable_types \
            file://setrans-mls.conf \
            file://setrans-mcs.conf \


### PR DESCRIPTION
Updating git:// URLs to https:// does not work as expected in OE.
Instead, keep the git:// URL and add/modify the protocol entry in
the SRC_URI to https.

TLDR summary: I messed up.
This time I verified that `bitbake fetch` works on all the recipes I modified. Sumo changes to follow.

@ni/rtos 
