### PR TITLE
fixup! Update git:// fetch GitHub URLs to https:// URLs - sumo

### DIFF
--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -129,7 +129,7 @@ RRECOMMENDS_libdevmapper_remove_class-target = "lvm2-udevrules"
 BBMASK += "meta-cloud-services/meta-openstack/recipes-kernel"
 
 # Base URI to NI Linux RT's Git repository
-NILRT_GIT ?= "https://github.com/ni"
+NILRT_GIT ?= "git://github.com/ni"
 
 # Creates ``*-lic`` subpackages for all OE recipes if enabled
 LICENSE_CREATE_PACKAGE ?= "1"

--- a/recipes-bsp/grub/grub-nilrt.inc
+++ b/recipes-bsp/grub/grub-nilrt.inc
@@ -4,7 +4,7 @@ PV = "2.02+git${SRCPV}"
 SRCREV = "61a02ce279575ea846e6ee7f8c9fb686fd54328c"
 
 SRC_URI = "\
-	${NILRT_GIT}/grub.git;branch=${GRUB_BRANCH} \
+	${NILRT_GIT}/grub.git;branch=${GRUB_BRANCH};protocol=https \
 	file://grub.cfg \
 	file://cfg \
 	file://grub.d \

--- a/recipes-bsp/u-boot/nilrt-u-boot.inc
+++ b/recipes-bsp/u-boot/nilrt-u-boot.inc
@@ -14,5 +14,5 @@ LIC_FILES_CHKSUM = "\
 	file://Licenses/x11.txt;md5=b46f176c847b8742db02126fb8af92e2; \
 "
 
-SRC_URI = "${NILRT_GIT}/u-boot.git;protocol=git;branch=${UBOOT_BRANCH}"
+SRC_URI = "${NILRT_GIT}/u-boot.git;protocol=https;branch=${UBOOT_BRANCH}"
 SRCREV = "653fc09e01ff78e08f9683e1585f4fac05f289d9"

--- a/recipes-connectivity/crda/crda_1.1.3.bb
+++ b/recipes-connectivity/crda/crda_1.1.3.bb
@@ -12,7 +12,7 @@ RDEPENDS_${PN} = "\
 
 S = "${WORKDIR}/git"
 
-SRC_URI = "https://github.com/mcgrof/crda.git;protocol=git;tag=v1.1.3"
+SRC_URI = "git://github.com/mcgrof/crda.git;protocol=https;tag=v1.1.3"
 
 CFLAGS_append =" -DCONFIG_LIBNL32 -I${STAGING_INCDIR}/libnl3"
 LDFLAGS_append =" -lnl-3 -lnl-genl-3 -lm"

--- a/recipes-connectivity/salt/salt_2018.3.%.bbappend
+++ b/recipes-connectivity/salt/salt_2018.3.%.bbappend
@@ -2,7 +2,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=c996f5a78d858a52c894fa3f4bec68c1"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI = "https://github.com/ni/salt.git;branch=ni/master/2018.3 \
+SRC_URI = "git://github.com/ni/salt.git;protocol=https;branch=ni/master/2018.3 \
            file://set_python_location_hashbang.patch \
            file://minion \
            file://salt-minion \

--- a/recipes-devtools/libfmi/libfmi_git.bb
+++ b/recipes-devtools/libfmi/libfmi_git.bb
@@ -2,7 +2,7 @@ DESCRIPTION="FMI Library (FMIL) is a software package written in C that enables 
 HOMEPAGE = "https://github.com/svn2github/FMILibrary"
 SECTION = "libs"
 
-SRC_URI = "https://github.com/svn2github/FMILibrary.git"
+SRC_URI = "git://github.com/svn2github/FMILibrary.git;protocol=https"
 SRCREV = "d49ed3ff2dabc6e17cc4a0c6f3fa6d2ae64a1683"
 
 S = "${WORKDIR}/git"

--- a/recipes-rt/librtpi/librtpi_0.0.1.bb
+++ b/recipes-rt/librtpi/librtpi_0.0.1.bb
@@ -6,7 +6,7 @@ LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1803fa9c2c3ce8cb06b4861d75310742"
 
 SRC_URI = "\
-	https://github.com/gratian/librtpi.git;branch=ni/latest \
+	git://github.com/gratian/librtpi.git;branch=ni/latest;protocol=https \
 	file://librtpi-use-serial-tests-config-needed-by-ptest.patch \
 	file://run-ptest \
 "

--- a/recipes-security/refpolicy/refpolicy-ni.inc
+++ b/recipes-security/refpolicy/refpolicy-ni.inc
@@ -1,4 +1,4 @@
-SRC_URI = "${NILRT_GIT}/ni-refpolicy.git;branch=nilrt/17.0/krogoth \
+SRC_URI = "${NILRT_GIT}/ni-refpolicy.git;branch=nilrt/17.0/krogoth;protocol=https \
            file://customizable_types \
            file://setrans-mls.conf \
            file://setrans-mcs.conf \

--- a/recipes-tpm/tpm2-tools/tpm2-tools_git.bbappend
+++ b/recipes-tpm/tpm2-tools/tpm2-tools_git.bbappend
@@ -1,6 +1,6 @@
 DEFAULT_PREFERENCE = "1"
 
-SRC_URI = "${NILRT_GIT}/tpm2-tools.git;branch=nilrt/18.1"
+SRC_URI = "${NILRT_GIT}/tpm2-tools.git;branch=nilrt/18.1;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-tpm/tpm2-tss/tpm2-tss_git.bbappend
+++ b/recipes-tpm/tpm2-tss/tpm2-tss_git.bbappend
@@ -1,2 +1,2 @@
 DEFAULT_PREFERENCE = "1"
-SRC_URI = "${NILRT_GIT}/tpm2-tss.git;protocol=git;branch=nilrt/18.0;name=${BPN};destsuffix=${BPN}"
+SRC_URI = "${NILRT_GIT}/tpm2-tss.git;protocol=https;branch=nilrt/18.0;name=${BPN};destsuffix=${BPN}"


### PR DESCRIPTION
Updating git:// URLs to https:// does not work as expected in OE.
Instead, keep the git:// URL and add/modify the protocol entry in
the SRC_URIs to https.
I verified that bitbake fetch works on all the recipes I modified.

@ni/rtos 