### PR TITLE
nilrt-proprietary: Add ni-wif-landingpage

### DIFF
--- a/recipes-core/images/nilrt-proprietary.inc
+++ b/recipes-core/images/nilrt-proprietary.inc
@@ -35,6 +35,7 @@ NI_PROPRIETARY_COMMON_PACKAGES += "\
         ni-webdav-system-webserver-support \
         ni-webserver-libs \
         ni-webservices-webserver-support \
+        ni-wif-landingpage \
         ni-wifibledd \
         ni-wireless-ath6kl \
         ni-wireless-cert-storage \


### PR DESCRIPTION
ni-wif-landingpage provides the new read-only web landing page
replacing the previous Silverlight-based page. This package is
required in safemode and runmode.

@ni/rtos 