### PR TITLE
Use local safemode for safemode-restore-image

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-restoremode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-restoremode.bb
@@ -36,10 +36,12 @@ RDEPENDS_${PN}_append_x64 = "\
     efivar              \
     fw-printenv         \
     grub                \
+    grub-efi            \
     grub-editenv        \
     eudev               \
     ni-smbios-helper    \
     nilrtdiskcrypt      \
+    safemode-image      \
     "
 
 RDEPENDS_${PN}_append_xilinx-zynqhf = "\

--- a/recipes-org/images/safemode-image.bb
+++ b/recipes-org/images/safemode-image.bb
@@ -10,31 +10,13 @@ SRC_URI = "\
 RDEPENDS_${PN} += "grub-efi grub"
 COMPATIBLE_MACHINE = "x64"
 
-inherit build-services
-# optional env var with path to local safemode tar.gz
-export SAFEMODE_PAYLOAD_PATH
-EXPORTS_TO_FETCH = "$EXPORTS_TO_FETCH"
-
-do_fetch_prepend() {
-        mkdir -p ${BS_EXPORT_DATA}
-
-        if [ -z "$SAFEMODE_PAYLOAD_PATH" ]; then
-                EXPORTS_TO_FETCH=$(bs_get_latest_export "nilinux/os-common/export/8.0")"/standard_x64_safemode.tar.gz"
-                SAFEMODE_PAYLOAD=$EXPORTS_TO_FETCH
-        else
-                SAFEMODE_PAYLOAD="${SAFEMODE_PAYLOAD_PATH}/standard_x64_safemode.tar.gz"
-                cp -f "$SAFEMODE_PAYLOAD" ${BS_EXPORT_DATA}
-        fi
-
-        echo SAFEMODE_PAYLOAD=$SAFEMODE_PAYLOAD >${BS_EXPORT_DATA}/safemode_version_info
-        echo SAFEMODE_MAJOR_VERSION=`echo $SAFEMODE_PAYLOAD |egrep -o "\/[0-9]+\.[0-9]+\/" |tr -d "/"` >>${BS_EXPORT_DATA}/safemode_version_info
-        echo SAFEMODE_MINOR_VERSION=`echo $SAFEMODE_PAYLOAD |egrep -o "\/[0-9]+\.[0-9]+.[0-9]+[abdf][0-9]+\/" |tr -d "/"` >>${BS_EXPORT_DATA}/safemode_version_info
-}
+SAFEMODE_IMAGE = "nilrt-safemode-image"
+do_rootfs[depends] += "${SAFEMODE_IMAGE}:do_image_complete"
 
 do_install() {
 	mkdir -p ${D}/payload/fonts
 
-	tar -xf "${BS_EXPORT_DATA}/standard_x64_safemode.tar.gz" -C ${D}/payload
+	tar -xf "${DEPLOY_DIR_IMAGE}/${SAFEMODE_IMAGE}-${MACHINE}.tar.gz" -C ${D}/payload
 
 	cp ${WORKDIR}/grubenv_non_ni_target	${D}/payload
 	cp ${WORKDIR}/unicode.pf2		${D}/payload/fonts
@@ -44,15 +26,6 @@ do_install() {
 	echo "BUILD_IDENTIFIER=${BUILD_IDENTIFIER}" > ${D}/payload/imageinfo
 	echo "GRUB_VERSION=${GRUB_VERSION}.0" >> ${D}/payload/imageinfo
 }
-
-sysroot_stage_all_append() {
-        install -m 0755 ${BS_EXPORT_DATA}/safemode_version_info ${SYSROOT_DESTDIR}
-}
-
-# always invalidate the sstate-cache for do_install and do_fetch as we depend on an external
-# file (standard_x64_safemode.tar.gz) which is not cached as part of sstate
-do_fetch[nostamp] = "1"
-do_install[nostamp] = "1"
 
 FILES_${PN} = "\
 	/payload \


### PR DESCRIPTION
Previously we used to get safemode from feeds to build
safemode-restore-image. Change this so we use locally built safemode.

Also added grub-efi and safemode-image to packagegroup-ni-restoremode.

### Testing
`bitbake packagegroup-ni-coreimagerepo`
`bitbake pacakge-index`
`bitbake safemode-restore-image`

Validated that created .wic file can be used to provision NI Linux RT on a VM and that the VM boots into safemode after.

We will probably want to move these recipes into recipes-core/images and do more cleanup later as described in [this work item](https://ni.visualstudio.com/DevCentral/_workitems/edit/1604743). For now I just wanted to build a restoremode image for the VM work.

@ni/rtos 