### PR TITLE
packagegroup-ni-restoremode: Remove safemode-image

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-restoremode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-restoremode.bb
@@ -41,7 +41,6 @@ RDEPENDS_${PN}_append_x64 = "\
     eudev               \
     ni-smbios-helper    \
     nilrtdiskcrypt      \
-    safemode-image      \
     "
 
 RDEPENDS_${PN}_append_xilinx-zynqhf = "\


### PR DESCRIPTION
safemode-image depends on nilrt-safemode-image which we build
after package feeds are built. But if safemode-image is in
a packagegroup there is a circular dependency.

So removing it to fix this.

@ni/rtos 