### PR TITLE
nilrt-safemode-image: Clean up runmode directory

### DIFF
--- a/recipes-core/images/nilrt-safemode-image.bb
+++ b/recipes-core/images/nilrt-safemode-image.bb
@@ -43,6 +43,7 @@ bootimg_fixup() {
 	mv "$(realpath ${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/bzImage)" "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/bzImage.real"
 	rm -f "${IMAGE_ROOTFS}/boot/bzImage"
 	mv "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/bzImage.real" "${IMAGE_ROOTFS}/boot/bzImage"
+	rm -rf "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}"
 
 	install -m 0644 "${THISDIR}/files/bootimage.ini" "${IMAGE_ROOTFS}/boot/bootimage.ini"
 	sed -i "s/%component_version%/${BUILDNAME}/" "${IMAGE_ROOTFS}/boot/bootimage.ini"


### PR DESCRIPTION
The kernel recipe installs the kernel in a runmode directory in the
safemode image. We later move the kernel to the parent directory, but
leave behind an empty symlink in the runmode directory.
Clean up this runmode directory by removing it entirely.

Before changes:
![image](https://user-images.githubusercontent.com/62362030/142058420-a4ef28f2-1496-4d19-b9bf-d48884f7fa04.png)

After changes:
![image](https://user-images.githubusercontent.com/62362030/142058328-239870be-606d-4372-ab0f-a7b61eeb7c5c.png)

@ni/rtos 