### PR TITLE
restore-mode: Add Hyper-V drivers

### DIFF
--- a/recipes-core/initrdscripts/files/init-restore-mode.sh
+++ b/recipes-core/initrdscripts/files/init-restore-mode.sh
@@ -101,6 +101,11 @@ if [[ $ARCH == "x86_64" ]]; then
 	# support VMWare image keyboard
 	modprobe atkbd 2> /dev/null
 	modprobe i8042 2> /dev/null
+	modprobe hv_vmbus 2> /dev/null
+	modprobe hv_balloon 2> /dev/null
+	modprobe hv_storvsc 2> /dev/null
+	modprobe hv_utils 2> /dev/null
+	modprobe hyperv-keyboard 2> /dev/null
 	remove_bootmode 2> /dev/null
 fi
 

--- a/recipes-core/packagegroups/packagegroup-ni-restoremode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-restoremode.bb
@@ -51,5 +51,10 @@ RDEPENDS_${PN}_append_xilinx-zynqhf = "\
 RRECOMMENDS_${PN}_x64 = "\
     kernel-module-tpm-tis \
     kernel-module-atkbd   \
+    kernel-module-hyperv-keyboard \
+    kernel-module-hv-storvsc \
+    kernel-module-hv-vmbus \
+    kernel-module-hv-utils \
+    kernel-module-hv-balloon \
     kernel-module-i8042   \
 "


### PR DESCRIPTION
Add drivers required for hyper-v support to restore-mode

### Testing
Verified recovery iso built with these changes works on Hyper-V.

@ni/rtos 