### PR TITLE
opkg: pull patches from upstream (hardknott)

### DIFF
--- a/recipes-devtools/opkg/files/0001-opkg_archive-output-libarchive-s-errno-wherever-we-o.patch
+++ b/recipes-devtools/opkg/files/0001-opkg_archive-output-libarchive-s-errno-wherever-we-o.patch
@@ -1,0 +1,274 @@
+From 16661219298dbe5938a8b34233afdb146a22d593 Mon Sep 17 00:00:00 2001
+From: Brenda Streiff <brenda.streiff@ni.com>
+Date: Fri, 5 Nov 2021 10:55:39 -0500
+Subject: [PATCH] opkg_archive: output libarchive's errno wherever we output a
+ string
+To: opkg-devel@googlegroups.com
+
+libarchive has both "archive_error_string" and "archive_errno" methods;
+the latter can provide greater detail. For instance, libarchive's
+"file_open" will set the error to a string of "Failed to open '%s'",
+but also set the errno value to the errno from the underlying open()
+call, which can provide a bit more detail, like if we failed due to
+ENOENT or ENOSPC, etc.
+
+This patch adds archive_errno reporting to every msg in opkg_archive.c
+where we are already returning the archive_error_string.
+
+Signed-off-by: Brenda Streiff <brenda.streiff@ni.com>
+Upstream-Status: Accepted [https://groups.google.com/g/opkg-devel/c/Df2N5Tf2uMk]
+---
+ libopkg/opkg_archive.c | 101 +++++++++++++++++++++--------------------
+ 1 file changed, 53 insertions(+), 48 deletions(-)
+
+diff --git a/libopkg/opkg_archive.c b/libopkg/opkg_archive.c
+index 1045a6c..03a4afb 100644
+--- a/libopkg/opkg_archive.c
++++ b/libopkg/opkg_archive.c
+@@ -97,13 +97,13 @@ static size_t read_data(struct archive *a, void *buffer, size_t len, int *eof)
+         /* We don't know the size read so we have to treat this
+          * as an error.
+          */
+-        opkg_msg(ERROR, "Warning when reading data from archive: %s\n",
+-                 archive_error_string(a));
++        opkg_msg(ERROR, "Warning when reading data from archive: %s (errno=%d)\n",
++                 archive_error_string(a), archive_errno(a));
+         return 0;
+ 
+     case ARCHIVE_RETRY:
+-        opkg_msg(ERROR, "Failed to read data from archive: %s\n",
+-                 archive_error_string(a));
++        opkg_msg(ERROR, "Failed to read data from archive: %s (errno=%d)\n",
++                 archive_error_string(a), archive_errno(a));
+         if (retries++ < 3) {
+             opkg_msg(NOTICE, "Retrying...");
+             goto retry;
+@@ -111,8 +111,8 @@ static size_t read_data(struct archive *a, void *buffer, size_t len, int *eof)
+             return 0;
+ 
+     default:
+-        opkg_msg(ERROR, "Failed to read data from archive: %s\n",
+-                 archive_error_string(a));
++        opkg_msg(ERROR, "Failed to read data from archive: %s (errno=%d)\n",
++                 archive_error_string(a), archive_errno(a));
+         return 0;
+     }
+ }
+@@ -269,8 +269,8 @@ static struct archive_entry *read_header(struct archive *ar, int *eof)
+         break;
+ 
+     case ARCHIVE_WARN:
+-        opkg_msg(NOTICE, "Warning when reading ar archive header: %s\n",
+-                 archive_error_string(ar));
++        opkg_msg(NOTICE, "Warning when reading ar archive header: %s (errno=%d)\n",
++                 archive_error_string(ar), archive_errno(ar));
+         break;
+ 
+     case ARCHIVE_EOF:
+@@ -279,16 +279,16 @@ static struct archive_entry *read_header(struct archive *ar, int *eof)
+         return NULL;
+ 
+     case ARCHIVE_RETRY:
+-        opkg_msg(ERROR, "Failed to read archive header: %s\n",
+-                 archive_error_string(ar));
++        opkg_msg(ERROR, "Failed to read archive header: %s (errno=%d)\n",
++                 archive_error_string(ar), archive_errno(ar));
+         if (retries++ < 3)
+             goto retry;
+         else
+             return NULL;
+ 
+     default:
+-        opkg_msg(ERROR, "Failed to read archive header: %s\n",
+-                 archive_error_string(ar));
++        opkg_msg(ERROR, "Failed to read archive header: %s (errno=%d)\n",
++                 archive_error_string(ar), archive_errno(ar));
+         return NULL;
+     }
+ 
+@@ -370,22 +370,22 @@ static struct archive *open_disk(int flags)
+ 
+     r = archive_write_disk_set_options(disk, flags);
+     if (r == ARCHIVE_WARN)
+-        opkg_msg(NOTICE, "Warning when setting disk options: %s\n",
+-                 archive_error_string(disk));
++        opkg_msg(NOTICE, "Warning when setting disk options: %s (errno=%d)\n",
++                 archive_error_string(disk), archive_errno(disk));
+     else if (r != ARCHIVE_OK) {
+-        opkg_msg(ERROR, "Failed to set disk options: %s\n",
+-                 archive_error_string(disk));
++        opkg_msg(ERROR, "Failed to set disk options: %s (errno=%d)\n",
++                 archive_error_string(disk), archive_errno(disk));
+         goto err_cleanup;
+     }
+ 
+     r = archive_write_disk_set_standard_lookup(disk);
+     if (r == ARCHIVE_WARN)
+         opkg_msg(NOTICE,
+-                 "Warning when setting user/group lookup functions: %s\n",
+-                 archive_error_string(disk));
++                 "Warning when setting user/group lookup functions: %s (errno=%d)\n",
++                 archive_error_string(disk), archive_errno(disk));
+     else if (r != ARCHIVE_OK) {
+-        opkg_msg(ERROR, "Failed to set user/group lookup functions: %s\n",
+-                 archive_error_string(disk));
++        opkg_msg(ERROR, "Failed to set user/group lookup functions: %s (errno=%d)\n",
++                 archive_error_string(disk), archive_errno(disk));
+         goto err_cleanup;
+     }
+ 
+@@ -425,13 +425,15 @@ static int extract_entry(struct archive *a, struct archive_entry *entry,
+         break;
+ 
+     case ARCHIVE_WARN:
+-        opkg_msg(NOTICE, "Warning when extracting archive entry '%s': %s\n",
+-                 archive_entry_pathname(entry), archive_error_string(a));
++        opkg_msg(NOTICE, "Warning when extracting archive entry '%s': %s (errno=%d)\n",
++                 archive_entry_pathname(entry), archive_error_string(a),
++                 archive_errno(a));
+         break;
+ 
+     case ARCHIVE_RETRY:
+-        opkg_msg(ERROR, "Failed to extract archive entry '%s': %s\n",
+-                 archive_entry_pathname(entry), archive_error_string(a));
++        opkg_msg(ERROR, "Failed to extract archive entry '%s': %s (errno=%d)\n",
++                 archive_entry_pathname(entry), archive_error_string(a),
++                 archive_errno(a));
+         if (retries++ < 3) {
+             opkg_msg(NOTICE, "Retrying...\n");
+             goto retry;
+@@ -439,8 +441,9 @@ static int extract_entry(struct archive *a, struct archive_entry *entry,
+             return -1;
+ 
+     default:
+-        opkg_msg(ERROR, "Failed to extract archive entry '%s': %s\n",
+-                 archive_entry_pathname(entry), archive_error_string(a));
++        opkg_msg(ERROR, "Failed to extract archive entry '%s': %s (errno=%d)\n",
++                 archive_entry_pathname(entry), archive_error_string(a),
++                 archive_errno(a));
+         return -1;
+     }
+ 
+@@ -508,8 +511,8 @@ static struct archive *open_outer(const char *filename)
+     /* Outer package is in 'ar' format, uncompressed. */
+     r = archive_read_support_format_ar(outer);
+     if (r != ARCHIVE_OK) {
+-        opkg_msg(ERROR, "Ar format not supported: %s\n",
+-                 archive_error_string(outer));
++        opkg_msg(ERROR, "Ar format not supported: %s (errno=%d)\n",
++                 archive_error_string(outer), archive_errno(outer));
+         goto err_cleanup;
+     }
+     r = archive_read_support_filter_gzip(outer);
+@@ -524,16 +527,16 @@ static struct archive *open_outer(const char *filename)
+     }
+     r = archive_read_support_format_tar(outer);
+     if (r != ARCHIVE_OK) {
+-        opkg_msg(ERROR, "Tar format not supported: %s\n",
+-             archive_error_string(outer));
++        opkg_msg(ERROR, "Tar format not supported: %s (errno=%d)\n",
++                 archive_error_string(outer), archive_errno(outer));
+         goto err_cleanup;
+     }
+ 
+     r = archive_read_open_filename(outer, filename, EXTRACT_BUFFER_LEN);
+     if (r != ARCHIVE_OK)
+     {
+-        opkg_msg(ERROR, "Failed to open package '%s': %s\n", filename,
+-                    archive_error_string(outer));
++        opkg_msg(ERROR, "Failed to open package '%s': %s (errno=%d)\n",
++                 filename, archive_error_string(outer), archive_errno(outer));
+         goto err_cleanup;
+     }
+     return outer;
+@@ -626,22 +629,22 @@ static struct archive *open_inner(struct archive *outer)
+ 
+     r = archive_read_support_format_tar(inner);
+     if (r != ARCHIVE_OK) {
+-        opkg_msg(ERROR, "Tar format not supported: %s\n",
+-                 archive_error_string(outer));
++        opkg_msg(ERROR, "Tar format not supported: %s (errno=%d)\n",
++                 archive_error_string(outer), archive_errno(outer));
+         goto err_cleanup;
+     }
+ 
+     r = archive_read_support_format_empty(inner);
+     if (r != ARCHIVE_OK) {
+-        opkg_msg(ERROR, "Empty format not supported: %s\n",
+-                 archive_error_string(inner));
++        opkg_msg(ERROR, "Empty format not supported: %s (errno=%d)\n",
++                 archive_error_string(inner), archive_errno(inner));
+         goto err_cleanup;
+     }
+ 
+     r = archive_read_open(inner, data, NULL, inner_read, inner_close);
+     if (r != ARCHIVE_OK) {
+-        opkg_msg(ERROR, "Failed to open inner archive: %s\n",
+-                 archive_error_string(inner));
++        opkg_msg(ERROR, "Failed to open inner archive: %s (errno=%d)\n",
++                 archive_error_string(inner), archive_errno(inner));
+         return NULL;
+     }
+ 
+@@ -732,30 +735,30 @@ static struct archive *open_compressed_file(const char *filename)
+          */
+         opkg_msg(INFO, "Gzip support provided by external program.\n");
+     } else if (r != ARCHIVE_OK) {
+-        opkg_msg(ERROR, "Gzip format not supported: %s\n",
+-                 archive_error_string(ar));
++        opkg_msg(ERROR, "Gzip format not supported: %s (errno=%d)\n",
++                 archive_error_string(ar), archive_errno(ar));
+         goto err_cleanup;
+     }
+ 
+     r = archive_read_support_format_raw(ar);
+     if (r != ARCHIVE_OK) {
+-        opkg_msg(ERROR, "Raw format not supported: %s\n",
+-                 archive_error_string(ar));
++        opkg_msg(ERROR, "Raw format not supported: %s (errno=%d)\n",
++                 archive_error_string(ar), archive_errno(ar));
+         goto err_cleanup;
+     }
+ 
+     r = archive_read_support_format_empty(ar);
+     if (r != ARCHIVE_OK) {
+-        opkg_msg(ERROR, "Empty format not supported: %s\n",
+-                 archive_error_string(ar));
++        opkg_msg(ERROR, "Empty format not supported: %s (errno=%d)\n",
++                 archive_error_string(ar), archive_errno(ar));
+         goto err_cleanup;
+     }
+ 
+     /* Open input file and prepare for reading. */
+     r = archive_read_open_filename(ar, filename, EXTRACT_BUFFER_LEN);
+     if (r != ARCHIVE_OK) {
+-        opkg_msg(ERROR, "Failed to open compressed file '%s': %s\n", filename,
+-                 archive_error_string(ar));
++        opkg_msg(ERROR, "Failed to open compressed file '%s': %s (errno=%d)\n",
++                 filename, archive_error_string(ar), archive_errno(ar));
+         goto err_cleanup;
+     }
+ 
+@@ -788,7 +791,8 @@ int gz_write_archive(const char *filename, const char *gz_filename)
+ 
+     r = archive_read_next_header2(disk, entry);
+     if (r != ARCHIVE_OK) {
+-        opkg_msg(ERROR, "Failed to read file: '%s' : %s", filename, archive_error_string(disk));
++        opkg_msg(ERROR, "Failed to read file: '%s' : %s (errno=%d)",
++                 filename, archive_error_string(disk), archive_errno(disk));
+         goto cleanup;
+     }
+ 
+@@ -797,7 +801,8 @@ int gz_write_archive(const char *filename, const char *gz_filename)
+ 
+     r = archive_write_header(a, entry);
+     if (r != ARCHIVE_OK) {
+-        opkg_msg(ERROR, "Failed to create compressed file: '%s' : %s", gz_filename, archive_error_string(a));
++        opkg_msg(ERROR, "Failed to create compressed file: '%s' : %s (errno=%d)",
++                 gz_filename, archive_error_string(a), archive_errno(a));
+         goto cleanup;
+     }
+ 
+-- 
+2.20.1
+

--- a/recipes-devtools/opkg/files/0001-opkg_conf-add-pid-suffix-to-volatile-cache-dir.patch
+++ b/recipes-devtools/opkg/files/0001-opkg_conf-add-pid-suffix-to-volatile-cache-dir.patch
@@ -1,0 +1,38 @@
+From fccc60abcd035b00f98d903066e4098c4ee1c294 Mon Sep 17 00:00:00 2001
+From: Brenda Streiff <brenda.streiff@ni.com>
+Date: Wed, 17 Nov 2021 12:57:06 -0600
+Subject: [PATCH] opkg_conf: add pid suffix to volatile cache dir
+To: opkg-devel@googlegroups.com
+
+Volatile cache directories are supposed to have a lifetime scoped to a
+particular process. Prior to feb40ec55c07 ("libopkg: do not require uid
+0 for RO cmds"), opkg operations were protected by a single lock;
+however, we might now have multiple opkg operations in-flight (for
+example, "opkg print-architecture" running independently of an "opkg
+install"). To handle this, uniquify the volatile cache_dir by appending
+the process ID so that different opkg processes will not stomp over each
+other.
+
+Signed-off-by: Brenda Streiff <brenda.streiff@ni.com>
+Upstream-Status: Accepted [https://groups.google.com/g/opkg-devel/c/x534f1NKOKk]
+---
+ libopkg/opkg_conf.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/libopkg/opkg_conf.c b/libopkg/opkg_conf.c
+index a8decef..37fcd2c 100644
+--- a/libopkg/opkg_conf.c
++++ b/libopkg/opkg_conf.c
+@@ -854,7 +854,8 @@ int opkg_conf_load(void)
+     }
+ 
+     if (opkg_config->volatile_cache) {
+-        sprintf_alloc(&tmp, "%s/%s", opkg_config->cache_dir, "volatile");
++        sprintf_alloc(&tmp, "%s/%s.%d", opkg_config->cache_dir, "volatile",
++                      (int)getpid());
+         free(opkg_config->cache_dir);
+         opkg_config->cache_dir = tmp;
+     }
+-- 
+2.20.1
+

--- a/recipes-devtools/opkg/opkg_%.bbappend
+++ b/recipes-devtools/opkg/opkg_%.bbappend
@@ -9,6 +9,7 @@ SRC_URI += " \
             file://run-ptest \
             file://0001-opkg-key-add-keys-even-if-creation-date-is-in-the-fu.patch \
             file://0001-opkg_conf.c-Verify-directory-exists-before-delete.patch \
+            file://0001-opkg_conf-add-pid-suffix-to-volatile-cache-dir.patch \
 "
 
 SRC_URI_append_armv7a = " \

--- a/recipes-devtools/opkg/opkg_%.bbappend
+++ b/recipes-devtools/opkg/opkg_%.bbappend
@@ -10,6 +10,7 @@ SRC_URI += " \
             file://0001-opkg-key-add-keys-even-if-creation-date-is-in-the-fu.patch \
             file://0001-opkg_conf.c-Verify-directory-exists-before-delete.patch \
             file://0001-opkg_conf-add-pid-suffix-to-volatile-cache-dir.patch \
+            file://0001-opkg_archive-output-libarchive-s-errno-wherever-we-o.patch \
 "
 
 SRC_URI_append_armv7a = " \


### PR DESCRIPTION
Pull two patches from upstream, one that fixes a multiprocess issue with volatile cache directories (bug #1722365), and one to help aid debugging.

@ni/rtos