### PR TITLE
Fix/Remove safemode ramdisk TODOs

### DIFF
--- a/recipes-core/images/nilrt-safemode-ramdisk.bb
+++ b/recipes-core/images/nilrt-safemode-ramdisk.bb
@@ -38,14 +38,9 @@ remove_alsa () {
 		alsa-utils-alsactl alsa-utils-alsamixer libasound2
 }
 
-# Radeon firmware is huge. Remove it from safemode and blacklist the module.
-# TODO: Maybe we should have a list of modules to install instead of getting
-#       the kernel-modules metapackage and then having to remove things
-#       individually?
-#       we probably don't need things like infiniband either...
+# Radeon firmware is huge and is not included in the safemode.
+# Blacklist the kernel module that gets automatically included.
 remove_radeon () {
-	opkg -o ${IMAGE_ROOTFS} -f ${IPKGCONF_TARGET} --force-depends remove \
-		linux-firmware-radeon
 	echo "blacklist radeon" > "${IMAGE_ROOTFS}/etc/modprobe.d/blacklist_radeon.conf"
 }
 

--- a/recipes-core/images/nilrt-safemode-ramdisk.bb
+++ b/recipes-core/images/nilrt-safemode-ramdisk.bb
@@ -29,15 +29,6 @@ IMAGE_INSTALL_NODEPS += "\
 
 BAD_RECOMMENDATIONS += "shared-mime-info"
 
-# Remove alsa, it pulls in a bunch of stuff and we don't need sound in
-# safemode.
-# TODO: this gets pulled in by packagegroup-base (!)
-remove_alsa () {
-	opkg -o ${IMAGE_ROOTFS} -f ${IPKGCONF_TARGET} --force-depends remove \
-		alsa-conf alsa-state alsa-states alsa-ucm-conf \
-		alsa-utils-alsactl alsa-utils-alsamixer libasound2
-}
-
 # Radeon firmware is huge and is not included in the safemode.
 # Blacklist the kernel module that gets automatically included.
 remove_radeon () {
@@ -82,7 +73,7 @@ bootimg_fixup () {
 	opkg -o ${IMAGE_ROOTFS} -f ${IPKGCONF_TARGET} clean
 }
 
-IMAGE_PREPROCESS_COMMAND += " remove_alsa; remove_radeon; bootimg_fixup; "
+IMAGE_PREPROCESS_COMMAND += " remove_radeon; bootimg_fixup; "
 
 addtask image_build_test before do_rootfs
 

--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -21,7 +21,6 @@ ALL_DISTRO_ARM_PACKAGES = "\
 
 ALL_DISTRO_x64_PACKAGES = "\
 	linux-firmware-i915 \
-	linux-firmware-radeon \
 	dmidecode \
 	efivar \
 	fw-printenv \

--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -21,6 +21,7 @@ RDEPENDS_${PN} = "\
 	glibc-gconv-iso8859-1 \
 	iproute2-tc \
 	librtpi \
+	linux-firmware-radeon \
 	lldpd \
 	niwatchdogpet \
 	opkg-utils-shell-tools \


### PR DESCRIPTION
#### Remove radeon firmware from safemode.
Previously, we removed the firmware during the image creation stage.
Instead, move the firmware package dependency from packagegroup-ni-base
to packagegroup-ni-runmode, so that the package is included only in
runmode images.
Also, remove TODO captured in AzDO WI 1742019.

-------

#### nilrt-safemode-ramdisk: Remove alsa uninstallation
alsa packages are not installed into safemode. So, the steps to
remove alsa packages from the image are unnecessary.

@ni/rtos 