### PR TITLE
local.conf.sample: Set system initialization method

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -193,3 +193,7 @@ BUILDNAME ?= "dev-nilrt"
 # track the version of this file when it was generated. This can safely be ignored if
 # this doesn't mean anything to you.
 CONF_VERSION = "1"
+
+# Explicitly set system initialization method
+INIT_MANAGER = "sysvinit"
+


### PR DESCRIPTION
It is advisable to explicitly set system initialization method.

Signed-off-by: Bill Pittman <bill.pittman@ni.com>

Tested builds locally after deleting the build folder and building from nothing.  Also verified the config file copied over the new INIT_MANAGER value.