### PR TITLE
Enable runmode to work on Hyper-V

### DIFF
--- a/recipes-core/initrdscripts/files/init-runmode-ramfs.sh
+++ b/recipes-core/initrdscripts/files/init-runmode-ramfs.sh
@@ -44,6 +44,12 @@ ARCH="`uname -m`"
 status "Running init process on ARCH=$ARCH"
 
 if [ "$ARCH" == "x86_64" ]; then
+	status "Running depmod"
+	depmod -a
+
+	modprobe hv_vmbus
+	modprobe hv_storvsc
+
 	# Root device which is detected asynchronously may not show up
 	#  early, so continously polling for it until it is available
 	#  or 10s timeout.

--- a/recipes-core/initrdscripts/files/ni_provisioning.safemode
+++ b/recipes-core/initrdscripts/files/ni_provisioning.safemode
@@ -181,12 +181,14 @@ has_tpm_chip ()
 	[ -e "/dev/tpm0" ]
 }
 
-check_for_tpm_chip()
+check_if_ramfs_required()
 {
 	# If use_ramfs was unspecified by user, set it based on
-	#  presence of TPM chip
+	#  presence of TPM chip or Hyper-V
 	if [ -z "$use_ramfs" ]; then
 		if has_tpm_chip; then
+			use_ramfs=true
+		elif lsmod | grep hv_storvsc &> /dev/null; then
 			use_ramfs=true
 		else
 			use_ramfs=false
@@ -317,8 +319,8 @@ install_grubenv()
 	grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv set "BIOSBootMode=efi"
 	grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv set "NITarget=$NI_TARGET"
 
-	# If target has a TPM chip, we need to enable an alternate boot flow
-	#  involving initramfs and bootflags dir
+	# If target has a TPM chip or runs on Hyper-V, we need to enable an alternate boot flow
+	# involving initramfs and bootflags dir
 	if $use_ramfs; then
 		grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv set "enable_initramfs=1"
 	fi
@@ -454,7 +456,7 @@ sanity_check()
 
 check_all_used_binaries
 load_kernel_modules
-check_for_tpm_chip
+check_if_ramfs_required
 
 echo "Installing safemode to: $TARGET_DISK."
 echo 6 > /proc/sys/kernel/printk

--- a/recipes-core/initrdscripts/init-runmode-ramfs_1.0.bb
+++ b/recipes-core/initrdscripts/init-runmode-ramfs_1.0.bb
@@ -18,6 +18,8 @@ RDEPENDS_${PN} += "\
 	nilrtdiskcrypt-reseal \
 	kernel-module-tpm-tis \
 	kernel-module-dm-crypt \
+	kernel-module-hv-storvsc \
+	kernel-module-hv-vmbus \
 "
 
 do_install() {


### PR DESCRIPTION
Hyper-V storage driver is required for runmode to be able to mount rootfs.
So build the drivers into initramfs and enable it if running on Hyper-V.

### Testing
Hyper-V VM provisioned with safemode with these changes has `enable_initramfs=1` in `/boot/grub/grubenv`.
Runmode with these changes can subsequently be installed on this VM and boots.

@ni/rtos 