### PR TITLE
Revert "salt: remove salt bbappends from meta-nilrt"

### DIFF
--- a/recipes-connectivity/salt/files/run-ptest
+++ b/recipes-connectivity/salt/files/run-ptest
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Kill any salt test processes which may be left around from orphaned test
+# runs.
+killall -q cli_master.py
+killall -q cli_syndic.py
+killall -q cli_minion.py
+killall -q cli_run.py
+
+python /usr/lib/python3.5/site-packages/salt-tests/tests/runtests.py \
+    --ptest-out \
+    --no-report \
+    --transport=tcp \
+    --run-destructive \
+    -n unit.modules.test_opkg \
+    -n integration.modules.test_system \
+    -n integration.modules.test_timezone \
+    -n integration.modules.test_shadow \
+    -n integration.states.test_user \
+    -n integration.modules.test_groupadd \
+    -n integration.modules.test_nilrt_ip \

--- a/recipes-connectivity/salt/files/salt-common.logrotate
+++ b/recipes-connectivity/salt/files/salt-common.logrotate
@@ -1,0 +1,8 @@
+/var/log/salt/master
+/var/log/salt/minion
+/var/log/salt/*.log
+{
+	daily
+	size 50k
+	notifempty
+}

--- a/recipes-connectivity/salt/files/transconf-hooks/salt
+++ b/recipes-connectivity/salt/files/transconf-hooks/salt
@@ -1,0 +1,120 @@
+#!/bin/bash
+set -euo pipefail
+
+# Transconf Salt Minion Runparts Entry
+#
+# The script can expect to run with the following environment:
+#
+# Environment:
+#  TRANSCONF_DEBUG: Set to "1" to enable debug prints
+#  TRANSCONF_SYSROOT: Absolute path to sysroot to be saved/restored
+#  TRANSCONF_IMAGE_DIR: Absolute path to uncompressed archive directory
+#  PWD: A temporary empty directory
+#  stdin closed
+#  umask is 0022
+#  ulimit -c 0 to disable core dumps
+#
+# Functions:
+#  status msg: Prints diagnostic message when transconf is in debug mode
+#  warning msg: Prints warning message
+#  error msg: Prints error message and returns with error
+#
+# Positional arg 1:
+#  "save":    Donate  files from TRANSCONF_SYSROOT into TRANSCONF_IMAGE_DIR
+#  "restore": Restore files from TRANSCONF_IMAGE_DIR to TRANSCONF_SYSROOT
+
+module_name=salt
+module_version=1
+
+module_image_dir="${TRANSCONF_IMAGE_DIR}/${module_name}"
+
+function do_restore() {
+	# restore the salt etc directory
+	mkdir -p "${TRANSCONF_SYSROOT}/etc/salt"
+
+	restore_generic "minion_id" "/etc/salt/minion_id" false 0644 "0:0"
+	restore_generic "minion.d/master.conf" "/etc/salt/minion.d/master.conf" \
+					true 0644 "0:0"
+
+	# pki encryption information
+	restore_generic "pki/." "/etc/salt/pki" true
+}
+
+function do_save() {
+	local salt_etc="${TRANSCONF_SYSROOT}/etc/salt"
+
+	cp "${salt_etc}/minion_id" "${module_image_dir}/minion_id"
+
+	# master.conf
+	if [ -e "${salt_etc}/minion.d/master.conf" ]; then
+		mkdir "${module_image_dir}/minion.d"
+		cp "${salt_etc}/minion.d/master.conf" "${module_image_dir}/minion.d/master.conf"
+	else
+		warning "No /etc/salt/minion.d/master.conf found; skipping its archival."
+	fi
+
+	# pki encryption information
+	if [ -d "${salt_etc}/pki" ]; then
+		cp -a "${salt_etc}/pki" "${module_image_dir}/pki"
+	else
+		warning "No PKI directory found; skipping its archival."
+	fi
+}
+
+# 1: img_path  : source file path (str) relative to the image root
+# 2: sys_path  : destination file path (str) relative to the sys root
+# 3: optional  : if True, do not error if the source DNE; else error
+# 4: mode      : if non-empty, chmod the destination file to this mode
+# 5: ownership : if non-empty, chown the destination file to this ownership
+function restore_generic() {
+	local src="${module_image_dir}/${1}"
+	local dst="${TRANSCONF_SYSROOT}/${2}"
+	local dir=`dirname "$dst"`
+
+	if [ ! -e "${src}" ]; then
+		if [ $3 ]; then  # if optional
+			return
+		else
+			error 'Required source file ${1} not found in image archive.'
+		fi
+	fi
+	status "Restoring $1 -> $2"
+	mkdir -p "${dir}"
+
+	cp -a "${src}" "${dst}"
+
+	if [ -n "${4:-}" ]; then  # if mode asserted
+		chmod "$4" "${dst}"
+	fi
+
+	if [ -n "${5:-}" ]; then  # if ownership asserted
+		chown "${5}" "${dst}"
+	fi
+}
+
+command_arg="${1:-}"
+case "$command_arg" in
+	"save")
+		status "Saving transconf files for module: ${module_name}"
+		mkdir "${module_image_dir}"
+
+		# module version
+		echo "${module_version}" >"${module_image_dir}/version"
+
+		do_save
+		;;
+
+	"restore")
+		status "Restoring transconf files for module: ${module_name}"
+		if [ -e "${module_image_dir}" ]; then
+			# Check version compatibility, can migrate if necessary
+			image_version=$(cat "${module_image_dir}/version")
+			[ "$module_version" -ge "$image_version" ] || error "Incompatible image version, max supported version is '$module_version', image version is '$image_version'"
+		fi
+
+		do_restore
+		;;
+	*)
+		error "Invalid command $command_arg"
+		;;
+esac

--- a/recipes-connectivity/salt/salt_3000.bbappend
+++ b/recipes-connectivity/salt/salt_3000.bbappend
@@ -1,0 +1,3 @@
+LIC_FILES_CHKSUM = "file://LICENSE;md5=c996f5a78d858a52c894fa3f4bec68c1"
+
+DEPENDS += "python3-distro-native"


### PR DESCRIPTION
Reverts ni/meta-nilrt#224

Based on discussion with @amstewart :
@andzn: "I wanted to change the salt branch in the meta-nilrt repo, but I didn't find the corresponding bbappend in the master/hardknott branch. I was looking for a file similar to this one: meta-nilrt/salt_2018.3.%.bbappend at f09f29a847134688036cdf03d92b7e6a995b8049 · andzn/meta-nilrt (github.com). The only one I found was this one in meta-cloudservices: meta-cloud-services/salt_3001.1.bb at nilrt/master/hardknott · ni/meta-cloud-services (github.com) but this one doesn't let us specify a git branch. Instead it seems to download packages from pythonhosted.org. Am I missing something?"

@amstewart : "I dropped the meta-nilrt salt bbappends during the hardknott rebase, because they conflicted with salt 3001, and we weren't sure at the time how or when we were going to address that. See the PR here. If you check the git history of that repo, it should be straightforward to revert the commits which removed the bbappends and apply your changes."