### PR TITLE
nilrt.conf: Bump version number and feed name

### DIFF
--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -2,9 +2,9 @@ require nilrt.inc
 
 DISTRO_NAME = "NI Linux Real-Time"
 
-DISTRO_VERSION = "8.10"
+DISTRO_VERSION = "8.11"
 
-NILRT_FEED_NAME = "2021.5"
+NILRT_FEED_NAME = "2021.8"
 
 DISTRO_FEATURES_append_x64 = "\
         x11 \


### PR DESCRIPTION
Bump DISTRO_VERSION to 8.11.
Bump NILRT_FEED_NAME to 2021.8.

Signed-off-by: Bill Pittman <bill.pittman@ni.com>