### PR TITLE
fixup! Use default options to mount nirootfs

### DIFF
--- a/recipes-core/images/nilrt-safemode-ramdisk.bb
+++ b/recipes-core/images/nilrt-safemode-ramdisk.bb
@@ -52,7 +52,7 @@ bootimg_fixup () {
 
 	echo "LABEL=nibootfs /boot ext4 sync 0 0" >> "${IMAGE_ROOTFS}/etc/fstab"
 	echo "LABEL=niconfig /etc/natinst/share ext4 sync 0 0" >> "${IMAGE_ROOTFS}/etc/fstab"
-	echo "LABEL=nirootfs /mnt/userfs ext4 sync 0 0" >> "${IMAGE_ROOTFS}/etc/fstab"
+	echo "LABEL=nirootfs /mnt/userfs ext4 defaults 0 0" >> "${IMAGE_ROOTFS}/etc/fstab"
 
 	# Add safemode marker
 	echo "safemode" > "${IMAGE_ROOTFS}/etc/natinst/safemode"


### PR DESCRIPTION
/mnt/userfs was being mounted synchronously in safemode, causing the
extraction of the base image to take upto 20 minutes. This is
different from the sumo safemode, where the rootfs was mounted with
the defaults - asynchronously. Continue to mount the rootfs
asynchronously to speed up I/O.


----
### Testing
The new base image extraction on the hardknott safemode takes 5 minutes now, similar to
the extraction time of the new base image on an older sumo safemode. Yet to test the full MAX installation experience.

@ni/rtos 