### PR TITLE
packagegroups: Remove python3 from packagegroups

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-extra.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-extra.bb
@@ -148,7 +148,6 @@ RDEPENDS_${PN} += "\
 	python3-nose \
 	python3-numpy \
 	python3-pyiface \
-	python3 \
 	python3-setuptools \
 	rpm \
 	rsync \

--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -42,7 +42,7 @@ RDEPENDS_${PN} += "\
 	libpython3 \
 	libyaml \
 	mpfr \
-	python3 \
+	python3-modules \
 	python3-aiodns \
 	python3-aiohttp \
 	python3-asn1crypto \


### PR DESCRIPTION
### Description
packagegroups: Remove python3 from packagegroups

python and python3 packages no longer exist and anything depending on
them should instead depend on pythonX-* or pythonX-modules.

python3-modules "provides python3" so things work even without
this change but it is cleaner to switch to python3-modules.

So renamed python3 to python3-modules in runmode packagegroup.

Removed python3 from extra packagegroup since it is already in runmode.

### Testing
`bitbake packagegroup-ni-coreimagerepo && bitbake package-index && bitbake nilrt-runmode-system-image` works.
`packagegroup-ni-runmode.ipk` now depends on `python3-modules`. Did not test `packagegroup-ni-extra.ipk`

@ni/rtos 