### PR TITLE
gdb: remove bbappend

### DIFF
--- a/recipes-devtools/gdb/gdb_%.bbappend
+++ b/recipes-devtools/gdb/gdb_%.bbappend
@@ -1,1 +1,0 @@
-PACKAGECONFIG_append = " python"


### PR DESCRIPTION
The meta-nilrt gdb_%.bbappend did nothing but add `python` to the gdb
PACKAGECONFIG. However, since the meta-nilrt bbappend was authored,
upstream OE has improved the gdb bb recipe such that python is already
detected and enabled. The bbappend is currently superfluous.

Remove the bbappend entirely.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

* [OE-core's equivalent line](https://github.com/ni/openembedded-core/blob/nilrt/master/hardknott/meta/recipes-devtools/gdb/gdb-common.inc#L35)

# Testing
Rebuilt `gdb` on my dev machine.

Old `PACKAGECONFIG`:
```
# $PACKAGECONFIG [12 operations]
<snip />
# pre-expansion value:
#   "readline python python"
PACKAGECONFIG="readline python python"
```

New `PACKAGECONFIG`:
```
# $PACKAGECONFIG [11 operations]
<snip />
# pre-expansion value:
#   "readline python"
PACKAGECONFIG="readline python"
```

@ni/rtos 