### PR TITLE
Remove obsolete libblockdev and libbytesize bbappends

### DIFF
--- a/recipes-devtools/libblockdev/libblockdev_%.bbappend
+++ b/recipes-devtools/libblockdev/libblockdev_%.bbappend
@@ -1,1 +1,0 @@
-PACKAGECONFIG_remove = "python3 escrow"

--- a/recipes-support/libbytesize/libbytesize_%.bbappend
+++ b/recipes-support/libbytesize/libbytesize_%.bbappend
@@ -1,1 +1,0 @@
-PACKAGECONFIG_remove += "python3"


### PR DESCRIPTION
```
 libbytesize: remove bbappend

NILRT no longer ships a libbytesize package. And if we did, we would
probably not care that it depends on python3 - since that is an accepted
dependency for modern NILRT runmodes.

Remove the bbappend because it is now superfluous.
```

```
libblockdev: remove bbappend

libblockdev is relevant to NILRT as a dependency of the `udisks2`
package. But there is no supported instance where udisks would be
installed to a hardknott recovery ramfs or safemode image, and we aren't
concerned about python3 or escrow dependencies in runmode.

So remove the bbappend as it is now obsolete.
```

Note that though we previously provided `udisks` in the -extra feed, we can no longer do that in hardknott without switching it to `udisks2` and enabling the `polkit` DISTRO_FEATURE. So `libblockdev` will actually never be build in hardknott anyway.

# Testing
Even though we won't use either package, I rebuilt `libblockdev`, `libbytesize` on my dev machine to confirm that the package configuration is still valid for our OE setup.

@ni/rtos 