### PR TITLE
packagegroup-ni-extra: remove dhcp recipes

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-extra.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-extra.bb
@@ -82,9 +82,6 @@ RDEPENDS_${PN} += "\
 	avahi \
 	bind \
 	cifs-utils \
-	dhcp-server \
-	dhcp-client \
-	dhcp-omshell \
 	libpcap \
 	ofono \
 	ppp \


### PR DESCRIPTION
The `dhcp` family of recipes has been dropped by OE upstream, and nilrt hasn't needed them anyway-- we've always used udhcpc/udhcpd from busybox for dhcp functionality.

---

Tested by building `nilrt-runmode-system-image` and `nilrt-safemode-image` with this change to ensure there isn't a lingering dependency somewhere in the base images, but both build fine.