### PR TITLE
pkggrps: move pkggrp-ni-nohz-kernel to the core feed

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-coreimagerepo.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-coreimagerepo.bb
@@ -8,6 +8,7 @@ RDEPENDS_${PN} = "\
 	packagegroup-core-boot \
 	packagegroup-ni-base \
 	packagegroup-ni-crio \
+	packagegroup-ni-nohz-kernel \
 	packagegroup-ni-ptest \
 	packagegroup-ni-restoremode \
 	packagegroup-ni-runmode \

--- a/recipes-core/packagegroups/packagegroup-ni-desirable.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-desirable.bb
@@ -14,7 +14,6 @@ RDEPENDS_${PN} += "\
 
 RDEPENDS_${PN}_append_x64 = "\
 	packagegroup-ni-next-kernel \
-	packagegroup-ni-nohz-kernel \
 	packagegroup-ni-mono-extra \
 	kernel-test-nohz \
 	ni-grpc-device \


### PR DESCRIPTION
The NI-internal Inverter Test System depends on the nohz kernel variant
for their ATS. Move the nohz kernel to into the core feed, to ensure
that it is always present and in the offline feed installer.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

# Testing
None; trivial.

@ni/rtos 