### PR TITLE
Add onboard to provide a virtual keyboard for touch panels

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-xfce.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-xfce.bb
@@ -24,6 +24,7 @@ RDEPENDS_${PN} = "\
 	mousepad \
 	ttf-pt-sans \
 	xserver-xorg-udev-rules \
+	onboard \
 "
 RDEPENDS_${PN}_append_x64 += "\
 	xf86-video-ati \

--- a/recipes-gnome/dconf/dconf_%.bbappend
+++ b/recipes-gnome/dconf/dconf_%.bbappend
@@ -1,0 +1,17 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://user \
+"
+
+CONFFILES_${PN}_append := " ${sysconfdir}/dconf/profile/user"
+
+do_install_append () {
+	install -d ${D}${sysconfdir}/dconf/db/local.d
+	install -d ${D}${sysconfdir}/dconf/profile
+
+	install -m 644 ${WORKDIR}/user ${D}${sysconfdir}/dconf/profile/
+}
+
+pkg_postinst_${PN} () {
+	dconf update
+}

--- a/recipes-gnome/dconf/files/user
+++ b/recipes-gnome/dconf/files/user
@@ -1,0 +1,2 @@
+user-db:user
+system-db:local

--- a/recipes-support/onboard/files/0001-add-xfce-to-autostart-onlyshowin.patch
+++ b/recipes-support/onboard/files/0001-add-xfce-to-autostart-onlyshowin.patch
@@ -1,0 +1,10 @@
+diff --git a/data/onboard-autostart.desktop.in b/data/onboard-autostart.desktop.in
+index 8fb55ac..cf022a0 100644
+--- a/data/onboard-autostart.desktop.in
++++ b/data/onboard-autostart.desktop.in
+@@ -9,4 +9,4 @@ NoDisplay=true
+ X-Ubuntu-Gettext-Domain=onboard
+ AutostartCondition=GSettings org.gnome.desktop.a11y.applications screen-keyboard-enabled
+ X-GNOME-AutoRestart=true
+-OnlyShowIn=GNOME;Unity;MATE;
++OnlyShowIn=GNOME;Unity;MATE;XFCE;

--- a/recipes-support/onboard/files/01-gnome-accessibility
+++ b/recipes-support/onboard/files/01-gnome-accessibility
@@ -1,0 +1,3 @@
+# We need accessibility on in order to use Onboard's auto-show.
+[org/gnome/desktop/interface]
+toolkit-accessibility=true

--- a/recipes-support/onboard/files/NI.colors
+++ b/recipes-support/onboard/files/NI.colors
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<!--
+    Copyright (c) 2022 National Instruments
+
+    SPDX-License-Identifier: GPL-3.0
+-->
+<color_scheme name="NI" format="2.1">
+    <window type="key-popup">
+        <color element="border" rgb="#044123" opacity="0.0"/>
+    </window>
+
+    <layer> <color element="background" rgb="#044123" opacity="1.0"/> </layer>
+    <layer> <color element="background" rgb="#044123" opacity="0.9"/> </layer>
+    <layer> <color element="background" rgb="#044123" opacity="0.9"/> </layer>
+
+    <key_group>
+        <color element="fill"   rgb="#f4f4f4"/>
+        <color element="stroke" rgb="#000000" opacity="0.0" />
+        <color element="label"  rgb="#044123"/>
+        icon0
+        
+        <key_group>
+            <color element="fill" rgb="#ffffff"/>
+            icon1, icon2
+        </key_group>
+        
+        <!-- dark keys -->
+        <key_group>
+            <color element="fill" rgb="#cddcc8"/>
+            <color element="label" rgb="#044123"/>
+            icon3,
+            RCTL, LCTL, RALT, LALT, LWIN, CAPS, 
+            LFSH, RTSH, NMLK,
+            MENU, RWIN, BKSP, TAB, RTRN, 
+            KPDL, KPEN, KPSU, KPDV, KPAD, KPMU,
+            LEFT, RGHT, UP, DOWN, INS, DELE, HOME, END, PGUP, PGDN,
+            F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12,
+            Prnt, Pause, ESC, Scroll,
+            secondaryclick, middleclick, doubleclick, dragclick, hoverclick,
+            hide, showclick, move, layer,
+            quit
+
+            <!-- word suggestions -->
+            <key_group>
+                <color element="fill" rgb="#cddcc8"/>
+                wordlist, prediction, pause-learning.wordlist, language.wordlist, hide.wordlist
+            </key_group>
+        </key_group>
+        
+        <!-- snippets -->
+        <key_group>
+            <color element="fill" rgb="#f4f4f4"/>
+            m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15
+        </key_group>
+        
+        <!-- red preferences -->
+        <key_group>
+            <color element="fill" rgb="#eb8768"/>
+            settings
+        </key_group>
+    </key_group>
+</color_scheme>

--- a/recipes-support/onboard/files/NI.theme
+++ b/recipes-support/onboard/files/NI.theme
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!--
+    Copyright (c) 2022 National Instruments
+
+    SPDX-License-Identifier: GPL-3.0
+-->
+<theme name="NI" format="1.3">
+    <color_scheme>NI</color_scheme>
+    <key_style>flat</key_style>
+    <roundrect_radius>20</roundrect_radius>
+    <key_fill_gradient>30</key_fill_gradient>
+    <key_stroke_gradient>70</key_stroke_gradient>
+    <key_gradient_direction>-3</key_gradient_direction>
+    <key_label_font></key_label_font>
+    <key_label_overrides></key_label_overrides>
+</theme>

--- a/recipes-support/onboard/files/onboard-defaults.conf
+++ b/recipes-support/onboard/files/onboard-defaults.conf
@@ -1,3 +1,8 @@
+[main]
+layout=Compact
+theme=NI
+key-label-font=DejaVu Sans
+
 [window]
 force-to-top=True
 

--- a/recipes-support/onboard/files/onboard-defaults.conf
+++ b/recipes-support/onboard/files/onboard-defaults.conf
@@ -1,0 +1,8 @@
+[window]
+force-to-top=True
+
+[auto-show]
+# Enable autoshow when there's no keyboard detected.
+enabled=True
+keyboard-device-detection-enabled=True
+keyboard-device-detection-exceptions=['::noserial']

--- a/recipes-support/onboard/onboard_%.bbappend
+++ b/recipes-support/onboard/onboard_%.bbappend
@@ -1,3 +1,26 @@
 # Onboard uses unicode glyphs in its key_defs.xml file, which means
 # we need a font that has those glyphs present.
 RDEPENDS_${PN}_append += "ttf-dejavu-sans"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://0001-add-xfce-to-autostart-onlyshowin.patch \
+            file://01-gnome-accessibility \
+            file://onboard-defaults.conf \
+"
+
+CONFFILES_${PN}_append := " ${sysconfdir}/onboard/onboard-defaults.conf \
+                            ${sysconfdir}/dconf/db/local.d/01-gnome-accessibility \
+"
+
+do_install_append () {
+	install -d ${D}${sysconfdir}/dconf/db/local.d
+	install -d ${D}${sysconfdir}/onboard
+
+	install -m 644 ${WORKDIR}/01-gnome-accessibility ${D}${sysconfdir}/dconf/db/local.d/
+	install -m 644 ${WORKDIR}/onboard-defaults.conf ${D}${sysconfdir}/onboard/
+}
+
+pkg_postinst_${PN} () {
+	dconf update
+}

--- a/recipes-support/onboard/onboard_%.bbappend
+++ b/recipes-support/onboard/onboard_%.bbappend
@@ -6,6 +6,8 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI += "file://0001-add-xfce-to-autostart-onlyshowin.patch \
             file://01-gnome-accessibility \
+            file://NI.colors \
+            file://NI.theme \
             file://onboard-defaults.conf \
 "
 
@@ -16,9 +18,13 @@ CONFFILES_${PN}_append := " ${sysconfdir}/onboard/onboard-defaults.conf \
 do_install_append () {
 	install -d ${D}${sysconfdir}/dconf/db/local.d
 	install -d ${D}${sysconfdir}/onboard
+	install -d ${D}${datadir}/onboard/themes
 
 	install -m 644 ${WORKDIR}/01-gnome-accessibility ${D}${sysconfdir}/dconf/db/local.d/
 	install -m 644 ${WORKDIR}/onboard-defaults.conf ${D}${sysconfdir}/onboard/
+
+	install -m 644 ${WORKDIR}/NI.colors ${D}${datadir}/onboard/themes/
+	install -m 644 ${WORKDIR}/NI.theme ${D}${datadir}/onboard/themes/
 }
 
 pkg_postinst_${PN} () {

--- a/recipes-support/onboard/onboard_%.bbappend
+++ b/recipes-support/onboard/onboard_%.bbappend
@@ -1,0 +1,3 @@
+# Onboard uses unicode glyphs in its key_defs.xml file, which means
+# we need a font that has those glyphs present.
+RDEPENDS_${PN}_append += "ttf-dejavu-sans"


### PR DESCRIPTION
As per AzDO#1639936, `florence` is deprecated and we'd like to use `onboard` as a replacement.

This patch set does several things:
- Configures `dconf` to provide a system-wide settings store (in addition to the user-only one that exists without configuration). This lets the `onboard` package push a setting to indicate to GNOME libraries that accessibility interfaces should be enabled.
- Configures onboard to start automatically with XFCE sessions.
- Configures onboard with a default setting to auto-show for text entry fields, but only when no USB keyboards are connected, e.g., the "I am only using a touch panel" case. This may require tweaking, since I don't have the recommended touch panel and I do not know if it enumerates as a keyboard.
- Adds a dependency on the "DejaVu Sans" font, so that we are guaranteed to have one font that supports the Unicode glyphs that Onboard wants to use for Tab, Shift, Return, Caps Lock, et al. This could be implemented as a set of `key-label-overrides` but 1) I did not wish to enumerate them all and 2) I didn't want to test to see how, for example, `Backspace` would look in the default "Compact" layout where it is a 1.0U key.
- Perhaps contentious: I didn't like the default "Classic Onboard" theming, so I am taking advantage of right-of-first-commit-set and adding an "NI" theme to be used as the default, which uses the corporate greens.
- Adds `onboard` to the `coreimagerepo` package group; this makes it optional and one must `opkg install` it, which is the same experience we had with `florence`

With this set of changes, I'm able to use the on-screen keyboard from a QEMU-based VM to type into a terminal and things appear to work as expected.

![Abc page](https://user-images.githubusercontent.com/444845/148855366-385f1c61-3f49-473e-8513-eeda76095aec.png)
![123 page](https://user-images.githubusercontent.com/444845/148855447-6a9627b7-ff4b-4e46-9622-d8a6ffbc2a82.png)
![more options page](https://user-images.githubusercontent.com/444845/148855488-3f3dab07-9dc2-4b14-a58c-e2a517eae035.png)
