### PR TITLE
Update the git fetch URL to use the https protocol

### DIFF
--- a/recipes-connectivity/wireless-regdb/wireless-regdb_1.0.bb
+++ b/recipes-connectivity/wireless-regdb/wireless-regdb_1.0.bb
@@ -11,7 +11,7 @@ S = "${WORKDIR}/git"
 # corresponds to master-2013-02-13
 SRCREV = "bb99560ff69c44c30e47416501639e37014689c3"
 
-SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/linville/wireless-regdb.git;protocol=git"
+SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/linville/wireless-regdb.git;protocol=https"
 
 FILES_${PN} += "${libdir}/crda/regulatory.bin"
 FILES_${PN} += "${libdir}/crda/pubkeys/linville.key.pub.pem"

--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -38,7 +38,7 @@ INHIBIT_PACKAGE_DEBUG_SPLIT="1"
 do_kernel_configme[depends] += "libgcc:do_populate_sysroot"
 
 SRC_URI = "\
-	${NILRT_GIT}/${GIT_KERNEL_REPO};protocol=git;nocheckout=1;branch=${KBRANCH} \
+	${NILRT_GIT}/${GIT_KERNEL_REPO};protocol=https;nocheckout=1;branch=${KBRANCH} \
 	file://export-kernel-headers.sh \
 "
 # Generically use the *latest* rev from the kernel source branch, if none is


### PR DESCRIPTION
GitHub has deprecated the git fetch protocol causing all git://
fetches that use the git protocol to fail.
https://github.blog/2021-09-01-improving-git-protocol-security-github/

Commit cherrypicked from nilrt/master/sumo.