### PR TITLE
openssh: Modify sysvinit script to close connections

### DIFF
--- a/recipes-connectivity/openssh/files/close-all-ssh-connections-patch
+++ b/recipes-connectivity/openssh/files/close-all-ssh-connections-patch
@@ -1,0 +1,10 @@
+--- a/init
++++ b/init
+@@ -53,6 +53,7 @@
+   stop)
+ 	echo -n "Stopping OpenBSD Secure Shell server: sshd"
+ 	start-stop-daemon -K -p $PIDFILE -x /usr/sbin/sshd
++	$(readlink -q $0 > /dev/null 2>&1) && killall sshd
+ 	echo "."
+ 	;;
+ 

--- a/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,5 +1,20 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
+SRC_URI += " \
+	file://close-all-ssh-connections-patch \
+"
+
+addtask patch_oe_source after do_patch before do_configure
+
+do_patch_oe_source () {
+    # Patch sysvinit file to close all open ssh connections on shutdown or reboot
+    #
+    # The typical do_patch logic will not work for this file since the do_patch logic is designed to
+    # patch the source code for openssh, and the file being patched is part of the recipe that builds
+    # the openssh IPK.
+    patch -u ${WORKDIR}/init -i ${WORKDIR}/close-all-ssh-connections-patch
+}
+
 do_install_append () {
     # this logic is only for nilrt and nilrt-xfce, not for nilrt-nxg
     if ${@oe.utils.conditional('DISTRO', 'nilrt-nxg', 'false', 'true', d)}; then


### PR DESCRIPTION
Modify the init script to close all open ssh connections when the
target reboots or shuts down.

### Testing

Tested locally and when the target reboots or halts, the ssh connection is closed.

Signed-off-by: Bill Pittman <bill.pittman@ni.com>