### PR TITLE
kernel-devsrc-nilrt: make olddefconfig before make prepare

### DIFF
--- a/recipes-kernel/linux/kernel-devsrc-nilrt.inc
+++ b/recipes-kernel/linux/kernel-devsrc-nilrt.inc
@@ -4,6 +4,7 @@
 pkg_postinst_ontarget_${PN} () {
 	cd /lib/modules/${KERNEL_VERSION}/build
 	find ./ -exec touch -m {} \;
+	make olddefconfig
 	make prepare
 	make modules_prepare
 


### PR DESCRIPTION
Sometimes when we bump minor kernel versions, new options can show up in the kernel config; a plain `make prepare` will then prompt for values for those options. This is a problem when postinsts are being run on first boot, because there's no way to see nor respond to such prompts-- a `make olddefconfig` beforehand will set these to defaults and avoid user interaction.