### PR TITLE
salt: Add salt-ptest package

### DIFF
--- a/recipes-support/salt/files/run-ptest
+++ b/recipes-support/salt/files/run-ptest
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Kill any salt test processes which may be left around from orphaned test
+# runs.
+killall -q cli_master.py
+killall -q cli_syndic.py
+killall -q cli_minion.py
+killall -q cli_run.py
+
+python -m salt-tests.tests.runtests \
+    --no-report \
+    --transport=tcp \
+    --run-destructive \
+    -n unit.modules.test_opkg \
+    -n integration.modules.test_system \
+    -n integration.modules.test_timezone \
+    -n integration.modules.test_shadow \
+    -n integration.states.test_user \
+    -n integration.modules.test_groupadd \
+    -n integration.modules.test_nilrt_ip \

--- a/recipes-support/salt/salt_3000.2.bb
+++ b/recipes-support/salt/salt_3000.2.bb
@@ -29,13 +29,14 @@ SRC_URI = "\
     file://salt-syndic \
     file://cloud \
     file://roster \
+    file://run-ptest \
 "
 
 SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"
 
-inherit setuptools3 update-rc.d
+inherit setuptools3 update-rc.d ptest
 
 # Avoid a QA Warning triggered by the test package including a file
 # with a .a extension
@@ -192,8 +193,10 @@ FILES_${PN}-cloud = "${bindir}/${PN}-cloud ${sysconfdir}/${PN}/cloud.conf.d/ ${s
 
 SUMMARY_${PN}-tests = "salt stack test suite"
 DESCRIPTION_${PN}-tests ="${DESCRIPTION_COMMON} This particular package provides the salt unit test suite."
-RDEPENDS_${PN}-tests = "${PN}-common python3-pytest-salt python3-tests python3-image bash"
+RDEPENDS_${PN}-tests = "${PN}-common python3-pytest-salt python3-pyzmq python3-six python3-tests python3-image bash"
 FILES_${PN}-tests = "${PYTHON_SITEPACKAGES_DIR}/salt-tests/tests/"
+
+RDEPENDS_${PN}-ptest += "salt-tests python3-distro python3-mock"
 
 FILES_${PN}-bash-completion = "${sysconfdir}/bash_completion.d/${PN}-common"
 


### PR DESCRIPTION
Add the salt-ptest package from the sumo salt bbappend recipe.
The goal of this change is to get the tests running. They do not all
pass at this time.
Changes from the sumo recipe:
- The --ptest-out option no longer exists in runtests.py and has been
removed from the test runner command in run-ptest.
- python3-mock and python3-distro have been added as dependencies to
the ptest package, without which the tests do not run.

@ni/rtos 