### PR TITLE
logrotate: remove duplicate entries for wtmp and btmp

### DIFF
--- a/recipes-extended/logrotate/logrotate/btmp
+++ b/recipes-extended/logrotate/logrotate/btmp
@@ -1,0 +1,5 @@
+# no packages own btmp -- we'll rotate it here
+/var/log/btmp {
+	create 0600 root utmp
+	rotate 1
+}

--- a/recipes-extended/logrotate/logrotate/logrotate.conf
+++ b/recipes-extended/logrotate/logrotate/logrotate.conf
@@ -21,16 +21,3 @@ compress
 missingok
 
 include /etc/logrotate.d
-
-# Raw login information for the system
-/var/log/wtmp {
-	monthly
-	create 0664 root utmp
-	size 1M
-	rotate 1
-}
-
-/var/log/btmp {
-	create 0600 root utmp
-	rotate 1
-}

--- a/recipes-extended/logrotate/logrotate/wtmp
+++ b/recipes-extended/logrotate/logrotate/wtmp
@@ -1,0 +1,7 @@
+# no packages own wtmp -- we'll rotate it here
+/var/log/wtmp {
+	monthly
+	create 0664 root utmp
+	size 1M
+	rotate 1
+}

--- a/recipes-extended/logrotate/logrotate_3.%.bbappend
+++ b/recipes-extended/logrotate/logrotate_3.%.bbappend
@@ -3,12 +3,19 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI += " \
 		file://logrotate.crontab \
 		file://logrotate.conf \
+		file://btmp \
+		file://wtmp \
 "
 
 do_install_append(){
     rm -rf ${D}${sysconfdir}/cron.daily/logrotate
     install -d ${D}${sysconfdir}/cron.d
     cat ${WORKDIR}/logrotate.crontab >> ${D}${sysconfdir}/cron.d/logrotate
+    # logrotate.conf, btmp, and wtmp config files are owned by logrotate
+    # upstream installs example versions of these config files
+    # we are intentionally overwriting them here with our own versions
     install -p -m 644 ${WORKDIR}/logrotate.conf ${D}${sysconfdir}/logrotate.conf
+    install -p -m 644 ${WORKDIR}/btmp ${D}${sysconfdir}/logrotate.d/btmp
+    install -p -m 644 ${WORKDIR}/wtmp ${D}${sysconfdir}/logrotate.d/wtmp
 }
 


### PR DESCRIPTION
**Implementation:**

Upstream move wtmp and btmp definitions from logrotate.conf to logrotate.d in https://github.com/ni/openembedded-core/commit/5b4aedd6b18b6ba6ca1bcd460a0b51ced41656cd?diff=split. nilrt has wtmp and btmp definition in logrotate.conf. The duplicate entries cause these errors in crond log:
```
2022-01-25T02:15:01.051+00:00 NI-cRIO-9049-01CEEE05 CROND[15011]: (root) CMDOUT (error: /etc/logrotate.conf:26 duplicate log entry for /var/log/wtmp)
2022-01-25T02:15:01.051+00:00 NI-cRIO-9049-01CEEE05 CROND[15011]: (root) CMDOUT (error: /etc/logrotate.conf:33 duplicate log entry for /var/log/btmp)
```
We are going to follow what upstream did so we can overwrite them with our definitions and not have duplicate entries.

**Testing:**

- Built logrotate package locally
- Install it on 9049 and verify the content of `/etc/logrotate.conf`, `/etc/logrotate.d/btmp`, and `/etc/logrotate.d/wtmp`
- Verify that there is no more error in `/var/log/cron.log`

@ni/rtos 