### PR TITLE
packagegroup-ni-desirable: Relocate onboard package

### DIFF
--- a/recipes-core/packagegroups/packagefeed-ni-core.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-core.bb
@@ -8,6 +8,7 @@ RDEPENDS_${PN} = "\
 	packagegroup-core-boot \
 	packagegroup-ni-base \
 	packagegroup-ni-crio \
+	packagegroup-ni-graphical \
 	packagegroup-ni-internal-deps \
 	packagegroup-ni-nohz-kernel \
 	packagegroup-ni-ptest \
@@ -17,7 +18,7 @@ RDEPENDS_${PN} = "\
 	packagegroup-ni-transconf \
 	packagegroup-ni-tzdata \
 	packagegroup-ni-wifi \
-	${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'packagegroup-core-x11', '', d)} \
+	packagegroup-core-x11 \
 	packagegroup-core-standalone-sdk-target \
 	packagegroup-kernel-module-build \
 	dkms \
@@ -30,5 +31,4 @@ RDEPENDS_${PN}_append_x64 = "\
 	rauc-mark-good \
 	nilrt-grub-runmode \
 	nilrt-grub-safemode \
-	${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'packagegroup-ni-xfce', '', d)} \
 "

--- a/recipes-core/packagegroups/packagegroup-ni-graphical.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-graphical.bb
@@ -1,0 +1,11 @@
+SUMMARY = "Graphical packages for the NI Linux Realtime distribution"
+LICENSE = "MIT"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
+
+RDEPENDS_${PN} = "\
+    onboard \
+    packagegroup-ni-xfce \
+"

--- a/recipes-core/packagegroups/packagegroup-ni-xfce.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-xfce.bb
@@ -24,7 +24,6 @@ RDEPENDS_${PN} = "\
 	mousepad \
 	ttf-pt-sans \
 	xserver-xorg-udev-rules \
-	onboard \
 "
 RDEPENDS_${PN}_append_x64 += "\
 	xf86-video-ati \


### PR DESCRIPTION
The onboard keyboard package is not required to be installed in the
runmode image. This is the current state because packagegroup-ni-xfce
is included in the runmode image. Instead, create a new graphical package group that includes the xfce package group and onboard. This packagegroup is included in packagefeed-ni-core now instead of packagegroup-ni-xfce.
This ensures that onboard is not installed by default into the image and is available for installation from the core feed.

Verified that packagegroup-ni-graphical builds successfully.

@ni/rtos 