### PR TITLE
Use https in github repo SRC_URIS

### DIFF
--- a/recipes-devtools/mkinitcpio/mkinitcpio_git.bb
+++ b/recipes-devtools/mkinitcpio/mkinitcpio_git.bb
@@ -8,7 +8,7 @@ BRANCH="nilrt/18.0"
 PV = "v23+git${SRCPV}"
 
 SRC_URI = "\
-	${NILRT_GIT}/mkinitcpio.git;protocol=git;branch=${BRANCH} \
+	${NILRT_GIT}/mkinitcpio.git;protocol=https;branch=${BRANCH} \
 	file://0001-Makefile-don-t-check-asciidoc-output.patch \
 	file://0002-Makefile-don-t-preserve-ownership-on-install.patch \
 "


### PR DESCRIPTION
Github is moving to deprecate the git protocol in its repos. Update all
github URIs to use the `https` protocol.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

---

This patchset was partially generated using a backported version of the [`convert-srcuri.py`](https://git.openembedded.org/openembedded-core/tree/scripts/contrib/convert-srcuri.py?id=5e2fc4676b8944fc1d36d567bb2d1ff4cff32294) script that Richard Purdie authored for OE upstream, when the community was mass-converting recipes over to use `protocol=https`. I removed the additional logic from the script to append `branch=master`, because it was more hassle than it was worth. I ran the script against this layer and manually checked the results. The script caught 95% of conversions, and I manually fixed the rest.

# Testing
1. Applied the "warning" commit from [ni/bitbake #6](https://github.com/ni/bitbake/pull/6).
2. Ran `bitbake -n ${targets}` using all the recipe targets which we currently build in the `NIOpenEmbedded` component, and recorded the *many* recipes which failed.
3. Applied this patchset to the meta layer.
4. Cleaned and re-ran bitbake and confirmed that there are now no recipes which warn about using the git protocol with github.

@ni/rtos 