### PR TITLE
ca-certificates: patch update-ca-certificates for sumo busybox

### DIFF
--- a/recipes-support/ca-certificates/ca-certificates/0001-update-ca-certificates-use-t-with-mktemp.patch
+++ b/recipes-support/ca-certificates/ca-certificates/0001-update-ca-certificates-use-t-with-mktemp.patch
@@ -1,0 +1,30 @@
+From 48418f0cb9e56f97a17919bc88c6bfb50bc91538 Mon Sep 17 00:00:00 2001
+From: Alex Stewart <alex.stewart@ni.com>
+Date: Fri, 28 Jan 2022 15:32:54 -0600
+Subject: [PATCH] update-ca-certificates: use -t with mktemp
+
+The `--tempdir` long argument is not supported by the version of busybox
+`mktemp` shipped with NIRLT sumo. Use the `-t` short arg instead.
+
+Upstream-status: Not appropriate (NILRT-specific)
+
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+---
+ sbin/update-ca-certificates | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/sbin/update-ca-certificates b/sbin/update-ca-certificates
+index 19f8e33..3df3430 100755
+--- a/sbin/update-ca-certificates
++++ b/sbin/update-ca-certificates
+@@ -115,8 +115,8 @@ trap cleanup 0
+ # Helper files.  (Some of them are not simple arrays because we spawn
+ # subshells later on.)
+ TEMPBUNDLE="${ETCCERTSDIR}/${CERTBUNDLE}.new"
+-ADDED="$(mktemp --tmpdir "ca-certificates.tmp.XXXXXX")"
+-REMOVED="$(mktemp --tmpdir "ca-certificates.tmp.XXXXXX")"
++ADDED="$(mktemp -t "ca-certificates.tmp.XXXXXX")"
++REMOVED="$(mktemp -t "ca-certificates.tmp.XXXXXX")"
+ 
+ # Adds a certificate to the list of trusted ones.  This includes a symlink
+ # in /etc/ssl/certs to the certificate file and its inclusion into the

--- a/recipes-support/ca-certificates/ca-certificates_20211016.bbappend
+++ b/recipes-support/ca-certificates/ca-certificates_20211016.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-update-ca-certificates-use-t-with-mktemp.patch"
+


### PR DESCRIPTION
The version of `mktemp` which ships with NILRT sumo's busybox version
does not support the `--tempdir` long argument. Patch the
ca-certificates upstream `update-ca-certificates` script to use the
short argument.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

---

The `ca-certificates` recipe in OE-core has been upgraded to align with upstream in [OE-core #42](https://github.com/ni/openembedded-core/pull/42). Upstream has upgraded their `mktemp` implementation to a version which supports the `--tempdir` long argument, so their `update-ca-certificates` script works as intended from upstream.

Sumo is using an older version of busybox which requires the short arg, so patch the new recipe to accommodate it.

Without this patch, the new ca-certificates postinst fails on sumo.

# Testing
Rebuilt the ca-certificates package with this change and upgraded a sumo safemode to use it. Validated that the postinst no longer fails* and that the `update-ca-certificates` script on-disk uses the short argument (`-t`).

\* There is a... bug? with the ca-certificates package where it calls `openssl rehash` - which is not a supported command by openssl 1.0.2. But I think this bug has existed in the ca-certificates package for a long time and doesn't reproduce when ca-certificates is installed via the bitbake rootfs, where it executes using the openssl on the host machine. Upstream seems to be aware of this issue, and doesn't care to fix it. I don't see a reason to fix it as a part of this patchset either.

@ni/rtos 