### PR TITLE
pkggrps: move tbb to internal-deps

### DIFF
--- a/recipes-core/packagegroups/packagefeed-ni-extra.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-extra.bb
@@ -459,7 +459,6 @@ RDEPENDS_${PN} += "\
 	strongswan \
 	system-config-keyboard \
 	libtalloc \
-	tbb \
 	tree \
 	usb-modeswitch \
 	vim \

--- a/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
@@ -3,6 +3,12 @@ LICENSE = "MIT"
 
 inherit packagegroup
 
+# NI-RFSA/G
+# Contact: Dharaniprakash Kurdimath <dharaniprakash.kurdimath@ni.com>
+RDEPENDS_${PN} += "\
+	tbb \
+"
+
 # nissl and nissleay
 # Contact: Haris Okanovic <haris.okanovic@ni.com>
 RDEPENDS_${PN} += "\


### PR DESCRIPTION
The NI-RFSA/G project has a dependency on the tbb package and requires
it in the core/ feeds to enable offline feed installation workflows.

Move `tbb` to the core feeds using packagegroup-ni-internal-deps.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

# Testing
Confirmed that `tbb` and `packagegroup-ni-internal-deps` still builds on my local dev machine. This change is pretty trivial.

@ni/rtos 