### PR TITLE
sysconfig-settings: add the missing uixml files for console enable

### DIFF
--- a/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.console_enable.binding.xml
+++ b/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.console_enable.binding.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<binding>
+    <!-- sysattr=ConsoleOutSwitch -->
+    <has sysattr="219541504" />
+</binding>

--- a/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.console_enable.const.de.xml
+++ b/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.console_enable.const.de.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<uistrings>
+    <str name="consoleout">Konsolenausgabe aktivieren</str>
+</uistrings>

--- a/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.console_enable.const.fr.xml
+++ b/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.console_enable.const.fr.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<uistrings>
+    <str name="consoleout">Activer la sortie console</str>
+</uistrings>

--- a/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.console_enable.const.ja.xml
+++ b/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.console_enable.const.ja.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<uistrings>
+    <str name="consoleout">Console Outを有効化</str>
+</uistrings>

--- a/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.console_enable.const.ko.xml
+++ b/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.console_enable.const.ko.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<uistrings>
+    <str name="consoleout">콘솔 출력 활성화</str>
+</uistrings>

--- a/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.console_enable.const.xml
+++ b/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.console_enable.const.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<uistrings>
+    <str name="consoleout">Enable Console Out</str>
+</uistrings>

--- a/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.console_enable.const.zh-CN.xml
+++ b/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.console_enable.const.zh-CN.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<uistrings>
+    <str name="consoleout">启用控制台输出</str>
+</uistrings>

--- a/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.console_enable.def.xml
+++ b/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.console_enable.def.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<item>
+    <group id="startupsettings" caption="{startupsettings}" weight="100" order="0">
+        <property id="consoleout" caption="{consoleout}" sysattr="219541504" writable="true" order="200" />
+    </group>
+</item>

--- a/recipes-ni/sysconfig-settings/sysconfig-settings_1.0.bb
+++ b/recipes-ni/sysconfig-settings/sysconfig-settings_1.0.bb
@@ -9,6 +9,14 @@ SRC_URI = "file://niselectsystemsettings \
            file://systemsettings/fpga_target.ini \
            file://systemsettings/rt_target.ini \
            file://systemsettings/target_common.ini \
+           file://uixml/nilinuxrt.console_enable.binding.xml \
+           file://uixml/nilinuxrt.console_enable.const.xml \
+           file://uixml/nilinuxrt.console_enable.const.de.xml \
+           file://uixml/nilinuxrt.console_enable.const.fr.xml \
+           file://uixml/nilinuxrt.console_enable.const.ja.xml \
+           file://uixml/nilinuxrt.console_enable.const.ko.xml \
+           file://uixml/nilinuxrt.console_enable.const.zh-CN.xml \
+           file://uixml/nilinuxrt.console_enable.def.xml \
            file://uixml/nilinuxrt.rtprotocol_enable.binding.xml \
            file://uixml/nilinuxrt.rtprotocol_enable.const.xml \
            file://uixml/nilinuxrt.rtprotocol_enable.const.de.xml \
@@ -39,6 +47,7 @@ FILES_${PN} = "/etc/natinst/niselectsystemsettings \
                /var/local/natinst/systemsettings/fpga_target.ini \
                /var/local/natinst/systemsettings/rt_target.ini \
                /var/local/natinst/systemsettings/target_common.ini \
+               /usr/local/natinst/share/uixml/sysconfig/nilinuxrt.console_enable.* \
                /usr/local/natinst/share/uixml/sysconfig/nilinuxrt.rtprotocol_enable.* \
                /usr/local/natinst/share/uixml/sysconfig/nilinuxrt.soft_dip_switch.* \
                /usr/local/natinst/share/uixml/sysconfig/nirio.soft_dip_switch.* \


### PR DESCRIPTION
### Implementation

Add the missing uixml files.

### Testing

Provision a VM using locally built recover media. After adding a `[consoleOut] `section to `rt_target.ini` and restarting `systemWebServer`, then "Enable Console Out" dip switch shows up in MAX just fine.

Signed-off-by: Jerry Xie <jerry.xie@ni.com>