### PR TITLE
Move kernel-devsrc.inc fixes to nilrt's kernel-dev src include files

### DIFF
--- a/recipes-kernel/linux/kernel-devsrc-debug.bb
+++ b/recipes-kernel/linux/kernel-devsrc-debug.bb
@@ -2,6 +2,6 @@ KERNEL_DEPENDENCY = "linux-nilrt-debug"
 KERNEL_DIRECTORY = "${DEPLOY_DIR_IMAGE}/kernel-debug/staging_kernel_dir"
 KERNEL_BUILD_DIRECTORY = "${DEPLOY_DIR_IMAGE}/kernel-debug/staging_kernel_builddir"
 
-require recipes-kernel/linux/kernel-devsrc.inc
+require recipes-kernel/linux/kernel-devsrc.bb
 require kernel-devsrc-nilrt.inc
 require kernel-devsrc-nilrt-alternate.inc

--- a/recipes-kernel/linux/kernel-devsrc-next.bb
+++ b/recipes-kernel/linux/kernel-devsrc-next.bb
@@ -2,6 +2,6 @@ KERNEL_DEPENDENCY = "linux-nilrt-next"
 KERNEL_DIRECTORY = "${DEPLOY_DIR_IMAGE}/kernel-next/staging_kernel_dir"
 KERNEL_BUILD_DIRECTORY = "${DEPLOY_DIR_IMAGE}/kernel-next/staging_kernel_builddir"
 
-require recipes-kernel/linux/kernel-devsrc.inc
+require recipes-kernel/linux/kernel-devsrc.bb
 require kernel-devsrc-nilrt.inc
 require kernel-devsrc-nilrt-alternate.inc

--- a/recipes-kernel/linux/kernel-devsrc-nilrt-alternate.inc
+++ b/recipes-kernel/linux/kernel-devsrc-nilrt-alternate.inc
@@ -1,10 +1,20 @@
 # This includes file contains content which is only appropriate for *alternate*
 # (non-standard) versions of the kernl-devsrc package (eg. kernel-devsrc-next).
 
+do_install[depends] += "${KERNEL_DEPENDENCY}:do_shared_workdir"
+do_install[depends] += "${KERNEL_DEPENDENCY}:do_install"
+do_configure[depends] += "${KERNEL_DEPENDENCY}:do_deploy"
+
+S = "${KERNEL_DIRECTORY}"
+B = "${KERNEL_BUILD_DIRECTORY}"
+
+KERNEL_VERSION = "${@get_kernelversion_headers('${B}')}"
+
+RDEPENDS_${PN}_remove = "python3"
+
 do_install_append() {
 	# Remove the symlink so it doesn't conflict with other
 	# kernel-devsrc packages
 	rm -f ${D}/usr/src/kernel
 	rmdir --ignore-fail-on-non-empty ${D}/usr/src
 }
-

--- a/recipes-kernel/linux/kernel-devsrc-nohz.bb
+++ b/recipes-kernel/linux/kernel-devsrc-nohz.bb
@@ -2,6 +2,6 @@ KERNEL_DEPENDENCY = "linux-nilrt-nohz"
 KERNEL_DIRECTORY = "${DEPLOY_DIR_IMAGE}/kernel-nohz/staging_kernel_dir"
 KERNEL_BUILD_DIRECTORY = "${DEPLOY_DIR_IMAGE}/kernel-nohz/staging_kernel_builddir"
 
-require recipes-kernel/linux/kernel-devsrc.inc
+require recipes-kernel/linux/kernel-devsrc.bb
 require kernel-devsrc-nilrt.inc
 require kernel-devsrc-nilrt-alternate.inc

--- a/recipes-kernel/linux/kernel-devsrc.bbappend
+++ b/recipes-kernel/linux/kernel-devsrc.bbappend
@@ -1,1 +1,5 @@
 require kernel-devsrc-nilrt.inc
+
+KERNEL_VERSION = "${@get_kernelversion_headers('${B}')}"
+
+RDEPENDS_${PN}:remove = "python3"


### PR DESCRIPTION
It is difficult to maintain out-of-tree commits to kernel-devsrc in oe-core, especially when trying to do an upstream merge. All modifications to kernel-devsrc.bb have to instead be made to kernel-devsrc.inc. This will also mess up history when doing those merges. 
As an alternative, revert those commits in oe-core (oe-core [PR](https://github.com/ni/openembedded-core/pull/44) )and make the same updates to our nilrt-specific kerneldev src include files.

Builds in progress.

@ni/rtos 
