### PR TITLE
[sumo] pkggrp-ni-extra: remove tbb

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-extra.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-extra.bb
@@ -489,7 +489,6 @@ RDEPENDS_${PN} += "\
 	strongswan \
 	system-config-keyboard \
 	libtalloc \
-	tbb \
 	tree \
 	usb-modeswitch \
 	usbpath \


### PR DESCRIPTION
tbb is a dependency of the NI-RFSA/G driver, which is only available for
x64 architectures.

Remove the tbb dependency from the extra feed, so that it can be added
to the x64 core feed. This will also remove it from the ARM extra/ feed,
but we do not have a particular requirement for tbb being in that feed.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

---

Because this is the sumo mainline, the commit which adds `tbb` to the core feed is in ni-central PR [#263833](https://dev.azure.com/ni/DevCentral/_git/ni-central/pullrequest/263833).

# Testing
Package removal; none necessary.

@ni/rtos 