### PR TITLE
convert git://github.com SRC_URIs to use https

### DIFF
--- a/recipes-devtools/mkinitcpio/mkinitcpio_git.bb
+++ b/recipes-devtools/mkinitcpio/mkinitcpio_git.bb
@@ -8,7 +8,7 @@ BRANCH="nilrt/18.0"
 PV = "v23+git${SRCPV}"
 
 SRC_URI = "\
-	${NILRT_GIT}/mkinitcpio.git;protocol=git;branch=${BRANCH} \
+	${NILRT_GIT}/mkinitcpio.git;protocol=https;branch=${BRANCH} \
 	file://0001-Makefile-don-t-check-asciidoc-output.patch \
 	file://0002-Makefile-don-t-preserve-ownership-on-install.patch \
 "


### PR DESCRIPTION
Github is moving to deprecate the git:// protocol for repo access. Use a
modified version of the upstream covert-srcuris.py script to find and
fixup github source URIs in-bulk.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

# Testing
Ran the `do_fetch` tasks of `packagefeed-ni-core` and confirmed that bitbake does not report any recipes as using a `git://github.com` URI.

@ni/rtos