### PR TITLE
nilrt-recovery-media: Use the same kernel as the recovery image

### DIFF
--- a/recipes-core/images/nilrt-recovery-media.bb
+++ b/recipes-core/images/nilrt-recovery-media.bb
@@ -48,4 +48,7 @@ ROOTFS_POSTPROCESS_COMMAND += "symlink_iso;"
 
 IMAGE_PREPROCESS_COMMAND += " bootimg_fixup; "
 
+# Use the same kernel binary as the image to create the wic boot device
+WIC_CREATE_EXTRA_ARGS = "-k ${IMAGE_ROOTFS}/boot/runmode"
+
 require includes/nilrt-core-image.inc


### PR DESCRIPTION
Use the kernel that was installed into the recovery image to
create the wic boot device to avoid kernel/driver mismatches
in the recovery media ISO.

Signed-off-by: Bill Pittman <bill.pittman@ni.com>

### Testing
Tested locally with the corresponding patch to openembedded-core/scripts/wic