### PR TITLE
nilrt-proprietary: Assign (not append) to vars

### DIFF
--- a/recipes-core/images/includes/nilrt-proprietary.inc
+++ b/recipes-core/images/includes/nilrt-proprietary.inc
@@ -7,11 +7,11 @@ LDCONFIGDEPEND = ""
 
 # NI infrastructure packages to be installed in the image
 
-NI_PROPRIETARY_SAFEMODE_PACKAGES += "\
+NI_PROPRIETARY_SAFEMODE_PACKAGES = "\
         ni-software-installation-daemon \
 "
 
-NI_PROPRIETARY_COMMON_PACKAGES += "\
+NI_PROPRIETARY_COMMON_PACKAGES = "\
         libnitargetcfg \
         ni-auth \
         ni-auth-webservice \
@@ -45,7 +45,7 @@ NI_PROPRIETARY_COMMON_PACKAGES += "\
         nissl \
 "
 
-NI_PROPRIETARY_RUNMODE_PACKAGES += "\
+NI_PROPRIETARY_RUNMODE_PACKAGES = "\
         ni-arch-gen \
         ni-sysmgmt-auth-utils \
         ni-sysmgmt-salt-minion-support \


### PR DESCRIPTION
We wish to parse this file in azdo to build rtos_nifeed.
So make this file the only source for NI proprietary packages by
assigning the package list to NI_PROPRIETARY_*PACKAGES variables
instead of appending.

### Testing
Verified through codesearch that there are no other places where these variables are assigned.