### PR TITLE
libxkbcommon: Override recipe to source from git

### DIFF
--- a/recipes-graphics/xorg-lib/libxkbcommon_0.8.0.bbappend
+++ b/recipes-graphics/xorg-lib/libxkbcommon_0.8.0.bbappend
@@ -1,0 +1,8 @@
+SRCREV = "b82e3b764e60df337ca695e8f8642e7bf42b0cca"
+SRC_URI = "git://github.com/xkbcommon/libxkbcommon.git;protocol=https"
+
+unset SRC_URI[md5sum]
+unset SRC_URI[sha256sum]
+unset UPSTREAM_CHECK_URI
+
+S = "${WORKDIR}/git"


### PR DESCRIPTION
Existing recipe gets sources from a tar on xkbcommon.org and in these
sources, parser.c and parser.h are already generated using bison 3.0.4.
When bitbake builds the recipe, it regenerates parser.c and parser.h
(because thats what libxkbcommon's meson rules say) - but this time with
bison 3.7.6 as that's the version our recipe is on.
When compiling parser.o though, the original parser.h gets
included instead of the newly generated one causing build failure due to
parser.c and parser.h mismatch.

This wasn't a problem for 21.0 because bison recipe was on 3.0.4.
But it was updated to 3.7.6 in 21.3 timeframe from which time the recipe
started failing.

So get the sources from github directly where parser.h and parser.c are
not already generated. The SRCREV points to 0.8.0 release.

Also updated `packagegroup-ni-coreimagerepo` to include `qtbase`.

Azdo Bug [#1848107](https://dev.azure.com/ni/DevCentral/_workitems/edit/1848107)

### Testing
Verified libxkbcommon builds locally.

@ni/rtos 