### PR TITLE
nilrt-proprietary.inc: move ni-sysmgmt-auth-utils to common

### DIFF
--- a/recipes-core/images/includes/nilrt-proprietary.inc
+++ b/recipes-core/images/includes/nilrt-proprietary.inc
@@ -30,6 +30,7 @@ NI_PROPRIETARY_COMMON_PACKAGES = "\
         ni-sysapi \
         ni-sysapi-remote \
         ni-sysapi-webservice \
+        ni-sysmgmt-auth-utils \
         ni-system-webserver \
         ni-traceengine \
         ni-webdav-system-webserver-support \
@@ -47,7 +48,6 @@ NI_PROPRIETARY_COMMON_PACKAGES = "\
 
 NI_PROPRIETARY_RUNMODE_PACKAGES = "\
         ni-arch-gen \
-        ni-sysmgmt-auth-utils \
         ni-sysmgmt-salt-minion-support \
         ni-sysmgmt-sysapi-expert \
         python3-ni-systemlink-sdk \


### PR DESCRIPTION
ni-sysmgmt-auth-utils provides the /usr/bin/nihaspassword utility -
which is used by NI MAX to determine if a NILRT installation has an
administrator password set. If the utility is not present, MAX falls
back to a legacy workflow, which is not supported in hardknott. Current
hardknott safemodes do not have the utility, and so enter into this
errant legacy workflow.

Move the ni-sysmgmt-auth-utils package into the "COMMON" packages, so
that it is installed to both safemode and runmode.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

NI AZDO bug: [Bug 1852514](https://dev.azure.com/ni/DevCentral/_workitems/edit/1852514)

# Testing
* Built the `nilrt-recovery-media` target locally, created a safemode VM, and confirmed that the bug described in the commit message occurs.
* Applied this PR and rebuilt `nilrt-recovery-media`, which implied rebuilting `nilrt-safemode-initramfs`. Confirmed that `nihaspassword` is now installed to safemode.

@ni/rtos 