### PR TITLE
packagegroup-ni-internal-deps: Add qtbase

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
@@ -27,3 +27,9 @@ RDEPENDS_${PN} += "\
 RDEPENDS_${PN} += "\
 	libfmi \
 "
+
+# Required for VCOM Toolkit
+# Contact: Stefano Caiola <stefano.caiola@ni.com>
+RDEPENDS_${PN}_append_x64 = "\
+	qtbase \
+"


### PR DESCRIPTION
qtbase is required for vcom so adding it to core feeds via
packagegroup-ni-internal-deps.

### Testing
None

@ni/rtos 