### PR TITLE
ni-shutdown-guard: Add -safemode package

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-safemode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-safemode.bb
@@ -16,6 +16,7 @@ RDEPENDS_${PN} = " \
 	e2fsprogs-mke2fs \
 	e2fsprogs-tune2fs \
 	ni-netcfgutil \
+	ni-shutdown-guard-safemode \
 	ni-systemimage \
 	sysconfig-settings-ssh \
 "

--- a/recipes-ni/ni-shutdown-guard/files/nilrt-safemode
+++ b/recipes-ni/ni-shutdown-guard/files/nilrt-safemode
@@ -1,0 +1,1 @@
+-c nisystemimage -c nisystemformat -c niinstallsafemode -c restore.sh

--- a/recipes-ni/ni-shutdown-guard/ni-shutdown-guard_1.0.bb
+++ b/recipes-ni/ni-shutdown-guard/ni-shutdown-guard_1.0.bb
@@ -6,10 +6,12 @@ SECTION = "base"
 
 SRC_URI = "\
 	file://holdoff-shutdown \
+	file://nilrt-safemode \
 	file://rguard \
 "
 
-FILES_${PN} += "\
+# ni-shutdown-guard package settings
+FILES_${PN} = "\
 	${sysconfdir}/init.d/holdoff-shutdown \
 	${sbindir}/rguard \
 "
@@ -21,11 +23,24 @@ INITSCRIPT_PARAMS = "stop 00 0 6 ."
 
 inherit update-rc.d
 
+# ni-shutdown-guard-safemode package settings
+PACKAGES += "${PN}-safemode"
+
+SUMMARY_${PN}-safemode = "Shutdown/reboot guard run-parts file(s) for NILRT safemode"
+DESCRIPTION_${PN}-safemode = "Run-parts file(s) for ni-shutdown-guard to prevent shutdown/reboot to protect critical operations in safemode"
+
+FILES_${PN}-safemode = "\
+	${sysconfdir}/holdoff-shutdown.d/nilrt-safemode \
+"
+
+RDEPENDS_${PN}-safemode += "${PN}"
+
 do_install () {
 	install -d ${D}${sbindir}
 	install -d ${D}${sysconfdir}/init.d
 	install -d ${D}${sysconfdir}/holdoff-shutdown.d
 
-	install -m 0755   ${WORKDIR}/holdoff-shutdown    ${D}${sysconfdir}/init.d
 	install -m 0755   ${WORKDIR}/rguard              ${D}${sbindir}
+	install -m 0755   ${WORKDIR}/holdoff-shutdown    ${D}${sysconfdir}/init.d
+	install -m 0644   ${WORKDIR}/nilrt-safemode      ${D}${sysconfdir}/holdoff-shutdown.d
 }


### PR DESCRIPTION
Added ni-shutdown-guard-safemode package in ni-shutdown-guard recipe to
install safemode specific runparts file.

### Testing
Packages build and directory structure looks good.

![image](https://user-images.githubusercontent.com/8194523/155619326-04b06898-d956-4944-bd89-a5755e3e82ff.png)

Installed ni-shutdown-guard-safemode.ipk on a VM and verified `/etc/holdoff-shutdown.d/nilrt-safemode` is present.
Didn't test actual functionality of `ni-shutdown-guard` or `nilrt-safemode`.

@ni/rtos 