### PR TITLE
ni: update nisetupkernelconfig to allow coredump to work in safemode

### DIFF
--- a/recipes-ni/initscripts-nilrt/files/nisetupkernelconfig
+++ b/recipes-ni/initscripts-nilrt/files/nisetupkernelconfig
@@ -7,6 +7,9 @@
 #executable name as the suffix.
 safemodeflag=/etc/natinst/safemode
 if [ -f $safemodeflag ]; then
+  if [ ! -d /mnt/userfs/var/local/natinst/log ]; then
+    mkdir -p /mnt/userfs/var/local/natinst/log
+  fi
   echo "/mnt/userfs/var/local/natinst/log/core_dump.%E" > /proc/sys/kernel/core_pattern
 else
   echo "/var/local/natinst/log/core_dump.%E" > /proc/sys/kernel/core_pattern

--- a/recipes-ni/initscripts-nilrt/files/nisetupkernelconfig
+++ b/recipes-ni/initscripts-nilrt/files/nisetupkernelconfig
@@ -5,7 +5,12 @@
 
 #Create core dump files in the root directory of runmode with the
 #executable name as the suffix.
-echo "/var/local/natinst/log/core_dump.%E" > /proc/sys/kernel/core_pattern
+safemodeflag=/etc/natinst/safemode
+if [ -f $safemodeflag ]; then
+  echo "/mnt/userfs/var/local/natinst/log/core_dump.%E" > /proc/sys/kernel/core_pattern
+else
+  echo "/var/local/natinst/log/core_dump.%E" > /proc/sys/kernel/core_pattern
+fi
 
 #Enable core dump for tainted binaries
 echo 1 > /proc/sys/fs/suid_dumpable


### PR DESCRIPTION
If it is safemode, create core dump in non-volatile /mnt/userfs.

Signed-off-by: Jerry Xie <jerry.xie@ni.com>

### Testing
Run the updated nisetupkernelconfig script locally and run cmds below to generate core dumps in safemode and verify that the core dump is generated at `/mnt/userfs/var/local/natinst/log/`.
```
ulimit -c unlimited
sleep 10 &
killall -SIGSEGV sleep
```

@ni/rtos 