### PR TITLE
packagegroup-ni-desirable: Add sysconfig-settings-ui

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-desirable.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-desirable.bb
@@ -47,6 +47,7 @@ RDEPENDS_${PN} += "\
 	rsync \
 	sshpass \
 	strace \
+	sysconfig-settings-ui \
 	valgrind \
 	vim \
 "


### PR DESCRIPTION
The sysconfig-settings-ui and sysconfig-settings packages are required by our niskyline__rt__client__runtimei builds. Since we require these packages, they should be in desirable.

Signed-off-by: Jeffrey Pautler <jeffrey.pautler@ni.com>