### PR TITLE
packagegroup-ni-desirable: Add sysconfig-settings-ui

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-desirable.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-desirable.bb
@@ -52,6 +52,7 @@ RDEPENDS_${PN} += "\
 	rsync \
 	sshpass \
 	strace \
+	sysconfig-settings-ui \
 	valgrind \
 	vim \
 "


### PR DESCRIPTION
The sysconfig-settings-ui package is required by our niskyline__rt__client__runtimei build. Since we require this package, it should be in the desirable packagegroup.

Signed-off-by: Jeffrey Pautler <jeffrey.pautler@ni.com>