### PR TITLE
Create ni-rtfeatures package to contain handle_cpld_ip_reset script and rtfeatures udev rules

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -68,6 +68,7 @@ RDEPENDS_${PN} += "\
 	lsbinitscripts \
 	netbase \
 	ni-hw-scripts \
+	ni-rtfeatures \
 	ni-safemode-utils \
 	ni-shutdown-guard \
 	ni-systemformat \

--- a/recipes-core/udev/udev-extraconf/localextra.rules
+++ b/recipes-core/udev/udev-extraconf/localextra.rules
@@ -40,9 +40,3 @@ KERNEL=="ttyS[0-9]*", GROUP="tty", MODE="660"
 
 # v4l (video/webcam)
 KERNEL=="video[0-9]*", GROUP="ni", MODE="666"
-
-# create symlink to establish a uniform path to nirtfeatures
-DRIVER=="nirtfeatures",RUN+="/bin/ln -sf /sys%p /dev/nirtfeatures"
-
-#give all users read/write access to CPLD-created /dev/input/event?
-SUBSYSTEM=="input", ENV{ID_PATH}=="acpi-NIC775D:??", KERNEL=="event?", MODE="0666"

--- a/recipes-ni/ni-rtfeatures/files/init.d/handle_cpld_ip_reset
+++ b/recipes-ni/ni-rtfeatures/files/init.d/handle_cpld_ip_reset
@@ -11,6 +11,6 @@ fi
 
 if [ "$IP_RESET_REQUESTED" == "y" ]; then
 	mkdir -p /tmp/ip_reset_dir
-	/usr/local/natinst/bin/ninetcfgutil pulldefault -d /tmp/ip_reset_dir -g primary -g secondary
+	ninetcfgutil pulldefault -d /tmp/ip_reset_dir -g primary -g secondary
 	rm -rf /tmp/ip_reset_dir
 fi

--- a/recipes-ni/ni-rtfeatures/files/init.d/handle_cpld_ip_reset
+++ b/recipes-ni/ni-rtfeatures/files/init.d/handle_cpld_ip_reset
@@ -1,25 +1,12 @@
 #!/bin/sh
 
-# We are going to create a udev script to mount nirtfeatures under /dev
-# to make us more robust to changes in the absolute path under /sys. However
-# to allow things to continue to work until everything makes its way through
-# the system or in case that udev script doesn't run for some reason we fall
-# back to trying to find ip_reset in a likely spot.
-
 IP_RESET_FILE="/dev/nirtfeatures/ip_reset"
-SMBIOS_HELPER="/usr/share/nisysinfo/smbios_helper"
-
-if [ ! -e $IP_RESET_FILE ]; then
-        [ "${VERBOSE}" != "no" ] && echo "Unable to find ip_reset at normal spot. Attempting to find dynamically."
-        IP_RESET_FILE=`find /sys/bus/acpi/drivers/nirtfeatures -maxdepth 2 -follow -name ip_reset`
-fi
 
 IP_RESET_REQUESTED=""
-if [ -n "$IP_RESET_FILE" ]; then
+if [ -e "$IP_RESET_FILE" ]; then
 	grep -q '1' $IP_RESET_FILE && IP_RESET_REQUESTED="y"
-elif [ -r $SMBIOS_HELPER ]; then
-	source $SMBIOS_HELPER
-	get_ipreset && IP_RESET_REQUESTED="y"
+else
+	[ "${VERBOSE}" != "no" ] && echo "Unable to find ip_reset at normal spot."
 fi
 
 if [ "$IP_RESET_REQUESTED" == "y" ]; then

--- a/recipes-ni/ni-rtfeatures/files/init.d/handle_cpld_ip_reset
+++ b/recipes-ni/ni-rtfeatures/files/init.d/handle_cpld_ip_reset
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# We are going to create a udev script to mount nirtfeatures under /dev
+# to make us more robust to changes in the absolute path under /sys. However
+# to allow things to continue to work until everything makes its way through
+# the system or in case that udev script doesn't run for some reason we fall
+# back to trying to find ip_reset in a likely spot.
+
+IP_RESET_FILE="/dev/nirtfeatures/ip_reset"
+SMBIOS_HELPER="/usr/share/nisysinfo/smbios_helper"
+
+if [ ! -e $IP_RESET_FILE ]; then
+        [ "${VERBOSE}" != "no" ] && echo "Unable to find ip_reset at normal spot. Attempting to find dynamically."
+        IP_RESET_FILE=`find /sys/bus/acpi/drivers/nirtfeatures -maxdepth 2 -follow -name ip_reset`
+fi
+
+IP_RESET_REQUESTED=""
+if [ -n "$IP_RESET_FILE" ]; then
+	grep -q '1' $IP_RESET_FILE && IP_RESET_REQUESTED="y"
+elif [ -r $SMBIOS_HELPER ]; then
+	source $SMBIOS_HELPER
+	get_ipreset && IP_RESET_REQUESTED="y"
+fi
+
+if [ "$IP_RESET_REQUESTED" == "y" ]; then
+	mkdir -p /tmp/ip_reset_dir
+	/usr/local/natinst/bin/ninetcfgutil pulldefault -d /tmp/ip_reset_dir -g primary -g secondary
+	rm -rf /tmp/ip_reset_dir
+fi

--- a/recipes-ni/ni-rtfeatures/files/init.d/handle_cpld_ip_reset
+++ b/recipes-ni/ni-rtfeatures/files/init.d/handle_cpld_ip_reset
@@ -6,7 +6,7 @@ IP_RESET_REQUESTED=""
 if [ -e "$IP_RESET_FILE" ]; then
 	grep -q '1' $IP_RESET_FILE && IP_RESET_REQUESTED="y"
 else
-	[ "${VERBOSE}" != "no" ] && echo "Unable to find ip_reset at normal spot."
+	[ "${VERBOSE}" = "yes" ] && echo "Unable to find ip_reset at normal spot."
 fi
 
 if [ "$IP_RESET_REQUESTED" == "y" ]; then

--- a/recipes-ni/ni-rtfeatures/files/rtfeatures.rules
+++ b/recipes-ni/ni-rtfeatures/files/rtfeatures.rules
@@ -1,0 +1,5 @@
+# create symlink to establish a uniform path to nirtfeatures
+DRIVER=="nirtfeatures",RUN+="/bin/ln -sf /sys%p /dev/nirtfeatures"
+
+#give all users read/write access to CPLD-created /dev/input/event?
+SUBSYSTEM=="input", ENV{ID_PATH}=="acpi-NIC775D:??", KERNEL=="event?", MODE="0666"

--- a/recipes-ni/ni-rtfeatures/ni-rtfeatures_1.0.bb
+++ b/recipes-ni/ni-rtfeatures/ni-rtfeatures_1.0.bb
@@ -1,5 +1,5 @@
 SUMMARY = "rtfeatures user-space tools"
-DESCRIPTION = "Provides user-space tools to support rtfeatures."
+DESCRIPTION = "Provides user-space tools to support the nirtfeatures kernel module."
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 LICENSE = "MIT"
 SECTION = "base"

--- a/recipes-ni/ni-rtfeatures/ni-rtfeatures_1.0.bb
+++ b/recipes-ni/ni-rtfeatures/ni-rtfeatures_1.0.bb
@@ -1,0 +1,62 @@
+SUMMARY = "rtfeatures user-space tools"
+DESCRIPTION = "Provides user-space tools to support rtfeatures."
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+LICENSE = "MIT"
+SECTION = "base"
+
+DEPENDS += "\
+	update-rc.d-native \
+"
+
+SRC_URI += "\
+	file://init.d/handle_cpld_ip_reset \
+	file://rtfeatures.rules \
+"
+
+S = "${WORKDIR}"
+
+
+do_install () {
+	install -d ${D}${sysconfdir}/init.d/
+
+	install -m 0755 ${S}/init.d/handle_cpld_ip_reset    ${D}${sysconfdir}/init.d
+
+	install -d ${D}${sysconfdir}/udev/rules.d
+
+	install -m 0644 ${S}/rtfeatures.rules    ${D}${sysconfdir}/udev/rules.d/rtfeatures.rules
+}
+
+pkg_postinst_${PN} () {
+	if [ -n "$D" ]; then
+		OPT="-r $D"
+	else
+		OPT="-s"
+	fi
+
+	update-rc.d $OPT handle_cpld_ip_reset    start 6 1 3 4 5 .
+}
+
+pkg_postrm_${PN} () {
+	if [ -n "$D" ]; then
+		OPT="-f -r $D"
+	else
+		OPT="-f"
+	fi
+
+	update-rc.d $OPT handle_cpld_ip_reset  remove
+}
+
+
+PACKAGE_ARCH = "all"
+PACKAGES_remove += "${PN}-staticdev ${PN}-dev ${PN}-dbg"
+
+FILES_${PN} += "\
+	${sysconfdir}/init.d/handle_cpld_ip_reset \
+	${sysconfdir}/udev \
+"
+
+RDEPENDS_${PN} += "\
+	bash \
+	ni-netcfgutil \
+	udev \
+"

--- a/recipes-ni/ni-rtfeatures/ni-rtfeatures_1.0.bb
+++ b/recipes-ni/ni-rtfeatures/ni-rtfeatures_1.0.bb
@@ -15,37 +15,18 @@ SRC_URI += "\
 
 S = "${WORKDIR}"
 
+inherit update-rc.d
 
-do_install () {
+INITSCRIPT_NAME = "handle_cpld_ip_reset"
+INITSCRIPT_PARAMS = "start 6 1 3 4 5 ."
+
+do_install_append () {
 	install -d ${D}${sysconfdir}/init.d/
-
 	install -m 0755 ${S}/init.d/handle_cpld_ip_reset    ${D}${sysconfdir}/init.d
 
 	install -d ${D}${sysconfdir}/udev/rules.d
-
 	install -m 0644 ${S}/rtfeatures.rules    ${D}${sysconfdir}/udev/rules.d/rtfeatures.rules
 }
-
-pkg_postinst_${PN} () {
-	if [ -n "$D" ]; then
-		OPT="-r $D"
-	else
-		OPT="-s"
-	fi
-
-	update-rc.d $OPT handle_cpld_ip_reset    start 6 1 3 4 5 .
-}
-
-pkg_postrm_${PN} () {
-	if [ -n "$D" ]; then
-		OPT="-f -r $D"
-	else
-		OPT="-f"
-	fi
-
-	update-rc.d $OPT handle_cpld_ip_reset  remove
-}
-
 
 PACKAGE_ARCH = "all"
 PACKAGES_remove += "${PN}-staticdev ${PN}-dev ${PN}-dbg"


### PR DESCRIPTION
### Description

handle_cpld_ip_reset script is missing on Hardknott, and we need it for the long push button reset to reset network configuration on cRIO controllers. handle_cpld_ip_reset is a script that interact with rtfeatures in-tree driver which relies on udev rules for rtfeatures. So let's collect the rtfeatures related stuff together into its own package.

### Implementation

- Create new package ni-rtfeatures for handle_cpld_ip_reset script and rtfeatures udev rules (migrated from udev-extraconf)
- Add ni-rtfeatures to packagegroup-ni-base
- Simplify handle_cpld_ip_reset to remove fallback mechansim

### Testing

- Provisioned VM and made sure all the stuff is in the right place. For a VM, handle_cpld_ip_reset is basically a no-op;
- Tested on real cRIO 9049 and validate that pushing reset button > 5 seconds force the target to safe mode and then pushing reset button > 5 seconds again resets network configuration and force target to reboot to safe mode again.

@ni/rtos 