### PR TITLE
[hardknott] Create packagegroup-ni-contributors

### DIFF
--- a/recipes-core/packagegroups/packagefeed-ni-core.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-core.bb
@@ -7,6 +7,7 @@ RDEPENDS_${PN} = "\
 	packagegroup-base \
 	packagegroup-core-boot \
 	packagegroup-ni-base \
+	packagegroup-ni-contributors \
 	packagegroup-ni-crio \
 	packagegroup-ni-graphical \
 	packagegroup-ni-internal-deps \

--- a/recipes-core/packagegroups/packagegroup-ni-contributors.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-contributors.bb
@@ -7,3 +7,7 @@ LICENSE = "MIT"
 # RDEPENDS:${PN} += ""
 
 inherit packagegroup
+
+# Dependency: LQ-Bindings <https://github.com/JKSH/LQ-Bindings>
+# Contact: Sze Howe Koh <szehowe.koh@gmail.com>
+RDEPENDS:${PN} += "libxkbcommon"

--- a/recipes-core/packagegroups/packagegroup-ni-contributors.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-contributors.bb
@@ -1,0 +1,9 @@
+SUMMARY = "Core feed packages which are required and maintained by NILRT community members."
+LICENSE = "MIT"
+# All entries within this packagegroup must include a community maintainer
+# contact.
+# Dependency: <the community project which has this dependency>
+# Contact: <a DEVELOPER contact who can speak to the requirement>
+# RDEPENDS:${PN} += ""
+
+inherit packagegroup


### PR DESCRIPTION
Some NILRT customers have valuable community projects, and business products, which depend upon open-source (OE) packages in the core and extra feeds. The packages are important enough to them that they would be willing to put in some effort to fix them if they break and ensure that they are available in every distro release. But at the moment, we don't have a way to designate a package as falling into this category.

An example is the LQ-bindings project, which depends upon `libxkbcommon`. It was availabe in the extra/ feed prior to the 21.X releases, when it dropped unexpectedly for the downstream project.

So create a "contributors" packagegroup, which is a part of the core/ packagefeed. Into that packagegroup, we will declare packages which have community-maintainers and specify the downstream project and a technical contact. Packages in this group (as they are a part of the core packagefeed) must successfully build. If they break for whatever reason, we'll file a bug to the technical contact for the project and ask them to submit a fix. 

---

# Testing
Built `packagegroup-ni-contributors` and confirmed that the dependency on `libxkbcommon` is correctly applied.

@ni/rtos 