### PR TITLE
[hardknott] bblayers.conf.sample: drop meta-ivi

### DIFF
--- a/conf/bblayers.conf.sample
+++ b/conf/bblayers.conf.sample
@@ -8,7 +8,6 @@ BBFILES ?= ""
 BBLAYERS ?= " \
 	${GIT_REPODIR}/meta-cloud-services \
 	${GIT_REPODIR}/meta-cloud-services/meta-openstack \
-	${GIT_REPODIR}/meta-ivi/meta-ivi \
 	${GIT_REPODIR}/meta-java \
 	${GIT_REPODIR}/meta-measured \
 	${GIT_REPODIR}/meta-mingw \


### PR DESCRIPTION
The meta-ivi layer is dead upstream and is not necessary for NILRT
hardknott.

Drop the meta-layer from the bblayer as a step in removing it from the
project.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

Most of the meta-nilrt work to drop meta-ivi packages [was done](https://github.com/ni/meta-nilrt/commit/281838ac9894fea4dd2b8ee2692bec40485042e0) in meta-nilrt #300. All that remains here is removing it from the bblayers.

NI AZDO: [Technical Debt 1769944](https://dev.azure.com/ni/DevCentral/_workitems/edit/1769944)

# Testing
* Ran `bitbake --parse-only packagefeed-ni-core`; no errors.
* Ran `bitbake --parse-only packagefeed-ni-extra`; no errors.
* I already audited the recipes in the layer in the spreadsheet linked in the NI AZDO item.

@ni/rtos 