### PR TITLE
Adding CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,2 @@
+# Contributing to the NI Linux RT meta-nilrt Layer
+Guidelines for contributing to the NI Linux Real-Time project can be found in the [ni/nilrt](https://github.com/ni/nilrt) repository's [CONTRIBUTING.md](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md). Refer to that document for the appropriate guidelines.


### PR DESCRIPTION
Adding CONTRIBUTING.md to point to nilrt CONTRIBUTING.md

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

@ni/rtos 