### PR TITLE
linux-nilrt: Don't run postinst in safemode

### DIFF
--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -97,6 +97,11 @@ do_shared_workdir_append() {
 }
 
 pkg_postinst_ontarget_${KERNEL_PACKAGE_NAME}-base_append_x64 () {
+	# The postinst is intended to be run when new kernels are installed
+	# in runmode so that uninstalling them works correctly.
+	# It does not make sense to run this on safemode. So skip.
+	[ -f /etc/natinst/safemode ] && exit 0
+
 	cd "$D/${KERNEL_IMAGEDEST}"
 
 	if [ -f "${KERNEL_IMAGETYPE}" ]; then


### PR DESCRIPTION
kernel package file's posinst fails when safemode is booted and /boot/runmode directory isn't present (which happens when runmode isn't installed), and opkg complains about this when installing new packages.

In any case, we shouldn't be running postinst in safemode. So return from postinst if in safemode.

### Testing
Added `[ -f /etc/natinst/safemode ] && exit 0` line to existing postinst on a safemode and verified running posinst manually doesn't fail like before.