### PR TITLE
sysvinit-inittab: Bring back custom start_getty

### DIFF
--- a/recipes-core/sysvinit/sysvinit-inittab/start_getty
+++ b/recipes-core/sysvinit/sysvinit-inittab/start_getty
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Copyright (c) 2012-2013 National Instruments.
+# All rights reserved.
+# Spawn getty on the enabled, controlling console device. There will be at most
+# one of these. If there aren't any, don't spawn any.
+
+
+SPEED=""
+CONSOLE=""
+TERM=$3
+
+while read cons flags; do
+   case "$flags" in
+   *EC*) CONSOLE="$cons"
+         SPEED=$(stty speed < /dev/$CONSOLE)
+         echo Autodetected console "$CONSOLE" with baud rate "$SPEED"
+         break
+         ;;
+   esac
+done < /proc/consoles
+
+# If there aren't any detected consoles, exit
+[ -z "$CONSOLE" ] && exit 0
+
+# busybox' getty does this itself, util-linux' agetty needs extra help
+getty="/sbin/getty"
+case $(readlink -f "${getty}") in
+    */busybox*)
+        ;;
+    *)
+        if [ -x "/usr/bin/setsid" ] ; then
+            setsid="/usr/bin/setsid"
+        fi
+        ;;
+esac
+
+${setsid:-} ${getty} -L $SPEED $CONSOLE $TERM

--- a/recipes-core/sysvinit/sysvinit-inittab_2.%.bbappend
+++ b/recipes-core/sysvinit/sysvinit-inittab_2.%.bbappend
@@ -1,0 +1,3 @@
+# overwrite the standard OE start_getty with our ni-specific one; start_getty
+# is already added in SRC_URI so we just put our path first so OE fetches it.
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"


### PR DESCRIPTION
Serial console should be enabled/disabled based on the corresponding
setting in MAX.

These changes bring back the custom start_getty file that was previously
deleted. Some modifications were done to make it similar to OE's
start_getty.

### Testing
Built `sysvinit-inittab` recipe and verified the package contains these changes.

Manually copied `start_getty` from the package to a cRIO-9030 and verified that serial console output is enabled or disabled depending on the corresponding setting in MAX.