### PR TITLE
nilrt.inc: Set SERIAL_CONSOLES to tty2

### DIFF
--- a/recipes-core/sysvinit/sysvinit-inittab/start_getty
+++ b/recipes-core/sysvinit/sysvinit-inittab/start_getty
@@ -2,11 +2,11 @@
 # Copyright (c) 2012-2013 National Instruments.
 # All rights reserved.
 # Spawn getty on the enabled, controlling console device. There will be at most
-# one of these. If there aren't any, don't spawn any.
+# one of these. If there aren't any, spawn with values provided in inittab to
+# keep this script running as it will be respawned by sysvinit if it dies.
 
-
-SPEED=""
-CONSOLE=""
+SPEED=$1
+CONSOLE=$2
 TERM=$3
 
 while read cons flags; do
@@ -18,9 +18,6 @@ while read cons flags; do
          ;;
    esac
 done < /proc/consoles
-
-# If there aren't any detected consoles, exit
-[ -z "$CONSOLE" ] && exit 0
 
 # busybox' getty does this itself, util-linux' agetty needs extra help
 getty="/sbin/getty"

--- a/recipes-core/sysvinit/sysvinit-inittab_2.%.bbappend
+++ b/recipes-core/sysvinit/sysvinit-inittab_2.%.bbappend
@@ -1,3 +1,10 @@
 # overwrite the standard OE start_getty with our ni-specific one; start_getty
 # is already added in SRC_URI so we just put our path first so OE fetches it.
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+# The console specified here is used as default by start_getty in case a real console
+# isn't detected from /proc/consoles (happens when console is disabled from MAX).
+# If a console isn't detected, we don't want start_getty to exit as that would
+# cause sysvinit to respawn it.
+# Using tty2 here as it isn't used elsewhere.
+SERIAL_CONSOLES = "38400;tty2"


### PR DESCRIPTION
If serial console is disabled in MAX, start_getty still needs to keep
running (as it'll only be respawned by sysvinit if it dies). So we need
to start getty on some unused terminal.

The console specified in SERIAL_CONSOLES is passed to start_getty
(controlled by /etc/inittab). So have start_getty default to this value
in case a real console isn't found.

### Testing

Built `sysvinit-inittab`, verified that tty2 is used instead of ttyS0 in `/etc/inittab`. Following is the line from `/etc/inittab`

> 2:12345:respawn:/bin/start_getty 38400 tty2 vt102

Modified a target with these changes and verified that console enable and disable work as expected and when console is disabled, `getty` is also started on `tty2` and a log like below doesn't appear in `/var/log/messages`

> init: Id "S0" respawning too fast: disabled for 5 minutes

