### PR TITLE
Remove meta-measured as it is dead upstream

### DIFF
--- a/conf/bblayers.conf.sample
+++ b/conf/bblayers.conf.sample
@@ -8,7 +8,6 @@ BBFILES ?= ""
 BBLAYERS ?= " \
 	${GIT_REPODIR}/meta-cloud-services \
 	${GIT_REPODIR}/meta-cloud-services/meta-openstack \
-	${GIT_REPODIR}/meta-measured \
 	${GIT_REPODIR}/meta-nilrt \
 	${GIT_REPODIR}/meta-openembedded/meta-filesystems \
 	${GIT_REPODIR}/meta-openembedded/meta-gnome \

--- a/recipes-core/packagegroups/packagefeed-ni-extra.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-extra.bb
@@ -772,11 +772,6 @@ RDEPENDS_${PN} += "\
 	qpid \
 "
 
-# meta-measured
-RDEPENDS_${PN} += "\
-	trousers \
-"
-
 # meta-virtualization
 RDEPENDS_${PN} += "\
 	cgroup-lite \

--- a/recipes-support/strongswan/strongswan_5.%.bbappend
+++ b/recipes-support/strongswan/strongswan_5.%.bbappend
@@ -3,7 +3,54 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI += "file://ipsec.init \
 "
 
-PACKAGECONFIG += " eap-identity eap-mschapv2"
+PACKAGECONFIG += " \
+    aikgen \
+    eap-identity \
+    eap-mschapv2 \
+    imc-test \
+    imv-test \
+    imc-scanner \
+    imv-scanner \
+    imc-os \
+    imv-os \
+    imc-attestation \
+    imv-attestation \
+    imc-swima \
+    imv-swima \
+    tnc-ifmap \
+    tnc-imc \
+    tnc-imv \
+    tnc-pdp \
+    tnccs-11 \
+    tnccs-20 \
+    tnccs-dynamic \
+    tss-trousers \
+    "
+
+PACKAGECONFIG[aikgen] = "--enable-aikgen,--disable-aikgen,,"
+PACKAGECONFIG[imc-test] = "--enable-imc-test,--disable-imc-test,,"
+PACKAGECONFIG[imv-test] = "--enable-imv-test,--disable-imv-test,,"
+PACKAGECONFIG[imc-scanner] = "--enable-imc-scanner,--disable-imc-scanner,,"
+PACKAGECONFIG[imv-scanner] = "--enable-imv-scanner,--disable-imv-scanner,,"
+PACKAGECONFIG[imc-os] = "--enable-imc-os,--disable-imc-os,,"
+PACKAGECONFIG[imv-os] = "--enable-imv-os,--disable-imv-os,,"
+PACKAGECONFIG[imc-attestation] = "--enable-imc-attestation,--disable-imc-attestation,,"
+PACKAGECONFIG[imv-attestation] = "--enable-imv-attestation,--disable-imv-attestation,,"
+PACKAGECONFIG[imc-swima] = "--enable-imc-swima,--disable-imc-swima,json-c,"
+PACKAGECONFIG[imv-swima] = "--enable-imv-swima,--disable-imv-swima,json-c,"
+PACKAGECONFIG[tnc-ifmap] = "--enable-tnc-ifmap,--disable-tnc-ifmap,libxml2,"
+PACKAGECONFIG[tnc-imc] = "--enable-tnc-imc,--disable-tnc-imc,,"
+PACKAGECONFIG[tnc-imv] = "--enable-tnc-imv,--disable-tnc-imv,,"
+PACKAGECONFIG[tnc-pdp] = "--enable-tnc-pdp,--disable-tnc-pdp,,"
+PACKAGECONFIG[tnccs-11] = "--enable-tnccs-11,--disable-tnccs-11,libxml2,"
+PACKAGECONFIG[tnccs-20] = "--enable-tnccs-20,--disable-tnccs-20,,"
+PACKAGECONFIG[tnccs-dynamic] = "--enable-tnccs-dynamic,--disable-tnccs-dynamic,,"
+PACKAGECONFIG[tss-trousers] = "--enable-tss-trousers,,libtspi,"
+
+FILES_${PN} += "${libdir}/ipsec/imcvs/*.so ${datadir}/regid.2004-03.org.strongswan"
+FILES_${PN}-dbg += "${libdir}/ipsec/imcvs/.debug"
+FILES_${PN}-dev += "${libdir}/ipsec/imcvs/*.la"
+FILES_${PN}-staticdev += "${libdir}/ipsec/imcvs/*.a"
 
 inherit update-rc.d
 

--- a/recipes-support/trousers/files/tcsd.service
+++ b/recipes-support/trousers/files/tcsd.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=TCG Core Services Daemon
+After=syslog.target
+
+[Service]
+Type=forking
+ExecStart=@SBINDIR@/tcsd
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-support/trousers/files/trousers-udev.rules
+++ b/recipes-support/trousers/files/trousers-udev.rules
@@ -1,0 +1,2 @@
+# trousers daemon expects tpm device to be owned by tss user & group
+KERNEL=="tpm[0-9]*", MODE="0600", OWNER="tss", GROUP="tss"

--- a/recipes-support/trousers/files/trousers.init.sh
+++ b/recipes-support/trousers/files/trousers.init.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:		tcsd trousers
+# Required-Start:	$local_fs $remote_fs $network
+# Required-Stop:	$local_fs $remote_fs $network
+# Should-Start:
+# Should-Stop:
+# Default-Start:	2 3 4 5
+# Default-Stop:		0 1 6
+# Short-Description:	starts tcsd
+# Description:		tcsd belongs to the TrouSerS TCG Software Stack
+### END INIT INFO
+
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+DAEMON=/usr/sbin/tcsd
+NAME=tcsd
+DESC="Trusted Computing daemon"
+USER="tss"
+
+test -x "${DAEMON}" || exit 0
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+case "${1}" in
+	start)
+		echo "Starting $DESC: "
+
+		if [ ! -e /dev/tpm* ]
+		then
+			echo "device driver not loaded, skipping."
+			exit 0
+		fi
+
+		start-stop-daemon --start --quiet --oknodo --pidfile /var/run/${NAME}.pid --user ${USER} --chuid ${USER} --exec ${DAEMON} -- ${DAEMON_OPTS}
+		RETVAL="$?"
+		echo "$NAME."
+		[ "$RETVAL" = 0 ] && pidof $DAEMON > /var/run/${NAME}.pid
+		exit $RETVAL
+		;;
+
+	stop)
+		echo "Stopping $DESC: "
+
+		start-stop-daemon --stop --quiet --oknodo --pidfile /var/run/${NAME}.pid --user ${USER} --exec ${DAEMON}
+		RETVAL="$?"
+                echo  "$NAME."
+		rm -f /var/run/${NAME}.pid
+		exit $RETVAL
+		;;
+
+	restart|force-reload)
+		"${0}" stop
+		sleep 1
+		"${0}" start
+		exit $?
+		;;
+	*)
+		echo "Usage: ${NAME} {start|stop|restart|force-reload|status}" >&2
+		exit 3
+		;;
+esac
+
+exit 0

--- a/recipes-support/trousers/trousers.inc
+++ b/recipes-support/trousers/trousers.inc
@@ -1,0 +1,93 @@
+SUMMARY = "TrouSerS - An open-source TCG Software Stack implementation, created and released by IBM."
+DESCRIPTION = " \
+  Trousers is an open-source TCG Software Stack (TSS), released under the \
+  Common Public License. Trousers aims to be compliant with the current (1.1b) \
+  and upcoming (1.2) TSS specifications available from the Trusted Computing \
+  Group website: http://www.trustedcomputinggroup.org. \
+  "
+SECTION = "tpm"
+PR = "r0"
+LICENSE = "CPL-1.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=8031b2ae48ededc9b982c08620573426"
+DEPENDS = "openssl"
+
+SRC_URI += "http://sourceforge.net/projects/trousers/files/trousers/${PV}/trousers-${PV}.tar.gz \
+            file://trousers.init.sh \
+            file://trousers-udev.rules \
+            file://tcsd.service \
+"
+
+PROVIDES = "${PACKAGES}"
+PACKAGES = " \
+	libtspi \
+	libtspi-dbg \
+	libtspi-dev \
+	libtspi-doc \
+	libtspi-staticdev \
+	trousers \
+	trousers-dbg \
+	trousers-doc \
+	"
+
+FILES_libtspi = " \
+	${libdir}/*.so.1.2.0 \
+	${libdir}/*.so.1 \
+	"
+FILES_libtspi-dbg = " \
+	${libdir}/.debug \
+	${prefix}/src/debug/${PN}/${PV}-${PR}/${PN}-${PV}/src/tspi \
+	${prefix}/src/debug/${PN}/${PV}-${PR}/${PN}-${PV}/src/trspi \
+	${prefix}/src/debug/${PN}/${PV}-${PR}/${PN}-${PV}/src/include/*.h \
+	${prefix}/src/debug/${PN}/${PV}-${PR}/${PN}-${PV}/src/include/tss \
+	"
+FILES_libtspi-dev = " \
+	${includedir} \
+	${libdir}/*.so \
+	"
+FILES_libtspi-doc = " \
+	${mandir}/man3 \
+	"
+FILES_libtspi-staticdev = " \
+	${libdir}/*.la \
+	${libdir}/*.a \
+	"
+FILES_${PN} = " \
+	${sbindir}/tcsd \
+	${sysconfdir} \
+	${localstatedir} \
+	"
+FILES_${PN}-dbg += " \
+	${sbindir}/.debug \
+	${prefix}/src/debug \
+	"
+FILES_${PN}-doc += " \
+	${mandir}/man5 \
+	${mandir}/man8 \
+	"
+
+inherit autotools pkgconfig useradd update-rc.d systemd
+
+INITSCRIPT_NAME = "trousers"
+INITSCRIPT_PARAMS = "start 99 2 3 4 5 . stop 19 0 1 6 ."
+
+EXTRA_OECONF="--with-gui=none"
+
+USERADD_PACKAGES = "${PN}"
+GROUPADD_PARAM_${PN} = "--system tss"
+USERADD_PARAM_${PN} = "--system -M -d /var/lib/tpm -s /bin/false -g tss tss"
+
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE_${PN} = "tcsd.service"
+SYSTEMD_AUTO_ENABLE = "disable"
+
+do_install_append() {
+        install -d ${D}${sysconfdir}/init.d
+        install -m 0755 ${WORKDIR}/trousers.init.sh ${D}${sysconfdir}/init.d/trousers
+        install -d ${D}${sysconfdir}/udev/rules.d
+        install -m 0644 ${WORKDIR}/trousers-udev.rules ${D}${sysconfdir}/udev/rules.d/45-trousers.rules
+        install -d ${D}${systemd_unitdir}/system
+        install -m 0644 ${WORKDIR}/tcsd.service ${D}${systemd_unitdir}/system/
+        sed -i -e 's#@SBINDIR@#${sbindir}#g' ${D}${systemd_unitdir}/system/tcsd.service
+}
+
+BBCLASSEXTEND = "native"

--- a/recipes-support/trousers/trousers_0.3.15.bb
+++ b/recipes-support/trousers/trousers_0.3.15.bb
@@ -1,0 +1,6 @@
+S = "${WORKDIR}/${PN}-${PV}"
+
+require trousers.inc
+
+SRC_URI[md5sum] = "eb1b02e98c7d360749b9076196db3f0f"
+SRC_URI[sha256sum] = "1e5be93e518372acf1d92d2f567d01a46fdb0b730487e544e6fb896c59cac77f"


### PR DESCRIPTION
### Description

meta-measured layer is no longer being maintained upstream. Migrate the strongswan bbappend from meta-measured into meta-nilrt and remove meta-measured;

[Technical Debt 1564625](https://ni.visualstudio.com/DevCentral/_workitems/edit/1564625)

### Implementation
- Migrate strongswan and trousser to meta-nilrt
- Remove meta-measured from meta-nilrt

### Testing
Pending