### PR TITLE
nilrt.conf: Set feed version for the 21.8 release

### DIFF
--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -4,7 +4,7 @@ DISTRO_NAME = "NI Linux Real-Time"
 
 DISTRO_VERSION = "8.11"
 
-NILRT_FEED_NAME = "unstable-legacy"
+NILRT_FEED_NAME = "2021.8"
 
 DISTRO_FEATURES_append_x64 = "\
         x11 \


### PR DESCRIPTION
Service for the System Image 21.8 release.

Will verify feed path in CI.
