### PR TITLE
salt: Staple the salt recipe for the 21.8 release (sumo)

### DIFF
--- a/recipes-connectivity/salt/salt_2018.3.%.bbappend
+++ b/recipes-connectivity/salt/salt_2018.3.%.bbappend
@@ -2,7 +2,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=c996f5a78d858a52c894fa3f4bec68c1"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI = "git://github.com/ni/salt.git;protocol=https;branch=ni/master/2018.3 \
+SRC_URI = "git://github.com/ni/salt.git;protocol=https;branch=ni/skyline-21.5-rt/2018.3 \
            file://set_python_location_hashbang.patch \
            file://minion \
            file://salt-minion \
@@ -17,7 +17,7 @@ SRC_URI = "git://github.com/ni/salt.git;protocol=https;branch=ni/master/2018.3 \
            file://run-ptest \
 "
 
-SRCREV = "${AUTOREV}"
+SRCREV = "15a3ac7fe7ec46d56e18d998d79ddac7c7ce23f1"
 PV = "2018.3+git${SRCPV}"
 
 S="${WORKDIR}/git"


### PR DESCRIPTION
Service for the System Image 21.8 release. The recipe has been stapled to the [same](https://github.com/ni/meta-nilrt/commit/efd2478716b2c8f74548f17aa1e12c8bf3bfec00) versions used in the 21.5 release.