### PR TITLE
nilrt.conf: Bump DISTRO_VERSION to 8.12

### DIFF
--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -2,7 +2,7 @@ require nilrt.inc
 
 DISTRO_NAME = "NI Linux Real-Time"
 
-DISTRO_VERSION = "8.11"
+DISTRO_VERSION = "8.12"
 
 NILRT_FEED_NAME = "unstable-legacy"
 


### PR DESCRIPTION
nilrt.conf: Bump DISTRO_VERSION to 8.12

### Testing
None

### Note
Not bumping DISTRO_VERSION on hardknott branch