### PR TITLE
Updating config partition startup script priorities for consistency with other places. 

### DIFF
--- a/recipes-ni/initscripts-nilrt/initscripts-nilrt_1.0.bb
+++ b/recipes-ni/initscripts-nilrt/initscripts-nilrt_1.0.bb
@@ -70,9 +70,9 @@ do_install () {
 	update-rc.d -r ${D} nicreatecpuacctgroups start 2  4 5 .
 	update-rc.d -r ${D} nisetupkernelconfig   start 3  5 .
 	update-rc.d -r ${D} nicleanstalelinks     start 5  S .
-	update-rc.d -r ${D} nipopulateconfigdir   start 36 S .
-	update-rc.d -r ${D} mountconfig           start 36 S .
-	update-rc.d -r ${D} populateconfig        start 36 S . start 30 0 6 .
+	update-rc.d -r ${D} nipopulateconfigdir   start 35 S .
+	update-rc.d -r ${D} mountconfig           start 35 S .
+	update-rc.d -r ${D} populateconfig        start 35 S . start 30 0 6 .
 	update-rc.d -r ${D} wirelesssetdomain     start 36 S .
 	update-rc.d -r ${D} cleanvarcache         start 38 0 6 S .
 	update-rc.d -r ${D} firewall              start 39 S .


### PR DESCRIPTION
Updating priority of config partition startup scripts.

The priority of the config partition startup scripts in rcS.d were
updated in other places we build our images. This change ensures
the values here match the new values elsewhere.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

AzDO Work Item: https://ni.visualstudio.com/DevCentral/_workitems/edit/1341307/

**Note:** I changed the priority of `nipopulateconfigdir` as it seemed related as well. This script does not exist in the other build system.

## Testing
Deployed the run mode image to an x64 target and confirmed the new priorities were present. Confirmed valid date and no errors in dmesg.