### PR TITLE
Making kdump work for nilrt

### DIFF
--- a/recipes-kernel/kexec/kexec-tools/kdump.conf
+++ b/recipes-kernel/kexec/kexec-tools/kdump.conf
@@ -1,0 +1,19 @@
+#the kdump kernel version string.
+KDUMP_KVER="`uname -r`"
+
+#this will be passed to the kdump kernel as kdump kernel command line
+#only go to runlevel 3 to make boot faster
+#blacklist nikal so no NI driver module would be loaded
+KDUMP_CMDLINE="`cat /proc/cmdline` 3 usbcore.nousb nomodeset module_blacklist=nikal"
+
+#the kernel image for kdump
+KDUMP_KIMAGE="/boot/runmode/bzImage"
+
+#Where to save the vmcore
+KDUMP_VMCORE_PATH="/var/crash/`date +"%Y-%m-%d"`"
+
+#OE makdumpfile in OE cannot read the vmlinux image when booted in crashkernel
+# due a dwarf error so do not pass in the vmlinux and only compresss the image
+# reduce the image size by about (10~20%)
+#the arguments to makedumpfile
+MAKEDUMPFILE_ARGS="-c -D"

--- a/recipes-kernel/kexec/kexec-tools_2.0.21.bbappend
+++ b/recipes-kernel/kexec/kexec-tools_2.0.21.bbappend
@@ -1,0 +1,9 @@
+SUMMARY = "nilrt specific modification for kdump"
+FILESEXTRAPATHS_prepend := "${THISDIR}/kexec-tools:"
+
+SRC_URI += " file://kdump.conf \
+           "
+
+pkg_postinst_kdump() {
+    sed -i 's/set otherbootargs="\(.*\)"/set otherbootargs="\1 crashkernel=128M "/' /boot/runmode/bootimage.cfg
+}


### PR DESCRIPTION
### Description
It would be nice if we get crashkernel working just by installing a few packages, this PR tries to achieve that.

1. `opkg install packagegroup-ni-debug-kernel`
2. `opkg install kexec kexec-tools makedumpfile kdump`
3. Reboot
4. `cat /sys/kernel/kexec_crash_loaded`, make sure it is 1
5. `echo c > /proc/sysrq-trigger` to trigger a crash
6. The dumpfile should be in `/var/crash/`, locate it. The OE crash does not process the dumpfile correctly. So you need to compile crash 8.0.0++ from source. Then do `crash vmcore vmlinux` to analyze the log.

### Implementation
Make nilrt specific modification to kdump.conf.

### Testing
It works on a 9049 4 GB RAM running Hardknott image, the compressed dumpfile is 3.4 GB.
