### PR TITLE
[Salt] Restaple the 21.8 recipe

### DIFF
--- a/recipes-support/salt/salt_3000.2.bb
+++ b/recipes-support/salt/salt_3000.2.bb
@@ -32,7 +32,7 @@ SRC_URI = "\
     file://run-ptest \
 "
 
-SRCREV = "2390363a777ee0ee893bb8698ededcc0bf535278"
+SRCREV = "82051e1a7c95058602257fc8528f28c90dbde065"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Restaple the 21.8 recipe to point to a commit that contains fixes for restartcheck and msgpack

Signed-off-by: Raul Zavaczki <raul.zavaczki@ni.com>