### PR TITLE
makedumpfile: add a ptest to check compatibility with running kernel

### DIFF
--- a/recipes-kernel/makedumpfile/files/makedumpfile-is-kernel-supported.c
+++ b/recipes-kernel/makedumpfile/files/makedumpfile-is-kernel-supported.c
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * makedumpfile-is-kernel-supported.c
+ *
+ * makedumpfile has a supported kernel version range, but doesn't expose a
+ * way to check the current kernel version against it... so this simple
+ * executable sucks in the header file in order to do so.
+ */
+
+#include <errno.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/utsname.h>
+
+// get KVER_MAJ_SHIFT, KVER_MIN_SHIFT, KERNEL_VERSION, OLDEST_VERSION, LATEST_VERSION:
+#include "makedumpfile.h"
+
+// inverse of the KERNEL_VERSION() macro
+#define VERSION_FMT "%d.%d.%d"
+#define VERSION_SPLIT(x) \
+	((x) >> KVER_MAJ_SHIFT) & ((1 << (32 - KVER_MAJ_SHIFT)) - 1), \
+	((x) >> KVER_MIN_SHIFT) & ((1 << (KVER_MAJ_SHIFT - KVER_MIN_SHIFT)) - 1), \
+	(x) & ((1 << KVER_MIN_SHIFT) - 1)
+
+#define PTEST_NAME "makedumpfile-is-kernel-supported"
+
+void ptest_pass() {
+	printf("PASS: %s\n", PTEST_NAME);
+	exit(0);
+}
+
+void ptest_fail() {
+	printf("FAIL: %s\n", PTEST_NAME);
+	exit(1);
+}
+
+bool get_kernel_version(char *release, uint32_t *version) {
+	unsigned long maj, min, rel;
+	char *start, *end;
+
+	*version = 0;
+
+	start = release;
+	maj = strtol(start, &end, 10);
+	if (maj == LONG_MAX)
+		return false;
+
+	start = end + 1;
+	min = strtol(start, &end, 10);
+	if (min == LONG_MAX)
+		return false;
+
+	start = end + 1;
+	rel = strtol(start, &end, 10);
+	if (rel == LONG_MAX)
+		return false;
+
+	*version = KERNEL_VERSION(maj, min, rel);
+	return true;
+}
+
+int main(int argc, char *argv[])
+{
+	struct utsname utsname;
+	uint32_t version;
+	int err;
+
+	if (uname(&utsname)) {
+		err = errno;
+		printf("ERROR: uname() failed to retrieve kernel information: %s\n",
+			strerror(err));
+		ptest_fail();
+	}
+
+	if (!get_kernel_version(utsname.release, &version)) {
+		printf("ERROR: failure parsing kernel version '%s'\n",
+			utsname.release);
+		ptest_fail();
+	}
+
+	if ((version < OLDEST_VERSION) || (LATEST_VERSION < version)) {
+		printf("ERROR: kernel version " VERSION_FMT " not within supported range [" VERSION_FMT " .. " VERSION_FMT "]\n",
+			VERSION_SPLIT(version),	VERSION_SPLIT(OLDEST_VERSION),
+			VERSION_SPLIT(LATEST_VERSION));
+		ptest_fail();
+	}
+
+	ptest_pass();
+}

--- a/recipes-kernel/makedumpfile/files/run-ptest
+++ b/recipes-kernel/makedumpfile/files/run-ptest
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# redirect all stderr to stdout to maintain ordering of output
+exec 2>&1
+
+./makedumpfile-is-kernel-supported
+RESULT=${PIPESTATUS[0]}
+
+exit $RESULT

--- a/recipes-kernel/makedumpfile/makedumpfile_%.bbappend
+++ b/recipes-kernel/makedumpfile/makedumpfile_%.bbappend
@@ -1,0 +1,25 @@
+# Add a ptest to makedumpfile to check that it works on the currently-
+# running kernel. Unfortunately, while the range of supported versions
+# is a static constant within makedumpfile, it's not exposed by any
+# options to makedumpfile itself, so we have to provide our own helper
+# that uses the parent recipe's makedumpfile.h.
+
+inherit ptest
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = "\
+	file://run-ptest \
+	file://makedumpfile-is-kernel-supported.c \
+"
+
+do_compile_ptest_append() {
+	${CC} ${CFLAGS} -I${S} -o ${WORKDIR}/makedumpfile-is-kernel-supported ${WORKDIR}/makedumpfile-is-kernel-supported.c ${LDFLAGS}
+}
+
+do_install_ptest_append() {
+	install -m 0755 ${WORKDIR}/run-ptest ${D}${PTEST_PATH}
+	install -m 0755 ${WORKDIR}/makedumpfile-is-kernel-supported ${D}${PTEST_PATH}
+}
+
+RDEPENDS_${PN}-ptest += " bash "


### PR DESCRIPTION
makedumpfile needs to know some things about internal kernel structures,
which means that it has a supported kernel version range. Since the nilrt
layer uses a different (and sometimes newer) kernel version than the OE
upstream on which it is based, add a ptest so that we can have a check to
see if our current version of makedumpfile works on a kernel upgrade.

Fixes AzDO#1904487.