### PR TITLE
Revert "nilrt-proprietary: Disable running ldconfig."

### DIFF
--- a/recipes-core/images/includes/nilrt-proprietary.inc
+++ b/recipes-core/images/includes/nilrt-proprietary.inc
@@ -1,10 +1,3 @@
-# Disable running ldconfig at the end of the rootfs creation process.
-# Running ldconfig removes symlinks created by ni packages installed
-# to the rootfs, particularly the symlinks to libraries in
-# NIWebServer. This needs to be investigated before ldconfig can be
-# reenabled.
-LDCONFIGDEPEND = ""
-
 # NI infrastructure packages to be installed in the image
 
 NI_PROPRIETARY_SAFEMODE_PACKAGES = "\


### PR DESCRIPTION
This reverts commit a4b2c6ee19fab091c667838030330d5f31de5e1c as it is no
longer required after fixing absolute link issue in pseudo.

### Testing
Verified absolute links aren't deleted during image build with [these changes](https://github.com/ni/openembedded-core/pull/51).

### Note
This is dependent on https://github.com/ni/openembedded-core/pull/51. Please merge this only after that one is merged.
