### PR TITLE
Change NILRT_FEED_NAME to 2022.0

### DIFF
--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -6,7 +6,7 @@ DISTRO_VERSION = "9.0"
 
 DISTRO_CODENAME = "${LAYERSERIES_COMPAT_meta-nilrt}"
 
-NILRT_FEED_NAME = "unstable"
+NILRT_FEED_NAME = "2022.0"
 
 DISTRO_FEATURES_append_x64 = "\
         x11 \


### PR DESCRIPTION
Set NILRT_FEED_NAME to 2022.0 so the feeds will be published to and
consumed from 2022.0 folder.

Work Item: [#1813456](https://ni.visualstudio.com/DevCentral/_workitems/edit/1813456)

### Testing
None