### PR TITLE
Change NILRT_FEED_NAME to 2022.0

### DIFF
--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -4,7 +4,7 @@ DISTRO_NAME = "NI Linux Real-Time"
 
 DISTRO_VERSION = "8.12"
 
-NILRT_FEED_NAME = "unstable-legacy"
+NILRT_FEED_NAME = "2022.0"
 
 DISTRO_FEATURES_append_x64 = "\
         x11 \


### PR DESCRIPTION
Set NILRT_FEED_NAME to 2022.0 so that sumo feeds will be published to
and consumed from 2022.0 folder.

Work Item: [#1813456](https://ni.visualstudio.com/DevCentral/_workitems/edit/1813456)

### Testing
None

### Note
There is a similar PR for hardknott branch https://github.com/ni/meta-nilrt/pull/375.