### PR TITLE
ni_provisioning.common: Increase inode size

### DIFF
--- a/recipes-core/initrdscripts/files/ni_provisioning.common
+++ b/recipes-core/initrdscripts/files/ni_provisioning.common
@@ -22,7 +22,7 @@ GREEN='\e[0;32m'
 ASK_BEFORE_REBOOT=0
 ARCH=$(uname -m)
 VERBOSE_ARGS=${VERBOSE_ARGS:-"-q"}
-MKFS_ARGS=${MKFS_ARGS:-"$VERBOSE_ARGS -F"}
+MKFS_ARGS=${MKFS_ARGS:-"$VERBOSE_ARGS -F -I 256"}
 verbose_mode=${verbose_mode:-0}
 
 if [ "$verbose_mode" -eq 0 ]; then
@@ -528,7 +528,7 @@ early_setup()
 
 	if [[ $verbose_mode -eq 1 ]]; then
 		VERBOSE_ARGS="-v"
-		MKFS_ARGS="$VERBOSE_ARGS -F"
+		MKFS_ARGS="$VERBOSE_ARGS -F -I 256"
 	fi
 
 	if [[ -z $TARGET_DISK ]]; then


### PR DESCRIPTION
Change inode size on boot and config partitions from the default
of 128 to 256 to account for file dates further into the future
past the year 2038.

Signed-off-by: Bill Pittman <bill.pittman@ni.com>

### Testing

Used a couple of VMs to get before and after numbers and then verified those numbers against a 9032, they all had the same before and after numbers:

```
         after   before
config   13609    13129
boot    168897   163265
```