### PR TITLE
ni-modules-autoload: Add recipe

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -23,6 +23,7 @@ RDEPENDS_${PN} = "\
 	librtpi \
 	linux-firmware-radeon \
 	lldpd \
+	ni-modules-autoload \
 	niwatchdogpet \
 	opkg-utils-shell-tools \
 	parted \

--- a/recipes-ni/ni-modules-autoload/files/ni-modules-autoload
+++ b/recipes-ni/ni-modules-autoload/files/ni-modules-autoload
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Copyright (c) 2012-2013 National Instruments.
+# All rights reserved.
+
+# Script for auto-loading kernel modules (needed for modules that are not auto-loaded by udev)
+
+cd /etc/modules.autoload.d
+
+case "$1" in
+    start)
+	for mod in *; do
+	    modprobe -q "$mod"
+	done
+	#autodetection of hardware
+	find /sys/devices -name modalias |
+	    while read -r m; do
+		read -r alias < "$m"
+		modprobe -q "$alias"
+	    done
+	;;
+    stop)
+	for mod in *; do
+	    modprobe -q -r "$mod"
+	done
+	;;
+esac

--- a/recipes-ni/ni-modules-autoload/ni-modules-autoload_1.0.bb
+++ b/recipes-ni/ni-modules-autoload/ni-modules-autoload_1.0.bb
@@ -1,0 +1,28 @@
+SUMMARY = "Initscript for autloading NI modules"
+DESCRIPTION = "Initscript to autoload NI modules in /etc/modules.autoload.d"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+SECTION = "base"
+
+SRC_URI = "\
+	file://ni-modules-autoload \
+"
+
+FILES_${PN} = "\
+	${sysconfdir}/modules.autoload.d \
+	${sysconfdir}/init.d/ni-modules-autoload \
+"
+
+RDEPENDS_${PN} += "bash"
+
+INITSCRIPT_NAME = "ni-modules-autoload"
+INITSCRIPT_PARAMS = "start 37 S ."
+
+inherit update-rc.d
+
+do_install () {
+	install -d ${D}${sysconfdir}/modules.autoload.d
+
+	install -d ${D}${sysconfdir}/init.d/
+	install -m 0755 ${WORKDIR}/ni-modules-autoload ${D}${sysconfdir}/init.d/
+}


### PR DESCRIPTION
Add ni-modules-autoload recipe that installs an initscript to autoload
modules specified in /etc/modules.autoload.d/.

### Testing

- Built locally
- Provisioned a VM with this BSI and verified that modules listed in `/etc/modules.autoload.d` get loaded on startup