### PR TITLE
packagegroup-ni-internal-deps: Add rdma-core

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
@@ -33,3 +33,9 @@ RDEPENDS_${PN} += "\
 RDEPENDS_${PN}_append_x64 = "\
 	qtbase \
 "
+
+# ni-rdma, libnirdma
+# Contact: Eric Gross <eric.gross@ni.com>
+RDEPENDS_${PN} += "\
+	rdma-core \
+"


### PR DESCRIPTION
libnirdma requires rdma-core as a dependency; add it to the core feeds via packagegroup-ni-internal-deps.

Resolves AzDO#1926845.