### PR TITLE
sysconfig-settings: Add systemsettings directory

### DIFF
--- a/recipes-ni/sysconfig-settings/sysconfig-settings_1.0.bb
+++ b/recipes-ni/sysconfig-settings/sysconfig-settings_1.0.bb
@@ -48,9 +48,10 @@ FILES_${PN} = "${settingsdatadir}/consoleout.ini \
                ${uixmldir}/nilinuxrt.rtprotocol_enable.* \
                ${uixmldir}/nilinuxrt.rtapp_disable.* \
                ${uixmldir}/nilinuxrt.fpga_disable.* \
+               ${systemsettingsdir} \
 "
 
-DEPENDS += "shadow-native pseudo-native niacctbase"
+DEPENDS += "shadow-native pseudo-native niacctbase base-files-nilrt"
 RDEPENDS_${PN} += "niacctbase bash fw-printenv"
 
 # sysconfig-settings-ssh package
@@ -124,8 +125,10 @@ do_install () {
 
 	# Common interface for system settings (soft dip switches, etc.)
 	install -d -m 0775 ${D}${settingsdatadir}/
-	chown ${LVRT_USER}:${LVRT_GROUP} ${D}${settingsdatadir}/
 	install -m 0644 ${S}/systemsettings/* ${D}${settingsdatadir}/
+
+	# Create shared systemsettingsdir with appropriate permissions and ownership
+	install -d -m 0775 -o ${LVRT_USER} -g ${LVRT_GROUP} ${D}${systemsettingsdir}
 
 	install -d ${D}${sysconfdir}/init.d/
 	install -m 0755 ${WORKDIR}/nisetembeddeduixml ${D}${sysconfdir}/init.d


### PR DESCRIPTION
Create shared systemsettings directory with expected permissions
and ownership.

Signed-off-by: Bill Pittman <bill.pittman@ni.com>

### Testing
```
0 ✓ bill@ravine /ssd/hardknott/nilrt/build $ ar -p tmp-glibc/deploy/ipk/core2-64/sysconfig-settings_1.0-*.ipk ./data.tar.xz |tar tJv |grep var
drwxr-xr-x root/root         0 2022-04-20 14:03 ./var/
drwxr-xr-x root/root         0 2022-04-20 14:03 ./var/local/
drwxrwxr-x lvuser/ni         0 2022-04-20 14:03 ./var/local/natinst/
drwxrwxr-x lvuser/ni         0 2022-04-20 14:03 ./var/local/natinst/systemsettings/

```