### PR TITLE
Revert "Add python3-typing-extensions to aiohttp"

### DIFF
--- a/recipes-devtools/python/python3-aiohttp_%.bbappend
+++ b/recipes-devtools/python/python3-aiohttp_%.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS_${PN} += "python3-typing-extensions"


### PR DESCRIPTION
This reverts commit 05c7dd363e36136161c64061c728b82fe4b4be87.

This .bbappend was used to add an RDEPENDS, but meta-openembedded is doing that now as of commit b1b87f731a26 ("python3-aiohttp: add missing RDEPENDS on python3-typing-extensions") which makes this .bbappend unnecessary.

Resolves AzDO#1769689.