### PR TITLE
base-files-nilrt: Remove unnecessary pkg_postinst

### DIFF
--- a/recipes-ni/base-files-nilrt/base-files-nilrt_1.0.bb
+++ b/recipes-ni/base-files-nilrt/base-files-nilrt_1.0.bb
@@ -82,18 +82,3 @@ do_install () {
 	# add machine-info and allow System Web Server to modify it
 	install -m 0664 -g ${LVRT_GROUP} ${WORKDIR}/machine-info ${D}${sysconfdir}/
 }
-
-pkg_postinst_${PN} () {
-	# HACK: force ownership of certain directories. See AzDO#1918906.
-	# The various ni-* IPKs from NIFeeds are installed with
-	# IMAGE_INSTALL_NODEPS and therefore do not depend on
-	# base-files-nilrt, and so at present they are installed into the
-	# rootfs first. This is a problem, because it means that "ni-sdmon"
-	# and "ni-traceengine" start owning things like /var/local/natinst
-	# or /usr because they end up creating those directories first
-	# (without our permissions here). As a workaround, we chmod/chown
-	# here, but we should really fix the order and let this happen via
-	# via 'install -d'.
-	chown ${LVRT_USER}:${LVRT_GROUP} $D/var/local/natinst $D/var/local/natinst/log $D${sysconfdir}/natinst/share/
-	chmod 0775 $D/var/local/natinst $D/var/local/natinst/log
-}


### PR DESCRIPTION
Remove the hack to change owner and permissions after all packages
are installed.  This commit reverts commit 54e857930.

Signed-off-by: Bill Pittman <bill.pittman@ni.com>

NOTE: The commit this one reverts is no longer necessary after https://github.com/ni/openembedded-core/pull/52 is pulled.