### PR TITLE
nisystemformat: Use larger inode size on config partition

### DIFF
--- a/recipes-ni/ni-systemformat/files/nisystemformat
+++ b/recipes-ni/ni-systemformat/files/nisystemformat
@@ -190,7 +190,7 @@ format_config()
 	  ext4)
 		local volume_label="niconfig"
 		local options=""
-		mkfs.ext4 -q -F -L $volume_label $options ${2:-$CONFIGFS_DEV}
+		mkfs.ext4 -q -F -I 256 -L $volume_label $options ${2:-$CONFIGFS_DEV}
 		;;
 	esac
 }


### PR DESCRIPTION
When formatting the system, the config partition should use a larger
i-node size than the default to allow for dates past the year 2038.

Signed-off-by: Bill Pittman <bill.pittman@ni.com>