### PR TITLE
Revert "packagegroup-ni-xfce: Add xorg-udev-rules"

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-xfce.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-xfce.bb
@@ -23,7 +23,6 @@ RDEPENDS_${PN} = "\
 	fontconfig-overrides \
 	mousepad \
 	ttf-pt-sans \
-	xserver-xorg-udev-rules \
 "
 RDEPENDS_${PN}_append_x64 += "\
 	xf86-video-ati \


### PR DESCRIPTION
This reverts commit b2fb080fea0e89ac681924109cd1eb5b4270a5f1.

Reverting this commit because I reverted another commit which was
responsible for our only xorg udev rule.

Signed-off-by: Jeffrey Pautler <jeffrey.pautler@ni.com>