### PR TITLE
run-cyclictest: Remove --notrace option

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/run-cyclictest
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/run-cyclictest
@@ -56,7 +56,7 @@ function add_system_info()
 function run_cyclictest()
 {
     LOG="$LOG_DIR/cyclictest-$1-`date +'%Y_%m_%d-%H_%M_%S'`.log"
-    cyclictest --smp --priority=98 --mlockall --notrace --interval=997 --quiet --duration="$TEST_DURATION" --histofall=1000 --histfile="$LOG" > /dev/null
+    cyclictest --smp --priority=98 --mlockall --interval=997 --quiet --duration="$TEST_DURATION" --histofall=1000 --histfile="$LOG" > /dev/null
     add_system_info "$LOG"
 
     LATENCY=$(grep -sw "# Max Latencies:" "$LOG" | awk '{max=$4; for(i=4; i<=NF; i++) if ($i>max) max=$i; gsub("^0*", "", max); print max}')


### PR DESCRIPTION
Remove --notrace option when calling cyclictest as it isn't available in
latest versions anymore.

### Testing
`run-cyclictest` can run with the changes.