### PR TITLE
Build ja_JP.WINDOWS-31J locale for LabVIEW usage.

### DIFF
--- a/recipes-core/glibc/glibc/windows-31j_support.patch
+++ b/recipes-core/glibc/glibc/windows-31j_support.patch
@@ -1,0 +1,29 @@
+From fe8ae616254da00628b45b22500e384fb8c503a0 Mon Sep 17 00:00:00 2001
+From: Charlie Johnston <charlie.johnston@ni.com>
+Date: Mon, 9 May 2022 11:03:55 -0500
+Subject: [PATCH] Adding ja_JP.WINDOWS-31J to built locales
+
+For Japanese locales, glibc only includes unicode-based locales right now but
+some NI software requires non-unicode locales. This enables the WINDOWS-31J
+(CP932) Japanese locale. 
+
+Upstream-Status: Inappropriate [NI-specific changes]
+---
+ localedata/SUPPORTED | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/localedata/SUPPORTED b/localedata/SUPPORTED
+index 1ee5b5e8c8..04fd977d94 100644
+--- a/localedata/SUPPORTED
++++ b/localedata/SUPPORTED
+@@ -280,6 +280,7 @@ it_IT@euro/ISO-8859-15 \
+ iu_CA/UTF-8 \
+ ja_JP.EUC-JP/EUC-JP \
+ ja_JP.UTF-8/UTF-8 \
++ja_JP.WINDOWS-31J/WINDOWS-31J \
+ ka_GE.UTF-8/UTF-8 \
+ ka_GE/GEORGIAN-PS \
+ kab_DZ/UTF-8 \
+-- 
+2.30.2
+

--- a/recipes-core/glibc/glibc_2.%.bbappend
+++ b/recipes-core/glibc/glibc_2.%.bbappend
@@ -6,3 +6,9 @@ SRC_URI =+ " \
 	file://cp936_support.patch \
 	file://cp936-gconv-modules.patch \
 "
+
+# Add patch to build the ja_JP.WINDOWS-31J locale for LabVIEW
+# Japanese language support.
+SRC_URI =+ " \
+	file://windows-31j_support.patch \
+"


### PR DESCRIPTION
Add glibc patch to build windows-31j locale.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

Currently, the en_US.ISO-8859-1 and zh_CN.GBK locales that correspond to the LabVIEW L1 and CP936 locales respectively are built, but not the ja_JP.WINDOWS-31J locale that corresponds to the LabVIEW CP932 locale. This change enables that locale to be build when building glibc-locale.

Azure Work-Item: https://dev.azure.com/ni/DevCentral/_workitems/edit/1908372/

Testing Performed:
Built locally and confirmed the new ja_JP.WINDOWS-31J locale files were built.
Tested installing the locale files to a target and setting them as a locale. 