### PR TITLE
Add glibc locale equivalents to LabVIEW locales to Base System Image

### DIFF
--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -26,5 +26,5 @@ KERNEL_IMAGEDEST = "boot/runmode"
 # - cf oe-core base-files/base-files_3.0.14.bb
 ROOT_HOME = "/home/admin"
 
-IMAGE_LINGUAS ?= "en-us en-us.iso-8859-1"
+IMAGE_LINGUAS ?= "en-us en-us.iso-8859-1 ja-jp.windows-31j zh-cn.gbk"
 


### PR DESCRIPTION
Include Japanese and Chinese locales in base system image.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

This change adds the non-UTF8 Japanese and Chinese locales to the base system image. This will allow aliasing of the LabVIEW locales to glibc-based locales. Note that this depends on #391 to be submitted first.

AzDO Work Item: https://dev.azure.com/ni/DevCentral/_workitems/edit/1908372/

# Testing
- Hand installed a locally build BSI and confirmed the new locales were present by default:
``` bash
admin@NI-cRIO-9043-01D74D6D:~# locale -a
C
POSIX
en_US
en_US.iso88591
en_US.utf8
ja_JP.windows31j
zh_CN.gbk
```
- Checked new and old BSI size.
   - Old: 276910080
   - New: 278824960