### PR TITLE
Add ni-locale-alias package for handling legacy NI Software locales

### DIFF
--- a/recipes-core/glibc/glibc_2.%.bbappend
+++ b/recipes-core/glibc/glibc_2.%.bbappend
@@ -18,3 +18,21 @@ SRC_URI =+ " \
 SRC_URI =+ " \
 	file://alias-custom-locales.patch \
 "
+
+## package: ni-locale-alias ##
+PACKAGES =+ " ni-locale-alias "
+FILES_ni-locale-alias = "${datadir}/locale/locale.alias"
+SUMMARY_ni-locale-alias = "NI Locale Aliases"
+DESCRIPTION_ni-locale-alias = "Custom locale.alias file for NI Software."
+
+# Disable building split locale packages since those are empty.
+# Locale files for glibc are built by glibc-locale.
+PACKAGE_NO_LOCALE = "1"
+
+# The stash_locale_package_cleanup function deletes the /usr/share/locale
+# directory from the package/ staging area before it can be allocated to
+# ni-locale-alias. Restore it before splitting subpackages.
+restore_locale_alias() {
+	install -D ${LOCALESTASH}${datadir}/locale/locale.alias ${PKGD}${datadir}/locale/locale.alias
+}
+PACKAGE_PREPROCESS_FUNCS += " restore_locale_alias "

--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -23,6 +23,7 @@ RDEPENDS_${PN} = "\
 	librtpi \
 	linux-firmware-radeon \
 	lldpd \
+	ni-locale-alias \
 	ni-modules-autoload \
 	niwatchdogpet \
 	opkg-utils-shell-tools \


### PR DESCRIPTION
Add ni-locale-alias package to glibc_2.%.bbappend and include that package in packagegroup-ni-runmode.

This package provides a modified locale.alias file for handling legacy locales used by NI Software.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

AzDO Work Item: https://dev.azure.com/ni/DevCentral/_workitems/edit/1908372/

# Testing
- Built glibc and confirmed the new package existed and the old glibc-locale-locale.alias did not. 
- Built nilrt-base-system-image and installed on a target. Confirmed that the new package was present in the base system image.