### PR TITLE
[sumo] local.conf.sample: set default MACHINE=xilinx-zynq

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -16,8 +16,8 @@
 
 #
 # Machine Selection
-#   Supported NILRT machine values are: x64, xilinx-zynq
-MACHINE ?= "x64"
+#   Supported NILRT machine values are: xilinx-zynq
+MACHINE ?= "xilinx-zynq"
 
 # Distribution selection
 #   Supported NILRT distro values are: nilrt


### PR DESCRIPTION
The `x64` machine type is now primarily supported using the
`nilrt/master/hardknott/` mainline of nilrt.git. The `nilrt/master/sumo`
mainline primarily supports ARM implementations.

Set the default `MACHINE` value to `xilinx-zynq`, to save users the
hassle of remembering to set it each time they build from this mainline.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>