### PR TITLE
[sumo] pkggrp-ni-runmode: remove tbtadm

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-extra.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-extra.bb
@@ -266,10 +266,6 @@ RDEPENDS_${PN} += "\
 "
 
 
-# meta-openembedded/meta-oe/recipes-bsp
-RDEPENDS_${PN} += "\
-	tbtadm \
-"
 # meta-openembedded/meta-oe/recipes-connectivity
 RDEPENDS_${PN} += "\
 	gammu \

--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -28,7 +28,6 @@ RDEPENDS_${PN} = "\
 	parted \
 	rtctl \
 	systemimageupdateinfo \
-	tbtadm \
 	util-linux-sfdisk \
 	vlan \
 	zip \


### PR DESCRIPTION
When building the zynq safemode rootfs in the sumo mainline - only on the build machines - the opkg status will become contamindated with an entry for `tbtadm-lic`. It's status is `deinstall hold not-installed`, and its `VERSION` is set to an error string, apparently from the build machine environment.

This error is consistent on the build machines, but I cannot reproduce it outside of that environment, and it never affects the other rootfses. I suspect it may be related to [this opkg operation](https://github.com/ni/meta-nilrt/blob/840f2e5a38b579c26d6a585d917e8bef665a0d5b/recipes-core/images/niconsole-image-safe.bb#L17), but I don't have an easy way to test that theory on the build machines.

However, thunderbolt isn't actually used on any of the currently supported zynq targets. `tbtadm` was added in [this commit](https://github.com/ni/meta-nilrt/commit/e2653c9d05383b1b95ed3437a61076b408c14737) for PXI support. Since sumo only supports ARM, we can safely remove this package.

Natinst AZDO bug: [Bug 1956754](https://dev.azure.com/ni/DevCentral/_workitems/edit/1956754)


# Testing
* Rebuilt the `zynq*` make targets on my dev machine and confirmed that there are no references to `tbtadm` either in the opkg status file, or in the IPK feed.