### PR TITLE
Adding required SystemLink package to run mode file system

### DIFF
--- a/recipes-core/images/includes/nilrt-proprietary.inc
+++ b/recipes-core/images/includes/nilrt-proprietary.inc
@@ -44,5 +44,6 @@ NI_PROPRIETARY_RUNMODE_PACKAGES = "\
         ni-arch-gen \
         ni-sysmgmt-salt-minion-support \
         ni-sysmgmt-sysapi-expert \
+        python3-ni-asset-discovery \
         python3-ni-systemlink-sdk \
 "


### PR DESCRIPTION
Adding python3-ni-asset-discovery to NI_PROPRIETARY_RUNMODE_PACKAGES.

SystemLink requires python3-ni-asset-discovery to be installed as
part of runmode. This was previously installed as part of an ipk
bundle during base system image installation but will now need to
be manually included until proper dependencies can be configured.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

AzDO Work Item: https://dev.azure.com/ni/DevCentral/_workitems/edit/1990884/

# Testing
Built locally and deployed BSI to a target. Confirmed the following path existed and that the package was installed:
`/usr/lib/python3.5/site-packages/asset_discovery/`