### PR TITLE
nilrt-grub-runmode: fix up spectre/meltdown mitigation cfgs

### DIFF
--- a/recipes-bsp/grub/grub/grub-runmode-bootimage.cfg
+++ b/recipes-bsp/grub/grub/grub-runmode-bootimage.cfg
@@ -4,8 +4,17 @@ set consoleparam='console=tty0 console=ttyS0,115200n8'
 set kernel_path='/runmode/bzImage'
 
 set otherbootargs="rootwait rw usbcore.usbfs_memory_mb=0 consoleblank=0 rcu_nocbs=all "
-for cfg_d_file in /runmode/bootimage.cfg.d/*.cfg; do
-    source "$cfg_d_file"
+
+# These files are used to disable spectre/meltdown mitigations for
+# performance reasons. nirtcfg refers to these paths specifically for
+# enabling/disabling these configuration fragments, so they cannot go
+# into /runmode/bootimage.d. We also cannot load them via wildcard
+# (e.g. cve-*.cfg) because the provisioned grub might not have the
+# regexp module that adds support for file globbing.
+for mitigation_cfg in cve-2017-5715 cve-2017-5754 cve-2018-3620_3646 cve-2018-3639; do
+	if [ -f "/runmode/${mitigation_cfg}.cfg" ]; then
+		source "/runmode/${mitigation_cfg}.cfg"
+	fi
 done
 
 set usb_gadget_args="g_ether.idVendor=${USBVendorID} g_ether.idProduct=${USBProductID} g_ether.iProduct=${USBProduct}[${hostname}] g_ether.iSerialNumber=${SerialNum} g_ether.dev_addr=${usbgadgetethaddr} g_ether.bcdDevice=${USBDevice}"

--- a/recipes-bsp/grub/nilrt-grub-runmode_1.0.bb
+++ b/recipes-bsp/grub/nilrt-grub-runmode_1.0.bb
@@ -11,13 +11,15 @@ SRC_URI += " \
     file://grub.d \
 "
 
-FILES_${PN}     += "/boot/runmode/bootimage.cfg /boot/runmode/bootimage.cfg.d/*.cfg"
-CONFFILES_${PN} += "/boot/runmode/bootimage.cfg /boot/runmode/bootimage.cfg.d/*.cfg"
+FILES_${PN}     += "/boot/runmode/bootimage.cfg /boot/runmode/bootimage.cfg.d/*.cfg /boot/runmode/cve-*.cfg"
+CONFFILES_${PN} += "/boot/runmode/bootimage.cfg /boot/runmode/bootimage.cfg.d/*.cfg /boot/runmode/cve-*.cfg"
 
 do_install () {
 	install -d ${D}/boot/runmode
 	install -m 0644 ${WORKDIR}/grub-runmode-bootimage.cfg ${D}/boot/runmode/bootimage.cfg
 
-	install -d "${D}/boot/runmode/bootimage.cfg.d"
-	install -m 0644 ${WORKDIR}/grub.d/* ${D}/boot/runmode/bootimage.cfg.d
+	install -m 0644 ${WORKDIR}/grub.d/cve-2017-5715.cfg ${D}/boot/runmode
+	install -m 0644 ${WORKDIR}/grub.d/cve-2017-5754.cfg ${D}/boot/runmode
+	install -m 0644 ${WORKDIR}/grub.d/cve-2018-3620_3646.cfg ${D}/boot/runmode
+	install -m 0644 ${WORKDIR}/grub.d/cve-2018-3639.cfg ${D}/boot/runmode
 }


### PR DESCRIPTION
The sumo release offered grub configuration fragments for toggling various spectre/meltdown-related kernel command line arguments, because some mitigations have performance impacts that could affect existing customer applications.

We have a documented interface for toggling these via nirtcfg; however, the nirtcfg implementation is hardcoded to expect the configurations at paths that are not under bootimage.cfg.d. Additionally, the fragments under bootimage.cfg.d were only being properly sourced with a grub that supports wildcard expansion, which some older provisioned targets do not have.

In order to handle both of these issues, move the configuration fragments back into the /boot/runmode directory directly, and also restore explicitly sourcing those fragments by name in bootimage.cfg instead of using wildcards for compatibility with older provisioning. This gets us back to feature parity with sumo.