### PR TITLE
xfce4-panel: Explicitly set panel size property

### DIFF
--- a/recipes-xfce/xfce-nilrt-settings/files/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
+++ b/recipes-xfce/xfce-nilrt-settings/files/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
@@ -17,6 +17,7 @@
       </property>
       <property name="background-alpha" type="uint" value="0"/>
       <property name="autohide" type="bool" value="false"/>
+      <property name="size" type="uint" value="48"/>
     </property>
   </property>
   <property name="plugins" type="empty">

--- a/recipes-xfce/xfce-nilrt-settings/files/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
+++ b/recipes-xfce/xfce-nilrt-settings/files/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
@@ -15,9 +15,15 @@
         <value type="int" value="10"/>
         <value type="int" value="11"/>
       </property>
-      <property name="background-alpha" type="uint" value="0"/>
-      <property name="autohide" type="bool" value="false"/>
+      <property name="autohide-behavior" type="uint" value="0"/>
       <property name="size" type="uint" value="48"/>
+      <property name="background-style" type="uint" value="1"/>
+      <property name="background-rgba" type="array">
+        <value type="double" value="1.000000"/>
+        <value type="double" value="1.000000"/>
+        <value type="double" value="1.000000"/>
+        <value type="double" value="0.000000"/>
+      </property>
     </property>
   </property>
   <property name="plugins" type="empty">
@@ -36,7 +42,7 @@
         <value type="string" value="settings_manager_launcher.desktop"/>
       </property>
     </property>
-   <property name="plugin-4" type="string" value="launcher">
+    <property name="plugin-4" type="string" value="launcher">
       <property name="items" type="array">
         <value type="string" value="display_settings_launcher.desktop"/>
       </property>


### PR DESCRIPTION
Explicitly set panel size as newer xfce4-panel versions require it.
Without this, the panel size defaults to 30 which isn't enough to fit
the existing panel items and also causes tasklist panel item to not
display correctly and respond to mouse inputs.

Azdo Bug: [1995530](https://ni.visualstudio.com/DevCentral/_workitems/edit/1995530)

### Testing

- Verified that a BSI built with these changes fixes tasklist plugin issue and panel size is same as in sumo.

--

sumo has a transparent panel that was set with 'background-alpha'
property. But this property doesn't work on hardknott anymore. So used
panel properties UI to get the new transparency settings. This also
updated the 'autohide' property to 'autohide-behavior'.

### Testing

- Panel is transparent with the changes like in sumo

![image](https://user-images.githubusercontent.com/8194523/172224707-be73b42b-ca5b-4a0e-8064-8e68e9487f33.png)

