### PR TITLE
opkg: add patch to check if tmp_dir exists before deleting

### DIFF
--- a/recipes-devtools/opkg/files/0002-opkg-check-temp-dir-exists-before-delete.patch
+++ b/recipes-devtools/opkg/files/0002-opkg-check-temp-dir-exists-before-delete.patch
@@ -1,0 +1,32 @@
+From 7a8a38e6863d88de2869056b1cb53fc6de3d5f24 Mon Sep 17 00:00:00 2001
+From: Shruthi Ravichandran <shruthi.ravichandran@ni.com>
+Date: Tue, 7 Jun 2022 14:36:19 -0700
+Subject: [PATCH] opkg_conf: Check if tmp_dir exists before deleting
+
+opkg's rm_r prints an error message if the directory to be deleted
+does not exist. There are some cases when the tmp_dir is not created.
+Therefore, check if the tmp_dir exists before trying to delete it.
+
+Upstream-Status: Not Submitted [Hotfix for upcoming release]
+
+Signed-off-by: Shruthi Ravichandran <shruthi.ravichandran@ni.com>
+---
+ libopkg/opkg_conf.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libopkg/opkg_conf.c b/libopkg/opkg_conf.c
+index 37fcd2c..e13ebc1 100644
+--- a/libopkg/opkg_conf.c
++++ b/libopkg/opkg_conf.c
+@@ -906,7 +906,7 @@ void opkg_conf_deinit(void)
+     int i;
+     char **tmp;
+ 
+-    if (opkg_config->tmp_dir)
++    if (opkg_config->tmp_dir && file_exists(opkg_config->tmp_dir))
+         rm_r(opkg_config->tmp_dir);
+ 
+     if (opkg_config->volatile_cache && file_exists(opkg_config->cache_dir))
+-- 
+2.20.1
+

--- a/recipes-devtools/opkg/opkg_%.bbappend
+++ b/recipes-devtools/opkg/opkg_%.bbappend
@@ -8,6 +8,7 @@ SRC_URI += " \
             file://gpg.conf \
             file://run-ptest \
             file://0001-opkg-key-add-keys-even-if-creation-date-is-in-the-fu.patch \
+            file://0002-opkg-check-temp-dir-exists-before-delete.patch \
 "
 
 SRC_URI_append_armv7a = " \


### PR DESCRIPTION
For unknown reasons, the error message from the tmp_dir deletion gets embedded in the version string of *-lic packages within the opkg status file.
See bugs:
https://ni.visualstudio.com/DevCentral/_workitems/edit/1995116
https://ni.visualstudio.com/DevCentral/_workitems/edit/1956754

This patch is an attempt to unblock clients while I root cause the string issue.

I built the NIOpenEmbedded component with this change on the build server and verified that the version string of the gnupg-lic package is fixed in the runmode image. The gnupg-lic package bug is otherwise reproducible in every build on the build server.