### PR TITLE
 salt: always create the minion pki directory (+WS commit)

### DIFF
--- a/recipes-support/salt/files/salt-api
+++ b/recipes-support/salt/files/salt-api
@@ -79,7 +79,7 @@ case "$1" in
         else
             echo "$NAME is stopped"
         fi
-	;;
+        ;;
     #reload)
         # not implemented
         #;;

--- a/recipes-support/salt/files/salt-master
+++ b/recipes-support/salt/files/salt-master
@@ -76,10 +76,10 @@ case "$1" in
     status)
         pid=`pidof -x $DAEMON`
         if [ -n "$pid" ]; then
-	    echo "$NAME (pid $pid) is running ..."
-	else
-	    echo "$NAME is stopped"
-	fi
+            echo "$NAME (pid $pid) is running ..."
+        else
+            echo "$NAME is stopped"
+        fi
         ;;
     #reload)
         # not implemented

--- a/recipes-support/salt/files/salt-minion
+++ b/recipes-support/salt/files/salt-minion
@@ -39,6 +39,10 @@ do_start() {
         return 1
     fi
 
+    # The pki/minion directory must exist for unregistered minions to be added
+    # to NI masters from the Systemlink Web UI.
+    mkdir -p /etc/salt/pki/minion
+
     # Don't start the salt-minion when the master is disabled
     if [ -f "$MASTER_CONF_FILE" ] && [ "$(awk '$1 ~ /^master_type/ {print $2}' $MASTER_CONF_FILE)" = 'disable' ]; then
         return 0

--- a/recipes-support/salt/files/salt-minion
+++ b/recipes-support/salt/files/salt-minion
@@ -85,12 +85,12 @@ case "$1" in
         ;;
     status)
         pid=`pidof -x $DAEMON`
-	if [ -n "$pid" ]; then
-		echo "$NAME (pid $pid) is running ..."
-	else
-		echo "$NAME is stopped"
-	fi
-	;;
+        if [ -n "$pid" ]; then
+            echo "$NAME (pid $pid) is running ..."
+        else
+            echo "$NAME is stopped"
+        fi
+        ;;
     #reload)
         # not implemented
         #;;

--- a/recipes-support/salt/files/salt-syndic
+++ b/recipes-support/salt/files/salt-syndic
@@ -76,11 +76,11 @@ case "$1" in
     status)
         pid=`pidof -x $DAEMON`
         if [ -n "$pid" ]; then
-	    echo "$NAME (pid $pid) is running ..."
-	else
-	    echo "$NAME is stopped"
+            echo "$NAME (pid $pid) is running ..."
+        else
+            echo "$NAME is stopped"
         fi
-	;;
+        ;;
     #reload)
         # not implemented
         #;;


### PR DESCRIPTION
```
 salt: always create the minion pki directory

A bug exists in the NI salt-master script that adds unregistered minions
to a salt master workspace. The script tries to write a pre-approved key
into the minion's `/etc/salt/pki/minion/minion.pem` file. If that
directory doesn't exist, then the script fails.

We cannot fix the master-side script. So unconditionally create the
`.../pki/minion/` directory if it does not exist at startup.
```

NI AZDO: [#2015761](https://ni.visualstudio.com/DevCentral/_workitems/edit/2015761)

NOTE: I would have used `install -d` to create the directory, but it does the same as `mkdir -p` in this case, and `install` is not available by default on sumo images. So this implementation - even though it will not be cherry-picked to sumo - is a little more portable.

# Testing
* tested this change on a NILRT runmode and confirmed that the `/etc/salt/pki/minion` directory is always created at startup, even if the daemon decides not to run.