### PR TITLE
packagegroup-ni-internal-deps: add flexrio deps

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
@@ -39,3 +39,11 @@ RDEPENDS_${PN}_append_x64 = "\
 RDEPENDS_${PN} += "\
 	rdma-core \
 "
+
+# ni-flexrio-integratedio-libs, required for csi2serdesconfig
+# Contact: Michael Strain <michael.strain@ni.com>
+RDEPENDS_${PN}_append_x64 = "\
+	python3-core \
+	python3-ctypes \
+	python3-threading \
+"


### PR DESCRIPTION
FlexRIO has packages required by a script included
in the ni-flexrio-integratedio-libs package. This
adds the packages to packagegroup-ni-internal-deps
to ensure they are included properly.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

**Note**: I will cherry-pick this into the 22.5 branch in a separate PR.

AzDO work item: https://dev.azure.com/ni/DevCentral/_workitems/edit/1931318/

# Testing
Built locally and confirmed that the new packages are listed as dependencies of `packagegroup-ni-internal-deps` in that package's control file.