### PR TITLE
nilrt.inc: Point grub to 22.5 release branch

### DIFF
--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -2,7 +2,7 @@ MAINTAINER = "NI Linux Real-Time Maintainers <nilrt@ni.com>"
 
 TARGET_VENDOR = "-nilrt"
 
-GRUB_BRANCH = "main"
+GRUB_BRANCH = "nilrt/22.5/sumo"
 
 # Inherit the default LIBC features superset from OE-core
 DISTRO_FEATURES += "${DISTRO_FEATURES_LIBC}"


### PR DESCRIPTION
Service for the 2022C2 release.

### Testing
None