### PR TITLE
Restaple salt commit to include DNS fix

### DIFF
--- a/recipes-support/salt/salt_3000.2.bb
+++ b/recipes-support/salt/salt_3000.2.bb
@@ -32,7 +32,7 @@ SRC_URI = "\
     file://run-ptest \
 "
 
-SRCREV = "ea46e95d3050d6aa4d551542386a78553d983b4c"
+SRCREV = "d77a97425aa81d34dbe97024e6096ef9c18be7db"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
We recently discovered a weird behavior when trying to connect salt minions to unreachable hosts.
We cherry-picked the fix from salt upstream, but we have to update the commit SHA.

https://github.com/ni/salt/commit/d77a97425aa81d34dbe97024e6096ef9c18be7db

Signed-off-by: Raul Zavaczki <raul.zavaczki@ni.com>