### PR TITLE
packagegroup-ni-base: Add modutils-initscripts

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -66,6 +66,7 @@ RDEPENDS_${PN} += "\
 	linux-firmware-i915 \
 	logrotate \
 	lsbinitscripts \
+	modutils-initscripts \
 	netbase \
 	ni-hw-scripts \
 	ni-rtfeatures \


### PR DESCRIPTION
packagegroup-ni-base: Add modutils-initscripts
    
Modules specified in KERNEL_MODULE_AUTOLOAD will have a module_name.conf
file created in /etc/modules-load.d which will enable an initscript
installed by modutils-initscripts to autoload them.

We had some modules specified in KERNEL_MODULE_AUTOLOAD but didn't
include modutils-initscripts recipe in our images causing those modules
to not be loaded.

So add modutils-initscripts to packagegroup-ni-base.

AZDO WI: [#1722320](https://dev.azure.com/ni/DevCentral/_workitems/edit/1722320)

### Testing

- Built locally.
- Installed BSI to cRIO-9042 and verified that `g_ether.ko` is autloaded.
- Unpacked safemode initrd and verified that `modutils-initscripts` is installed.

### Note
We may eventually want to fix (and upstream) [kernel-module-split.bbclass](https://github.com/ni/openembedded-core/blob/nilrt/master/hardknott/meta/classes/kernel-module-split.bbclass#L88) so that modules specifying `KERNEL_MODULE_AUTOLOAD` have `modutils-initscripts` added to their package dependency list. But I think we would still want changes in this PR regardless.