### PR TITLE
packagegroup-ni-base: Add modutils-initscripts

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -66,6 +66,7 @@ RDEPENDS_${PN} += "\
 	linux-firmware-i915 \
 	logrotate \
 	lsbinitscripts \
+	modutils-initscripts \
 	netbase \
 	ni-hw-scripts \
 	ni-rtfeatures \


### PR DESCRIPTION
Modules specified in KERNEL_MODULE_AUTOLOAD will have a module_name.conf
file created in /etc/modules-load.d which will enable an initscript
installed by modutils-initscripts to autoload them.

We had some modules specified in KERNEL_MODULE_AUTOLOAD but didn't
include modutils-initscripts recipe in our images causing those modules
to not be loaded.

So add modutils-initscripts to packagegroup-ni-base.

Signed-off-by: Chaitanya Vadrevu <chaitanya.vadrevu@ni.com>
(cherry picked from commit 9a38e518675bc3b3d8c125b1bb2d78ad8251f827)

AZDO WI: [#1722320](https://dev.azure.com/ni/DevCentral/_workitems/edit/1722320)

### Testing
Tested on 22.5 branch. Ref [this](https://github.com/ni/meta-nilrt/pull/418).