### PR TITLE
nilrt-proprietary: remove ni-rtlog

### DIFF
--- a/recipes-core/images/includes/nilrt-proprietary.inc
+++ b/recipes-core/images/includes/nilrt-proprietary.inc
@@ -11,7 +11,6 @@ NI_PROPRIETARY_COMMON_PACKAGES = "\
         ni-avahi-client \
         ni-ca-certs \
         ni-rt-exec-webservice \
-        ni-rtlog \
         ni-sdmon \
         ni-service-locator \
         ni-skyline-file-client \


### PR DESCRIPTION
The ni-rtlog package provides the /etc/logrotate.d/nilvrterr.conf syslog
configuration snippet, and the `libni_rtlog.so` dynamic library. Neither
of these files is a requirement of any other software installed to the
NILRT base system image. Further, `ni-rtlog` is not an IPK dependency of
anything installed to the base image.

So remove ni-rtlog from the base image, in an effort to eschew the
requirement of having a LabVIEW IPK feed at image-build-time.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

# Testing
* Built the safemode and runmode images on my dev machine, created and booted a safemode VM. Everything seems OK.