### PR TITLE
Remove GRUB_VERSION and associated variables

### DIFF
--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -2,8 +2,6 @@ MAINTAINER = "NI Linux Real-Time Maintainers <nilrt@ni.com>"
 
 TARGET_VENDOR = "-nilrt"
 
-GRUB_BRANCH = "nilrt/19.0"
-
 DISTRO_FEATURES += "${DISTRO_FEATURES_DEFAULT}"
 # Common features enabled on all NILRT flavours
 DISTRO_FEATURES += "\

--- a/recipes-core/images/nilrt-recovery-media.bb
+++ b/recipes-core/images/nilrt-recovery-media.bb
@@ -34,10 +34,7 @@ bootimg_fixup() {
 	install -m 0644 ${THISDIR}/files/grubenv_non_ni_target	${IMAGE_ROOTFS}/payload
 	install -m 0644 ${THISDIR}/files/unicode.pf2		${IMAGE_ROOTFS}/payload/fonts
 
-	GRUB_VERSION=$(echo ${GRUB_BRANCH} | cut -d "/" -f 2)
-
 	echo "BUILD_IDENTIFIER=${BUILD_IDENTIFIER}" > ${IMAGE_ROOTFS}/payload/imageinfo
-	echo "GRUB_VERSION=${GRUB_VERSION}.0" >> ${IMAGE_ROOTFS}/payload/imageinfo
 }
 
 symlink_iso () {

--- a/recipes-core/initrdscripts/files/ni_provisioning.safemode
+++ b/recipes-core/initrdscripts/files/ni_provisioning.safemode
@@ -327,12 +327,10 @@ install_grubenv()
 set_versions()
 {
 	BUILD_IDENTIFIER=$(get_image_info BUILD_IDENTIFIER)
-	GRUB_IDENTIFIER=$(get_image_info GRUB_VERSION)
 
-	echo "set ni_grub_version=${GRUB_IDENTIFIER}" > $BOOTFS_MOUNTPOINT/grub/grub-ni-version
 	echo "set ni_recoverytool_version=${BUILD_IDENTIFIER}" > $BOOTFS_MOUNTPOINT/grub/recoverytool-ni-version
 
-	chmod 444 $BOOTFS_MOUNTPOINT/grub/grub-ni-version $BOOTFS_MOUNTPOINT/grub/recoverytool-ni-version
+	chmod 444 $BOOTFS_MOUNTPOINT/grub/recoverytool-ni-version
 }
 
 fixup_configfs()


### PR DESCRIPTION


Fixes azdo [bug](https://ni.visualstudio.com/DevCentral/_workitems/edit/2033588).

### Testing

Built nilrt-recovery-media and successfully ran the provisioning scripts to generate a qemu safemode VM. Was also able to start and log into the VM.