### PR TITLE
start_getty: Don't run getty on tty0 or tty1

### DIFF
--- a/recipes-core/sysvinit/sysvinit-inittab/start_getty
+++ b/recipes-core/sysvinit/sysvinit-inittab/start_getty
@@ -10,6 +10,12 @@ CONSOLE=$2
 TERM=$3
 
 while read cons flags; do
+   # tty1 comes up by default in inittab and tty0 is an alias to active terminal.
+   # So don't select these.
+   if [ "$cons" = "tty0" ] || [ "$cons" = "tty1" ]; then
+      continue;
+   fi
+
    case "$flags" in
    *EC*) CONSOLE="$cons"
          SPEED=$(stty speed < /dev/$CONSOLE)


### PR DESCRIPTION
In /etc/inittab, we run getty on tty1 by default and want to run getty
on default serial console if "Enable Console Out" is selected in MAX.

getty shouldn't be run more than once on the same terminal. So on
targets where tty0 or tty1 end up being the preferred console, we don't
want to run getty on them because getty is already running on tty1 and
tty0 is an alias to active terminal (and may point to tty1).

Azure WI: [2055925](https://ni.visualstudio.com/DevCentral/_workitems/edit/2055925)

### Testing
Verified terminal on a Hyper-V VM works correctly.
Ran these changes on a cRIO-9049 without issues.