### PR TITLE
add dkms recipe from oe-core

### DIFF
--- a/recipes-kernel/dkms/dkms_%.bbappend
+++ b/recipes-kernel/dkms/dkms_%.bbappend
@@ -1,1 +1,0 @@
-RDEPENDS_${PN} += "kernel-devsrc"

--- a/recipes-kernel/dkms/dkms_2.4.0.bb
+++ b/recipes-kernel/dkms/dkms_2.4.0.bb
@@ -1,0 +1,14 @@
+SUMMARY = "DKMS Recipe - Adds DKMS tool for target"
+HOMEPAGE = "https://github.com/dell/dkms/"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=0636e73ff0215e8d672dc4c32c317bb3"
+
+SRC_URI = "https://github.com/dell/${PN}/archive/v${PV}.tar.gz"
+
+SRC_URI[md5sum] = "d2e74dd79086c564a924b5763794091b"
+
+INSANE_SKIP_${PN} += "dev-deps"
+
+RDEPENDS_${PN} += "bash kmod gcc make patch kernel-dev"
+
+inherit autotools-brokensep

--- a/recipes-kernel/dkms/dkms_2.4.0.bb
+++ b/recipes-kernel/dkms/dkms_2.4.0.bb
@@ -12,9 +12,9 @@ SRCREV = "8c3065c6b26d573d55abfcb17b422204ba63e590"
 
 S = "${WORKDIR}/git"
 
-INSANE_SKIP_${PN} += "dev-deps"
+INSANE_SKIP:${PN} += "dev-deps"
 
-RDEPENDS_${PN} += " \
+RDEPENDS:${PN} += " \
 	bash \
 	gcc \
 	kernel-dev \

--- a/recipes-kernel/dkms/dkms_2.4.0.bb
+++ b/recipes-kernel/dkms/dkms_2.4.0.bb
@@ -6,9 +6,11 @@ SECTION = "kernel"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=0636e73ff0215e8d672dc4c32c317bb3"
 
-SRC_URI = "https://github.com/dell/${PN}/archive/v${PV}.tar.gz"
+SRC_URI = "git://github.com/dell/dkms.git;protocol=https;branch=master"
 
-SRC_URI[md5sum] = "d2e74dd79086c564a924b5763794091b"
+SRCREV = "8c3065c6b26d573d55abfcb17b422204ba63e590"
+
+S = "${WORKDIR}/git"
 
 INSANE_SKIP_${PN} += "dev-deps"
 

--- a/recipes-kernel/dkms/dkms_2.4.0.bb
+++ b/recipes-kernel/dkms/dkms_2.4.0.bb
@@ -1,5 +1,8 @@
-SUMMARY = "DKMS Recipe - Adds DKMS tool for target"
+SUMMARY = "Dynamic Kernel Module System (DKMS)"
+DESCRIPTION = "DKMS is a framework designed to allow individual kernel modules to be upgraded without changing the whole kernel. It is also very easy to rebuild modules as you upgrade kernels."
 HOMEPAGE = "https://github.com/dell/dkms/"
+BUGTRACKER = "https://github.com/dell/dkms/issues"
+SECTION = "kernel"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=0636e73ff0215e8d672dc4c32c317bb3"
 

--- a/recipes-kernel/dkms/dkms_2.4.0.bb
+++ b/recipes-kernel/dkms/dkms_2.4.0.bb
@@ -9,6 +9,14 @@ SRC_URI[md5sum] = "d2e74dd79086c564a924b5763794091b"
 
 INSANE_SKIP_${PN} += "dev-deps"
 
-RDEPENDS_${PN} += "bash kmod gcc make patch kernel-dev"
+RDEPENDS_${PN} += " \
+	bash \
+	gcc \
+	kernel-dev \
+	kernel-devsrc \
+	kmod \
+	make \
+	patch \
+"
 
 inherit autotools-brokensep


### PR DESCRIPTION
NILRT's dkms recipe has been rejected by both oe-core upstream and
meta-oe upstream.

Migrate the 2.4.0 version of the recipe to meta-nilrt directly, so that
it can be maintained as a NILRT-specific recipe.

See ni/openembedded-core commit e0cab6fc8868c32d120d2fea7d39798d6f4add35
for the recipe's original addition commit.

# Testing
Rebuilt and installed this `dkms` package to a 22.8 VM. Installed the `ni-pal-dkms` module from the `ni-main` feed. Everything worked correctly.