### PR TITLE
dkms: upgrade to 3.0.5

### DIFF
--- a/recipes-kernel/dkms/dkms/0001-Makefile-set-release-information-for-v3.0.5.patch
+++ b/recipes-kernel/dkms/dkms/0001-Makefile-set-release-information-for-v3.0.5.patch
@@ -1,0 +1,32 @@
+From 95d14416474848e4064a171923f99905e0091ac7 Mon Sep 17 00:00:00 2001
+From: Alex Stewart <alex.stewart@ni.com>
+Date: Tue, 12 Jul 2022 04:50:22 -0500
+Subject: [PATCH] Makefile: set release information for v3.0.5
+
+The release variables were not set for the original v3.0.5 release tag.
+So `dkms --version` would erroneously report `dkms-3.0.4`.
+
+Set the correct release information.
+
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+
+Upstream-Status: Submitted [https://github.com/dell/dkms/pull/233]
+
+---
+ Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index d4735d4..132cb69 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,7 +1,7 @@
+-RELEASE_DATE := "18 June 2022"
++RELEASE_DATE := "30 June 2022"
+ RELEASE_MAJOR := 3
+ RELEASE_MINOR := 0
+-RELEASE_MICRO := 4
++RELEASE_MICRO := 5
+ RELEASE_NAME := dkms
+ RELEASE_VERSION := $(RELEASE_MAJOR).$(RELEASE_MINOR).$(RELEASE_MICRO)
+ RELEASE_STRING := $(RELEASE_NAME)-$(RELEASE_VERSION)

--- a/recipes-kernel/dkms/dkms/0002-dkms.in-skip-sign_file-call-when-unset.patch
+++ b/recipes-kernel/dkms/dkms/0002-dkms.in-skip-sign_file-call-when-unset.patch
@@ -1,0 +1,39 @@
+From a2818feee267996a112d8f4571a2c410575d3543 Mon Sep 17 00:00:00 2001
+From: Alex Stewart <alex.stewart@ni.com>
+Date: Tue, 12 Jul 2022 04:55:59 -0500
+Subject: [PATCH] dkms.in: skip sign_file call when unset
+
+The module-signing script is located in prepare_signing(). It is
+possible for installation to proceed, even if no signing file is located
+on the system. In that case, the script promises that signing will not
+occur.
+
+However, in actual_build(), there is no check for the case where
+$sign_file is unset. So `eval "" sha512 ...` is executed instead - which
+is a nonsense command.
+
+If $sign_file is unset, skip signing.
+
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+
+Upstream-Status: Submitted [https://github.com/dell/dkms/pull/234]
+
+---
+ dkms.in | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/dkms.in b/dkms.in
+index ba312c3..4510436 100644
+--- a/dkms.in
++++ b/dkms.in
+@@ -1030,7 +1030,9 @@ actual_build()
+                     kmodsign sha512 $mok_signing_key $mok_certificate "$built_module"
+                     ;;
+                 *)
+-                    eval $sign_file sha512 $mok_signing_key $mok_certificate "$built_module"
++                    if [ -n "${sign_file}" ]; then
++                        eval $sign_file sha512 $mok_signing_key $mok_certificate "$built_module"
++                    fi
+                     ;;
+             esac
+         fi

--- a/recipes-kernel/dkms/dkms_3.0.5.bb
+++ b/recipes-kernel/dkms/dkms_3.0.5.bb
@@ -6,7 +6,10 @@ SECTION = "kernel"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-SRC_URI = "git://github.com/dell/dkms.git;protocol=https;branch=master"
+SRC_URI = "git://github.com/dell/dkms.git;protocol=https;branch=master \
+           file://0001-Makefile-set-release-information-for-v3.0.5.patch \
+           file://0002-dkms.in-skip-sign_file-call-when-unset.patch \
+           "
 
 SRCREV = "1e24a54acaa2e3a8aa6e8e24b21f47553370c4fe"
 

--- a/recipes-kernel/dkms/dkms_3.0.5.bb
+++ b/recipes-kernel/dkms/dkms_3.0.5.bb
@@ -4,15 +4,20 @@ HOMEPAGE = "https://github.com/dell/dkms/"
 BUGTRACKER = "https://github.com/dell/dkms/issues"
 SECTION = "kernel"
 LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://COPYING;md5=0636e73ff0215e8d672dc4c32c317bb3"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 SRC_URI = "git://github.com/dell/dkms.git;protocol=https;branch=master"
 
-SRCREV = "8c3065c6b26d573d55abfcb17b422204ba63e590"
+SRCREV = "1e24a54acaa2e3a8aa6e8e24b21f47553370c4fe"
 
 S = "${WORKDIR}/git"
 
+# We don't need the dist/ tarball.
+EXTRA_OEMAKE += " -o tarball"
+
 INSANE_SKIP:${PN} += "dev-deps"
+
+FILES:${PN} += " ${datadir}/bash-completion/*"
 
 RDEPENDS:${PN} += " \
 	bash \


### PR DESCRIPTION
This patchset upgrades the `dkms` recipe from `v2.4.0` (~2017) to `v3.0.5` (~2022-07). It also applies some fixes to the upstream codebase, which are pending upstream.

Dell doesn't maintain a NEWS or CHANGELOG for releases, but here are the changes between the versions.
[changes](https://github.com/dell/dkms/compare/8c3065c6b26d573d55abfcb17b422204ba63e590...1e24a54acaa2e3a8aa6e8e24b21f47553370c4fe)

NOTE: I tried also creating a `dkms-ptest` from the `:test/` directory in the dkms upstream source. It's kinda' almost close to working, but requires some patching and for us to provide new "expected output" for the test to compare against. So there is a pathway to get it working, but it was too much work for me to justify at this time.

# Testing
* Rebuilt `dkms` and installed it to a 22.8 VM. It successfully installs and uninstalls the `ni-pal-dkms` module. The real testing here will come out of client testing.
* Installed `dkms_3.0.5` to a cRIO-9049 with the latest 22.8 runmode. Installed the default software selection through MAX. Everything installed correctly and the system rebooted.; An eyeball sum of the loaded modules suggests that they are loaded correctly as well.
```
admin@NI-cRIO-9049-01E4AE87:~# dkms --version
dkms-3.0.5
admin@NI-cRIO-9049-01E4AE87:~# dkms status 
atomicchinchk/22.8.0d23, 5.10.115-rt67, x86_64: installed
nibds/22.8.0d20, 5.10.115-rt67, x86_64: installed
nicartenumk/22.5.0f102, 5.10.115-rt67, x86_64: installed
nicdcck/22.5.0f102, 5.10.115-rt67, x86_64: installed
nicdrk/22.5.0f102, 5.10.115-rt67, x86_64: installed
nichenumk/22.5.0f102, 5.10.115-rt67, x86_64: installed
nicsrk/22.5.0f102, 5.10.115-rt67, x86_64: installed
nidimk/22.8.0d15, 5.10.115-rt67, x86_64: installed
nidmxfk/22.5.0f102, 5.10.115-rt67, x86_64: installed
nifdrk/22.5.0f102, 5.10.115-rt67, x86_64: installed
nifresnelmbdc/22.5.0f102, 5.10.115-rt67, x86_64: installed
nifslk/22.5.0f102, 5.10.115-rt67, x86_64: installed
nikal/22.8.0d20, 5.10.115-rt67, x86_64: installed
nilmsk/22.5.0f102, 5.10.115-rt67, x86_64: installed
nimdbgk/22.8.0d21, 5.10.115-rt67, x86_64: installed
nimru2k/22.8.0d15, 5.10.115-rt67, x86_64: installed
nimsdrk/22.5.0f102, 5.10.115-rt67, x86_64: installed
nimxdfk/22.8.0d21, 5.10.115-rt67, x86_64: installed
niorbk/22.8.0d21, 5.10.115-rt67, x86_64: installed
nipalk/22.8.0d21, 5.10.115-rt67, x86_64: installed
nisdigk/22.5.0f102, 5.10.115-rt67, x86_64: installed
ni-si514/22.8.0d19, 5.10.115-rt67, x86_64: installed
nistc3rk/22.5.0f102, 5.10.115-rt67, x86_64: installed
niswdk/22.5.0f102, 5.10.115-rt67, x86_64: installed
```
* I tried installing the `kernel-next` package (after installing all the above DKMS modules), and that threw a strange warning about not supporting symlinks on the filesystem. It rebooted into kernel 5.15, but several modules failed to load, including some of the network modules. I'm not convinced that I did everything correctly, so I can't blame that on DKMS.
* In `dkms_3.0.0`, [upstream deprecated](https://github.com/dell/dkms/releases/tag/v3.0.0) several keys in the `dkms.conf` file. I grepped through the above modules' `dkms.conf`s and didn't see any offenders. Codesearch similarly returned nothing.
    * I otherwise didn't see anything alarming in the commit log.

# Maintainership
I won't merge this PR until:
* [x] meta-nilrt #427 has merged.
* [x] I have finished looking over the upstream changes since 2.4.0.
* [x] I have tested the new dkms on an x64 cRIO.