### PR TITLE
packagegroup-ni-base: Add efibootmgr

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -42,6 +42,7 @@ RDEPENDS_${PN} += "\
 	dpkg-start-stop \
 	e2fsprogs \
 	e2fsprogs-mke2fs \
+	efibootmgr \
 	efivar \
 	ethtool \
 	eudev \


### PR DESCRIPTION
efibootmgr is required by NI internal tools to switch between installed
OSes. So include it in safemode and runmode.

WI: [2066619](https://ni.visualstudio.com/DevCentral/_workitems/edit/2066619)

### Testing
None