### PR TITLE
xfce-nilrt-settings: Update lvuser configs to point to renamed xfce settings

### DIFF
--- a/recipes-xfce/xfce-nilrt-settings/files/menus/xfce-applications.menu
+++ b/recipes-xfce/xfce-nilrt-settings/files/menus/xfce-applications.menu
@@ -14,8 +14,8 @@
 
     <Layout>
         <Filename>xfce4-run.desktop</Filename>
-        <Filename>exo-terminal-emulator.desktop</Filename>
-        <Filename>exo-file-manager.desktop</Filename>
+        <Filename>xfce4-terminal-emulator.desktop</Filename>
+        <Filename>xfce4-file-manager.desktop</Filename>
         <Menuname>Settings</Menuname>
         <Separator/>
         <Filename>xfce4-about.desktop</Filename>

--- a/recipes-xfce/xfce-nilrt-settings/files/xfce4/panel/launcher-1/file_manager_launcher.desktop
+++ b/recipes-xfce/xfce-nilrt-settings/files/xfce4/panel/launcher-1/file_manager_launcher.desktop
@@ -10,4 +10,4 @@ OnlyShowIn=XFCE;
 X-XFCE-MimeType=x-scheme-handler/file;x-scheme-handler/trash;
 Name=File Manager
 Comment=Browse the file system
-X-XFCE-Source=file:///usr/share/applications/exo-file-manager.desktop
+X-XFCE-Source=file:///usr/share/applications/xfce4-file-manager.desktop

--- a/recipes-xfce/xfce-nilrt-settings/files/xfce4/panel/launcher-2/terminal_emulator_launcher.desktop
+++ b/recipes-xfce/xfce-nilrt-settings/files/xfce4/panel/launcher-2/terminal_emulator_launcher.desktop
@@ -9,4 +9,4 @@ Categories=Utility;X-XFCE;X-Xfce-Toplevel;
 OnlyShowIn=XFCE;
 Name=Terminal Emulator
 Comment=Use the command line
-X-XFCE-Source=file:///usr/share/applications/exo-terminal-emulator.desktop
+X-XFCE-Source=file:///usr/share/applications/xfce4-terminal-emulator.desktop


### PR DESCRIPTION
# Justification
Fix an issue where the pre-configured lvuser xfce configs were not pointing to the correct xfce setting for terminal-emulator and
file-manager.

AzDO Work Item: 2036899
# Implementation
Update lvuser xfce pre-configured settings to point from files with prefix of exo to xfce4
# Testing
I built and deployed the xfce-nilrt-settings package and verified the right click menu correctly showed and was able to launch the terminial-emulator and file-manager.

Before fix
![RightClickMenuBefore](https://user-images.githubusercontent.com/63658551/178778713-7b2dc261-c7df-4097-b970-d1c255126329.PNG)
After fix
![RightClickMenuAfter](https://user-images.githubusercontent.com/63658551/178778755-3ad08b3c-5f27-4f38-aeea-c48d5f982ebc.PNG)

