### PR TITLE
libpam: add NI-specific pamd.d/other file

### DIFF
--- a/recipes-extended/pam/libpam/pam.d/other
+++ b/recipes-extended/pam/libpam/pam.d/other
@@ -1,0 +1,27 @@
+#
+# /etc/pam.d/other - specify the PAM fallback behaviour
+#
+# Note that this file is used for any unspecified service; for example
+#if /etc/pam.d/cron  specifies no session modules but cron calls
+#pam_open_session, the session module out of /etc/pam.d/other is
+#used.
+
+#If you really want nothing to happen then use pam_permit.so or
+#pam_deny.so as appropriate.
+
+# We use pam_warn.so to generate syslog notes that the 'other'
+#fallback rules are being used (as a hint to suggest you should setup
+#specific PAM rules for the service and aid to debugging). We then
+#fall back to the system default in /etc/pam.d/common-*
+
+auth       required     pam_warn.so
+auth       include      common-auth
+
+account    required     pam_warn.so
+account    include      common-account
+
+password   required     pam_warn.so
+password   include      common-password
+
+session    required     pam_warn.so
+session    include      common-session

--- a/recipes-extended/pam/libpam_1.%.bbappend
+++ b/recipes-extended/pam/libpam_1.%.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"


### PR DESCRIPTION
NILRT prefers to handle the default PAM authentication behavior
differently from OE-core upstream. Previously, NILRT maintained an
out-of-stream commit to set the values of the `pam.d/other` file. This
commit was reverted from OE-core.

Move the NI-specific `other` file to meta-nilrt as-is.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

Natinst AZDO ID: [#1580104](https://dev.azure.com/ni/DevCentral/_workitems/edit/1580104)

# Testing
* Rebuilt the `libpam` package with this change, and verified that the `libpam-runtime:/etc/pam.d/other` conffile has the NI-specific values.

# Maintainership
* Depends on OE-core [#64](https://github.com/ni/openembedded-core/pull/64).