### PR TITLE
initscripts: refresh meta-nilrt bbappend

### DIFF
--- a/recipes-core/initscripts/initscripts_1.0.bbappend
+++ b/recipes-core/initscripts/initscripts_1.0.bbappend
@@ -2,10 +2,10 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}:${THISDIR}/${PN}-${PV}:"
 
 SRC_URI += " \
-            file://bootmisc_0001_make_hwclock_authoritative.patch \
-            file://bootmisc_0002_add_sanity_checks.patch \
-            file://urandom.default \
-            file://transconf-hooks \
+	file://bootmisc_0001_make_hwclock_authoritative.patch \
+	file://bootmisc_0002_add_sanity_checks.patch \
+	file://transconf-hooks \
+	file://urandom.default \
 "
 
 do_install_append() {

--- a/recipes-core/initscripts/initscripts_1.0.bbappend
+++ b/recipes-core/initscripts/initscripts_1.0.bbappend
@@ -1,5 +1,5 @@
 
-FILESEXTRAPATHS_prepend := "${THISDIR}:${THISDIR}/${PN}-${PV}:"
+FILESEXTRAPATHS:prepend := "${THISDIR}:${THISDIR}/${PN}-${PV}:"
 
 SRC_URI += " \
 	file://bootmisc_0001_make_hwclock_authoritative.patch \
@@ -8,7 +8,7 @@ SRC_URI += " \
 	file://urandom.default \
 "
 
-do_install_append() {
+do_install:append() {
 	install -d ${D}${sysconfdir}/default
 	install -m 0644 ${WORKDIR}/urandom.default ${D}${sysconfdir}/default/urandom
 
@@ -33,5 +33,5 @@ do_install_append() {
 
 # ${PN}-transconf
 inherit transconf-hook
-RDEPENDS_${PN}-transconf += "bash"
-TRANSCONF_HOOKS_${PN} = "transconf-hooks/hostname"
+RDEPENDS:${PN}-transconf += "bash"
+TRANSCONF_HOOKS:${PN} = "transconf-hooks/hostname"

--- a/recipes-core/initscripts/initscripts_1.0.bbappend
+++ b/recipes-core/initscripts/initscripts_1.0.bbappend
@@ -9,12 +9,8 @@ SRC_URI += " \
 "
 
 do_install_append() {
-	# install custom urandom defaults file only for older NILRT because it needs to
-	# be accessible both from its runmode & safemode
-	if ${@oe.utils.conditional('DISTRO', 'nilrt-nxg', 'false', 'true', d)}; then
-		install -d ${D}${sysconfdir}/default
-		install -m 0644 ${WORKDIR}/urandom.default ${D}${sysconfdir}/default/urandom
-	fi
+	install -d ${D}${sysconfdir}/default
+	install -m 0644 ${WORKDIR}/urandom.default ${D}${sysconfdir}/default/urandom
 
 	# re-assign urandom runlevel links
 	update-rc.d -r ${D} -f urandom remove

--- a/recipes-core/initscripts/initscripts_1.0.bbappend
+++ b/recipes-core/initscripts/initscripts_1.0.bbappend
@@ -29,10 +29,6 @@ do_install_append() {
 	update-rc.d -f -r ${D} checkroot.sh remove
 	update-rc.d -f -r ${D} mountnfs.sh remove
 	update-rc.d -f -r ${D} read-only-rootfs-hook.sh remove
-
-	if [ "${TARGET_ARCH}" = "arm" ]; then
-		sed -i -e "s/echo \"3\"/echo \"5\"/" ${D}/${sysconfdir}/init.d/alignment.sh
-	fi
 }
 
 # ${PN}-transconf


### PR DESCRIPTION
Primary commit
```
initscripts: change umountnfs rule to stop

Migrate the NI-specific umountnfs.sh update-rc.d rule from OE-core to
meta-nilrt.

Original justification from
ni/OE-core:16431c20b0e87084f0bf8728f2df8214dffa87d5:

The umountnfs script is currently configured to "start", and runs after
networking is stopped. This causes a ~3 minute timeout after networking is
shutdown when the system tries to connect to any mounted network shares.
Fix this by changing the script configuration to "stop" so that it can run
before networking is stopped.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>
```

This PR also fixes some whitespace, styling, removes deprecated distro features, and updates the variable override syntax in the `initscripts` bbappend.

Natinst AZDO: [#1580104](https://dev.azure.com/ni/DevCentral/_workitems/edit/1580104)

# Testing
* Rebuilt with this changeset and confirmed that `umountnfs.sh` is linked at prio `31` in runlevels `0, 1, and 3`.

# Maintainership
This PR depends on [OE-core #65](https://github.com/ni/openembedded-core/pull/65).