### PR TITLE
tbtadm: add recipe from NI meta-oe fork

### DIFF
--- a/recipes-bsp/tbtadm/tbtadm/0001-tbtadm-Disable-manpage-target.patch
+++ b/recipes-bsp/tbtadm/tbtadm/0001-tbtadm-Disable-manpage-target.patch
@@ -1,0 +1,31 @@
+From 592f65a45a22130dc03b423ecc9eb2d98ff167a2 Mon Sep 17 00:00:00 2001
+From: Kar Hin Ong <kar.hin.ong@ni.com>
+Date: Wed, 28 Nov 2018 00:30:02 -0800
+Subject: [PATCH] tbtadm: Disable manpage target
+
+Disable building the manpage target by hiding
+its source directory from the root cMakeList.txt.
+Disabling it because it requires txt2tags to compile
+and txt2tags is not available in OE layer.
+
+Signed-off-by: Kar Hin Ong <kar.hin.ong@ni.com>
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 52d513b..bddaee8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -19,7 +19,7 @@ add_subdirectory(common)
+ add_subdirectory(tbtacl)
+ add_subdirectory(tbtxdomain)
+ add_subdirectory(tbtadm)
+-add_subdirectory(docs)
++#add_subdirectory(docs)
+ 
+ configure_file(tests/test-integration-mock.py tests/test-integration-mock.py COPYONLY)
+ configure_file(tests/Dockerfile tests/Dockerfile COPYONLY)
+-- 
+2.7.4
+

--- a/recipes-bsp/tbtadm/tbtadm_0.9.3.bb
+++ b/recipes-bsp/tbtadm/tbtadm_0.9.3.bb
@@ -1,0 +1,22 @@
+SUMMARY = "Thunderbolt user-space management tool"
+DESCRIPTION = "tbtadm provides convenient way to interact with Thunderbolt kernel module, approve the connection of Thunderbolt devices, handle the ACL for auto-connecting devices and more."
+HOMEPAGE = "https://github.com/intel/thunderbolt-software-user-space"
+
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://COPYING;md5=565a8f58cc6472cf9c3ee9453d7e5aa4"
+
+DEPENDS = "cmake-native udev boost"
+RDEPENDS:${PN} = "boost-filesystem"
+
+inherit cmake
+
+SRCREV = "fe0fa2237b971ec8baae36b785d98a772684e5e7"
+SRC_URI = "git://github.com/intel/thunderbolt-software-user-space.git;protocol=https \
+           file://0001-tbtadm-Disable-manpage-target.patch \
+           "
+
+S = "${WORKDIR}/git"
+
+FILES:${PN} += "${datadir}/bash-completion/completions/tbtadm"
+
+EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=Release"


### PR DESCRIPTION
tbtadm does not seem to be receiving updates, its mailing list is offline, and in other distros it seems that bolt is preferred; thus tbtadm seems unsuitable to upstream into meta-oe.

At the same time, we still have customer documentation that refers to tbtadm; this change adds the recipe under meta-nilrt until such time as we can migrate over to bolt (which also does not have an OE recipe at this time).

Minor changes to update the github URI and the new bitbake variable syntax have been merged.