### PR TITLE
grub-safemode-bootimage: disable initramfs_async

### DIFF
--- a/recipes-bsp/grub/grub/grub-safemode-bootimage.cfg
+++ b/recipes-bsp/grub/grub/grub-safemode-bootimage.cfg
@@ -1,6 +1,6 @@
 set consoleparam='console=tty0 console=ttyS0,115200n8'
 set kernel_path='/.safe/bzImage'
 set rootfs_path='ramdisk_size=populate-ramdisk-size root=/dev/ram rootfstype=ext2'
-set otherbootargs='rw consoleblank=0'
+set otherbootargs='initramfs_async=0 rw consoleblank=0'
 set usb_gadget_args="g_ether.idVendor=${USBVendorID} g_ether.idProduct=${USBProductID} g_ether.iProduct=${USBProduct}[${hostname}] g_ether.iSerialNumber=${SerialNum} g_ether.dev_addr=${usbgadgetethaddr} g_ether.bcdDevice=${USBDevice}"
 set ramdisk_path='/.safe/ramdisk.xz'


### PR DESCRIPTION
Asynchronous unpacking of the initramfs was added to linux kernel 5.15
by upstream linux.git commit e7cb072eb988e46295512617c39d004f9e1c26f8.

The change introduces a significant hang during boot (on the order of 90
seconds) on some NI targets, which is undesirable.

Disable this feature using the `initramfs_async=0` kernel commandline
option.

Natinst AZDO: [#2095204](https://dev.azure.com/ni/DevCentral/_workitems/edit/2095204)

# Testing
* Tested this command line option on several cRIOs and confirmed that it resolves the observed boot hang.
* Built the `nilrt-grub-safemode` recipe with this change and confirmed that the `bootimage.cfg` contains the correct value.