### PR TITLE
remove deprecated src subpackage variables

### DIFF
--- a/recipes-devtools/valgrind/valgrind_%.bbappend
+++ b/recipes-devtools/valgrind/valgrind_%.bbappend
@@ -7,7 +7,5 @@ SRC_URI += " \
 
 # Enable -src package creation, which is not done by default in nilrt
 # OE recipes. valgrind-src is a runtime dependency of valgrind-ptest.
-
-ENABLE_SRC_INSTALL = "1"
 PACKAGE_DEBUG_SPLIT_STYLE = "debug-with-srcpkg"
 

--- a/recipes-httpd/apache-mod/apache-websocket_%.bbappend
+++ b/recipes-httpd/apache-mod/apache-websocket_%.bbappend
@@ -1,1 +1,0 @@
-ENABLE_SRC_INSTALL_${PN} = "1"

--- a/recipes-httpd/apache2/apache2_%.bbappend
+++ b/recipes-httpd/apache2/apache2_%.bbappend
@@ -1,4 +1,1 @@
-ENABLE_SRC_INSTALL_${PN} = "1"
-PACKAGES += " ${PN}-src "
-
 PACKAGECONFIG_append = " openldap "

--- a/recipes-support/apr/apr-iconv_%.bbappend
+++ b/recipes-support/apr/apr-iconv_%.bbappend
@@ -1,1 +1,0 @@
-ENABLE_SRC_INSTALL_${PN} = "1"

--- a/recipes-support/apr/apr-util_%.bbappend
+++ b/recipes-support/apr/apr-util_%.bbappend
@@ -1,1 +1,0 @@
-ENABLE_SRC_INSTALL_${PN} = "1"

--- a/recipes-support/apr/apr_%.bbappend
+++ b/recipes-support/apr/apr_%.bbappend
@@ -1,1 +1,0 @@
-ENABLE_SRC_INSTALL_${PN} = "1"

--- a/recipes-support/curl/curl_7.%.bbappend
+++ b/recipes-support/curl/curl_7.%.bbappend
@@ -13,5 +13,3 @@ SRC_URI += " \
 "
 
 SELECTED_OPTIMIZATION += "-Wno-deprecated-declarations"
-
-ENABLE_SRC_INSTALL_${PN} = "1"


### PR DESCRIPTION
The -src subpackage patchset which Haris Okanovic authored for NI's fork
of OE-core we never upstreamed. Since OE-core now has native mechanisms
for creating source subpackages, his patchset has been dropped.

Remove the ENABLE_SRC_INSTALL variables from meta-nilrt - since they are
not relevant to the current source subpackage implementation.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

Haris' patchset was removed by the work attached to NI AZDO [#1050812](https://dev.azure.com/ni/DevCentral/_workitems/edit/1050812).

# Testing
* Rebuilt the recipes touched by this patchset without issue.