### PR TITLE
[hardknott] recipes-gnome/ audit

### DIFF
--- a/recipes-gnome/dconf/dconf_%.bbappend
+++ b/recipes-gnome/dconf/dconf_%.bbappend
@@ -1,17 +1,18 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += "file://user \
 "
 
-CONFFILES_${PN}_append := " ${sysconfdir}/dconf/profile/user"
 
-do_install_append () {
+do_install:append () {
 	install -d ${D}${sysconfdir}/dconf/db/local.d
 	install -d ${D}${sysconfdir}/dconf/profile
 
 	install -m 644 ${WORKDIR}/user ${D}${sysconfdir}/dconf/profile/
 }
 
-pkg_postinst_${PN} () {
+pkg_postinst:${PN} () {
 	dconf update
 }
+
+CONFFILES:${PN}:append := " ${sysconfdir}/dconf/profile/user"

--- a/recipes-gnome/gtk+/gtk+3_%.bbappend
+++ b/recipes-gnome/gtk+/gtk+3_%.bbappend
@@ -1,1 +1,0 @@
-DEPENDS_remove += "docbook-utils-native"

--- a/recipes-gnome/gtk+/gtk+_%.bbappend
+++ b/recipes-gnome/gtk+/gtk+_%.bbappend
@@ -1,1 +1,0 @@
-DEPENDS_remove += "docbook-utils-native"


### PR DESCRIPTION
This patchset audits the `meta-nilrt:recipes-gnome/` directory. The only substantial change is to drop the `gtk+*` bbappends, since they are no longer needed to build the gtk recipes from OE upstream.

# Testing
* All recipes touched by this patchset still build.