### PR TITLE
[hardknott] recipes-xfce/ audit

### DIFF
--- a/recipes-xfce/fontconfig-overrides/fontconfig-overrides_1.0.bb
+++ b/recipes-xfce/fontconfig-overrides/fontconfig-overrides_1.0.bb
@@ -1,13 +1,10 @@
-DESCRIPTION = "Customized settings to use the right fonts in XFCE."
+SUMMARY = "Customized NILRT settings to use the right fonts in XFCE."
+DESCRIPTION = "Standard X fonts don't support anti-aliasing, tell fontconfig to use the appropriate TrueType fonts."
 SECTION = "x11"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
-RDEPENDS_${PN} = "fontconfig"
-S = "${WORKDIR}"
-
 SRC_URI = "file://48-nilrt-override.conf"
-
-FILES_${PN} = "${sysconfdir}/fonts"
+S = "${WORKDIR}"
 
 do_install () {
 	install -d ${D}/${sysconfdir}/fonts/conf.d
@@ -15,4 +12,7 @@ do_install () {
 	install -m 0644 48-nilrt-override.conf ${D}/${sysconfdir}/fonts/conf.avail/48-nilrt-override.conf
 	ln -sf ${sysconfdir}/fonts/conf.avail/48-nilrt-override.conf ${D}/${sysconfdir}/fonts/conf.d/48-nilrt-override.conf
 }
+
+FILES:${PN} = "${sysconfdir}/fonts"
+RDEPENDS:${PN} = "fontconfig"
 

--- a/recipes-xfce/xfce-nilrt-settings/xfce-nilrt-settings_1.0.bb
+++ b/recipes-xfce/xfce-nilrt-settings/xfce-nilrt-settings_1.0.bb
@@ -1,17 +1,12 @@
-DESCRIPTION = "Customized settings for the Xfce desktop environment."
+SUMMARY = "Customized NILRT settings for the XFCE desktop environment."
+DESCRIPTION = "Defines the default XFCE desktop environment settings for lvuser."
 SECTION = "x11"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
-S = "${WORKDIR}"
-
 DEPENDS = "shadow-native pseudo-native niacctbase"
-RDEPENDS_${PN} = "bash niacctbase xfce4-settings xfce4-session xfce4-panel"
 
-homedir = "/home/${LVRT_USER}"
-confdir = "${homedir}/.config"
-backgrounddir = "/usr/share/backgrounds/xfce"
-
-SRC_URI = "file://autostart/dpms.desktop \
+SRC_URI =  " \
+	file://autostart/dpms.desktop \
 	file://autostart/dualmonitor.desktop \
 	file://autostart/screensaver.desktop \
 	file://dual-monitor-setup.sh \
@@ -38,76 +33,84 @@ SRC_URI = "file://autostart/dpms.desktop \
 	file://xfce4/xfconf/xfce-perchannel-xml/xsettings.xml \
 	"
 
-FILES_${PN} = "${confdir}/autostart/dpms.desktop \
-	    ${confdir}/autostart/dualmonitor.desktop \
-	    ${confdir}/autostart/screensaver.desktop \
-	    ${confdir}/menus/xfce-applications.menu \
-	    ${confdir}/xfce4/desktop/icons.screen0-624x384.rc \
-	    ${confdir}/xfce4/desktop/icons.screen0-624x464.rc \
-	    ${backgrounddir}/nilrt-desktop-background.png \
-	    ${confdir}/xfce4/panel/launcher-1/file_manager_launcher.desktop \
-	    ${confdir}/xfce4/panel/launcher-2/terminal_emulator_launcher.desktop \
-	    ${confdir}/xfce4/panel/launcher-3/settings_manager_launcher.desktop \
-	    ${confdir}/xfce4/panel/launcher-4/display_settings_launcher.desktop \
-	    /usr/local/natinst/bin/showpanel \
-	    /usr/local/natinst/bin/hidepanel \
-	    /usr/local/bin/showpanel \
-	    /usr/local/bin/hidepanel \
-	    ${confdir}/xfce4/xfconf/xfce-perchannel-xml/keyboards.xml \
-	    ${confdir}/xfce4/xfconf/xfce-perchannel-xml/thunar.xml \
-	    ${confdir}/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml \
-	    ${confdir}/xfce4/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml \
-	    ${confdir}/xfce4/xfconf/xfce-perchannel-xml/xfce4-notifyd.xml \
-	    ${confdir}/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml \
-	    ${confdir}/xfce4/xfconf/xfce-perchannel-xml/xfce4-session.xml \
-	    ${confdir}/xfce4/xfconf/xfce-perchannel-xml/xfce4-settings-editor.xml \
-	    ${confdir}/xfce4/xfconf/xfce-perchannel-xml/xfce4-settings-manager.xml \
-	    ${confdir}/xfce4/xfconf/xfce-perchannel-xml/xfwm4.xml \
-	    ${confdir}/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml \
-	    /usr/local/natinst/bin/dual-monitor-setup.sh \
-	    "
+S = "${WORKDIR}"
+
+homedir = "/home/${LVRT_USER}"
+confdir = "${homedir}/.config"
+backgrounddir = "/usr/share/backgrounds/xfce"
 
 do_install () {
-	   install -d ${D}${confdir}/autostart
-	   install -d ${D}${confdir}/menus
-	   install -d ${D}${confdir}/xfce4/desktop
-	   install -d ${D}${confdir}/xfce4/panel/launcher-1
-	   install -d ${D}${confdir}/xfce4/panel/launcher-2
-	   install -d ${D}${confdir}/xfce4/panel/launcher-3
-	   install -d ${D}${confdir}/xfce4/panel/launcher-4
-	   install -d ${D}${confdir}/xfce4/xfconf/xfce-perchannel-xml
-	   install -d ${D}${backgrounddir}
-	   install -d ${D}/usr/local/bin
-	   install -d ${D}/usr/local/natinst/bin
+	install -d ${D}${confdir}/autostart
+	install -d ${D}${confdir}/menus
+	install -d ${D}${confdir}/xfce4/desktop
+	install -d ${D}${confdir}/xfce4/panel/launcher-1
+	install -d ${D}${confdir}/xfce4/panel/launcher-2
+	install -d ${D}${confdir}/xfce4/panel/launcher-3
+	install -d ${D}${confdir}/xfce4/panel/launcher-4
+	install -d ${D}${confdir}/xfce4/xfconf/xfce-perchannel-xml
+	install -d ${D}${backgrounddir}
+	install -d ${D}/usr/local/bin
+	install -d ${D}/usr/local/natinst/bin
 
-	   install -m 0644 ${S}/autostart/dpms.desktop ${D}${confdir}/autostart/
-	   install -m 0644 ${S}/autostart/dualmonitor.desktop ${D}${confdir}/autostart/
-	   install -m 0644 ${S}/autostart/screensaver.desktop ${D}${confdir}/autostart/
-	   install -m 0644 ${S}/menus/xfce-applications.menu ${D}${confdir}/menus/
-	   install -m 0644 ${S}/xfce4/desktop/icons.screen0-624x384.rc ${D}${confdir}/xfce4/desktop/
-	   install -m 0644 ${S}/xfce4/desktop/icons.screen0-624x464.rc ${D}${confdir}/xfce4/desktop/
-	   install -m 0644 ${S}/xfce4/desktop/nilrt-desktop-background.png ${D}${backgrounddir}/
-	   install -m 0644 ${S}/xfce4/panel/launcher-1/file_manager_launcher.desktop ${D}${confdir}/xfce4/panel/launcher-1/
-	   install -m 0644 ${S}/xfce4/panel/launcher-2/terminal_emulator_launcher.desktop ${D}${confdir}/xfce4/panel/launcher-2/
-	   install -m 0644 ${S}/xfce4/panel/launcher-3/settings_manager_launcher.desktop ${D}${confdir}/xfce4/panel/launcher-3/
-	   install -m 0644 ${S}/xfce4/panel/launcher-4/display_settings_launcher.desktop ${D}${confdir}/xfce4/panel/launcher-4/
-	   install -m 0755 ${S}/xfce4/panel/showpanel ${D}/usr/local/natinst/bin/
-	   install -m 0755 ${S}/xfce4/panel/hidepanel ${D}/usr/local/natinst/bin/
-	   install -m 0644 ${S}/xfce4/xfconf/xfce-perchannel-xml/keyboards.xml ${D}${confdir}/xfce4/xfconf/xfce-perchannel-xml/
-	   install -m 0644 ${S}/xfce4/xfconf/xfce-perchannel-xml/thunar.xml ${D}${confdir}/xfce4/xfconf/xfce-perchannel-xml/
-	   install -m 0644 ${S}/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml ${D}${confdir}/xfce4/xfconf/xfce-perchannel-xml/
-	   install -m 0644 ${S}/xfce4/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml ${D}${confdir}/xfce4/xfconf/xfce-perchannel-xml/
-	   install -m 0644 ${S}/xfce4/xfconf/xfce-perchannel-xml/xfce4-notifyd.xml ${D}${confdir}/xfce4/xfconf/xfce-perchannel-xml/
-	   install -m 0644 ${S}/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml ${D}${confdir}/xfce4/xfconf/xfce-perchannel-xml/
-	   install -m 0644 ${S}/xfce4/xfconf/xfce-perchannel-xml/xfce4-session.xml ${D}${confdir}/xfce4/xfconf/xfce-perchannel-xml/
-	   install -m 0644 ${S}/xfce4/xfconf/xfce-perchannel-xml/xfce4-settings-editor.xml ${D}${confdir}/xfce4/xfconf/xfce-perchannel-xml/
-	   install -m 0644 ${S}/xfce4/xfconf/xfce-perchannel-xml/xfce4-settings-manager.xml ${D}${confdir}/xfce4/xfconf/xfce-perchannel-xml/
-	   install -m 0644 ${S}/xfce4/xfconf/xfce-perchannel-xml/xfwm4.xml ${D}${confdir}/xfce4/xfconf/xfce-perchannel-xml/
-	   install -m 0644 ${S}/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml ${D}${confdir}/xfce4/xfconf/xfce-perchannel-xml/
-	   install -m 0755 ${S}/dual-monitor-setup.sh ${D}/usr/local/natinst/bin
+	install -m 0644 ${S}/autostart/dpms.desktop ${D}${confdir}/autostart/
+	install -m 0644 ${S}/autostart/dualmonitor.desktop ${D}${confdir}/autostart/
+	install -m 0644 ${S}/autostart/screensaver.desktop ${D}${confdir}/autostart/
+	install -m 0644 ${S}/menus/xfce-applications.menu ${D}${confdir}/menus/
+	install -m 0644 ${S}/xfce4/desktop/icons.screen0-624x384.rc ${D}${confdir}/xfce4/desktop/
+	install -m 0644 ${S}/xfce4/desktop/icons.screen0-624x464.rc ${D}${confdir}/xfce4/desktop/
+	install -m 0644 ${S}/xfce4/desktop/nilrt-desktop-background.png ${D}${backgrounddir}/
+	install -m 0644 ${S}/xfce4/panel/launcher-1/file_manager_launcher.desktop ${D}${confdir}/xfce4/panel/launcher-1/
+	install -m 0644 ${S}/xfce4/panel/launcher-2/terminal_emulator_launcher.desktop ${D}${confdir}/xfce4/panel/launcher-2/
+	install -m 0644 ${S}/xfce4/panel/launcher-3/settings_manager_launcher.desktop ${D}${confdir}/xfce4/panel/launcher-3/
+	install -m 0644 ${S}/xfce4/panel/launcher-4/display_settings_launcher.desktop ${D}${confdir}/xfce4/panel/launcher-4/
+	install -m 0755 ${S}/xfce4/panel/showpanel ${D}/usr/local/natinst/bin/
+	install -m 0755 ${S}/xfce4/panel/hidepanel ${D}/usr/local/natinst/bin/
+	install -m 0644 ${S}/xfce4/xfconf/xfce-perchannel-xml/keyboards.xml ${D}${confdir}/xfce4/xfconf/xfce-perchannel-xml/
+	install -m 0644 ${S}/xfce4/xfconf/xfce-perchannel-xml/thunar.xml ${D}${confdir}/xfce4/xfconf/xfce-perchannel-xml/
+	install -m 0644 ${S}/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml ${D}${confdir}/xfce4/xfconf/xfce-perchannel-xml/
+	install -m 0644 ${S}/xfce4/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml ${D}${confdir}/xfce4/xfconf/xfce-perchannel-xml/
+	install -m 0644 ${S}/xfce4/xfconf/xfce-perchannel-xml/xfce4-notifyd.xml ${D}${confdir}/xfce4/xfconf/xfce-perchannel-xml/
+	install -m 0644 ${S}/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml ${D}${confdir}/xfce4/xfconf/xfce-perchannel-xml/
+	install -m 0644 ${S}/xfce4/xfconf/xfce-perchannel-xml/xfce4-session.xml ${D}${confdir}/xfce4/xfconf/xfce-perchannel-xml/
+	install -m 0644 ${S}/xfce4/xfconf/xfce-perchannel-xml/xfce4-settings-editor.xml ${D}${confdir}/xfce4/xfconf/xfce-perchannel-xml/
+	install -m 0644 ${S}/xfce4/xfconf/xfce-perchannel-xml/xfce4-settings-manager.xml ${D}${confdir}/xfce4/xfconf/xfce-perchannel-xml/
+	install -m 0644 ${S}/xfce4/xfconf/xfce-perchannel-xml/xfwm4.xml ${D}${confdir}/xfce4/xfconf/xfce-perchannel-xml/
+	install -m 0644 ${S}/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml ${D}${confdir}/xfce4/xfconf/xfce-perchannel-xml/
+	install -m 0755 ${S}/dual-monitor-setup.sh ${D}/usr/local/natinst/bin
 
-	   ln -sf /usr/local/natinst/bin/showpanel ${D}/usr/local/bin/showpanel
-	   ln -sf /usr/local/natinst/bin/hidepanel ${D}/usr/local/bin/hidepanel
+	ln -sf /usr/local/natinst/bin/showpanel ${D}/usr/local/bin/showpanel
+	ln -sf /usr/local/natinst/bin/hidepanel ${D}/usr/local/bin/hidepanel
 
-	   chown -R ${LVRT_USER}:${LVRT_GROUP} ${D}${homedir}
+	chown -R ${LVRT_USER}:${LVRT_GROUP} ${D}${homedir}
 }
+
+FILES_${PN} =  " \
+	${confdir}/autostart/dpms.desktop \
+	${confdir}/autostart/dualmonitor.desktop \
+	${confdir}/autostart/screensaver.desktop \
+	${confdir}/menus/xfce-applications.menu \
+	${confdir}/xfce4/desktop/icons.screen0-624x384.rc \
+	${confdir}/xfce4/desktop/icons.screen0-624x464.rc \
+	${backgrounddir}/nilrt-desktop-background.png \
+	${confdir}/xfce4/panel/launcher-1/file_manager_launcher.desktop \
+	${confdir}/xfce4/panel/launcher-2/terminal_emulator_launcher.desktop \
+	${confdir}/xfce4/panel/launcher-3/settings_manager_launcher.desktop \
+	${confdir}/xfce4/panel/launcher-4/display_settings_launcher.desktop \
+	/usr/local/natinst/bin/showpanel \
+	/usr/local/natinst/bin/hidepanel \
+	/usr/local/bin/showpanel \
+	/usr/local/bin/hidepanel \
+	${confdir}/xfce4/xfconf/xfce-perchannel-xml/keyboards.xml \
+	${confdir}/xfce4/xfconf/xfce-perchannel-xml/thunar.xml \
+	${confdir}/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml \
+	${confdir}/xfce4/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml \
+	${confdir}/xfce4/xfconf/xfce-perchannel-xml/xfce4-notifyd.xml \
+	${confdir}/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml \
+	${confdir}/xfce4/xfconf/xfce-perchannel-xml/xfce4-session.xml \
+	${confdir}/xfce4/xfconf/xfce-perchannel-xml/xfce4-settings-editor.xml \
+	${confdir}/xfce4/xfconf/xfce-perchannel-xml/xfce4-settings-manager.xml \
+	${confdir}/xfce4/xfconf/xfce-perchannel-xml/xfwm4.xml \
+	${confdir}/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml \
+	/usr/local/natinst/bin/dual-monitor-setup.sh \
+	"
+RDEPENDS_${PN} = "bash niacctbase xfce4-settings xfce4-session xfce4-panel"

--- a/recipes-xfce/xfce4-notifyd/xfce4-notifyd_0.%.bbappend
+++ b/recipes-xfce/xfce4-notifyd/xfce4-notifyd_0.%.bbappend
@@ -1,7 +1,7 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += "file://icons.tar.xz;unpack=false"
 
-do_install_append() {
-    tar -xf ${WORKDIR}/icons.tar.xz -C ${D}
+do_install:append() {
+	tar -xf ${WORKDIR}/icons.tar.xz -C ${D}
 }

--- a/recipes-xfce/xfce4-panel/xfce4-panel_4.%.bbappend
+++ b/recipes-xfce/xfce4-panel/xfce4-panel_4.%.bbappend
@@ -1,7 +1,7 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += "file://icons.tar.xz;unpack=false"
 
-do_install_append() {
-    tar -xf ${WORKDIR}/icons.tar.xz -C ${D}
+do_install:append() {
+	tar -xf ${WORKDIR}/icons.tar.xz -C ${D}
 }

--- a/recipes-xfce/xserver-xfce-init/xserver-xfce-init_1.0.bb
+++ b/recipes-xfce/xserver-xfce-init/xserver-xfce-init_1.0.bb
@@ -1,14 +1,15 @@
-DESCRIPTION = "XFCE initscript"
+SUMMARY = "NILRT XFCE Initialization."
+DESCRIPTION = "Used to initialize XFCE when the embedded UI is enabled."
+SECTION = "x11"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
-SECTION = "x11"
 
-
-SRC_URI = "file://xserver-xfce \
-           file://gplv2-license.patch \
-           file://xserver-xfce.service \
-           file://xserver-xfce.conf \
-           file://xserver-logrotate.conf \
+SRC_URI = " \
+	file://xserver-xfce \
+	file://gplv2-license.patch \
+	file://xserver-xfce.service \
+	file://xserver-xfce.conf \
+	file://xserver-logrotate.conf \
 "
 
 S = "${WORKDIR}"
@@ -18,30 +19,26 @@ inherit allarch update-rc.d
 INITSCRIPT_NAME = "xserver-xfce"
 INITSCRIPT_PARAMS = "start 01 5 2 . stop 01 0 1 6 ."
 INITSCRIPT_PARAMS_shr = "start 90 5 2 . stop 90 0 1 6 ."
+SYSTEMD_SERVICE:${PN} = "xserver-xfce.service"
 
 do_install() {
-    if ${@bb.utils.contains('DISTRO_FEATURES','sysvinit','true','false',d)}; then
-        install -d ${D}${sysconfdir}/init.d
-        install -d ${D}${sysconfdir}/default/
-        install xserver-xfce ${D}${sysconfdir}/init.d
-        install -m 0644 xserver-xfce.conf ${D}${sysconfdir}/default/xserver-xfce
-    fi
-    if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
-        install -d ${D}${systemd_unitdir}/system
-        install -m 0644 xserver-xfce.conf ${D}${sysconfdir}/default/xserver-xfce
-        install -m 0644 ${WORKDIR}/xserver-xfce.service ${D}${systemd_unitdir}/system
-    fi
-    install -d ${D}${sysconfdir}/logrotate.d
-    install -m 0644 xserver-logrotate.conf ${D}${sysconfdir}/logrotate.d/xserver.conf
+	if ${@bb.utils.contains('DISTRO_FEATURES','sysvinit','true','false',d)}; then
+		install -d ${D}${sysconfdir}/init.d
+		install -d ${D}${sysconfdir}/default/
+		install xserver-xfce ${D}${sysconfdir}/init.d
+		install -m 0644 xserver-xfce.conf ${D}${sysconfdir}/default/xserver-xfce
+	fi
+	if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+		install -d ${D}${systemd_unitdir}/system
+		install -m 0644 xserver-xfce.conf ${D}${sysconfdir}/default/xserver-xfce
+		install -m 0644 ${WORKDIR}/xserver-xfce.service ${D}${systemd_unitdir}/system
+	fi
+	install -d ${D}${sysconfdir}/logrotate.d
+	install -m 0644 xserver-logrotate.conf ${D}${sysconfdir}/logrotate.d/xserver.conf
 }
-
-# Get util-linux for su
-RDEPENDS_${PN} = "xserver-common (>= 1.30) xinit xfce4-session util-linux"
 
 FILES_${PN} += "${sysconfdir}/default/xserver-xfce"
 
-SYSTEMD_SERVICE_${PN} = "xserver-xfce.service"
-
-#RPROVIDES_${PN} = "xserver-nodm-init"
-#RREPLACES_${PN} = "xserver-nodm-init"
-RCONFLICTS_${PN} = "xserver-nodm-init"
+# Get util-linux for su
+RDEPENDS:${PN} = "xserver-common (>= 1.30) xinit xfce4-session util-linux"
+RCONFLICTS:${PN} = "xserver-nodm-init"


### PR DESCRIPTION
This PR audits the recipes-xfce/ files for quality. I verified these recipes are still needed and updated them for style and syntax.
fontconfig-overrides_1.0.bb, xfce-nilrt-settings_1.0.bb, and xserver-xfce-init_1.0.bb were missing SUMMARYs so I changed the DESCRIPTIONs to be the SUMMARYs and updated the DESCRIPTIONs.

NI AZDO [#2106919](https://dev.azure.com/ni/DevCentral/_workitems/edit/2106919)

### Testing

- all recipes touched by this PR still build.
- installed the updated xfce packages to a NILRT target and did some basic xfce sanity checks.