### PR TITLE
linux-nilrt-next: bump version to latest 5.19 development branch

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-next_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-next_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NILRT linux kernel next development build"
 NI_RELEASE_VERSION = "master"
-LINUX_VERSION = "5.15"
+LINUX_VERSION = "5.19"
 LINUX_KERNEL_TYPE = "next"
 
 require linux-nilrt-alternate.inc


### PR DESCRIPTION
Signed-off-by: Gratian Crisan <gratian.crisan@ni.com>