### PR TITLE
[hardknott] Add logging to system log for pstore saves.

### DIFF
--- a/recipes-ni/pstore-save/files/pstore-save
+++ b/recipes-ni/pstore-save/files/pstore-save
@@ -46,6 +46,7 @@ done
 
 function log_msg () {
     echo "$SCRIPTNAME: $@"
+    logger "$SCRIPTNAME: $@"
 }
 
 function log_error () {


### PR DESCRIPTION
Currently, pstore-save only saves to dmesg. Add
logging to syslog as well for support purposes.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

AzDO Work Item: https://dev.azure.com/ni/DevCentral/_workitems/edit/1991389/

## Testing:
- Forced a crash with magic sysrq and confirmed that the new item appeared in the logs:
```
admin@rtos-ci-nilrt-b:~# dmesg | grep pstore
[    0.121952] pstore: Registered efi as persistent store backend
[    0.122569] pstore: Using crash dump compression: deflate
[    1.143127] pstore-save: Saving prior dmesg from crash to /var/lib/pstore/20220819_204926
admin@rtos-ci-nilrt-b:~# cat /var/log/messages | grep pstore
2022-08-19T20:50:04.921+00:00 rtos-ci-nilrt-b kernel: [    0.121952] pstore: Registered efi as persistent store backend
2022-08-19T20:50:04.921+00:00 rtos-ci-nilrt-b kernel: [    0.122569] pstore: Using crash dump compression: deflate
2022-08-19T20:50:04.921+00:00 rtos-ci-nilrt-b [    1.143127] pstore-save: Saving prior dmesg from crash to /var/lib/pstore/20220819_204926
```
- Ran the ptests and confirmed they passed:
``` 
START: ptest-runner
2022-08-19T20:51
BEGIN: /usr/lib/pstore-save/ptest
PASS: pstore_save_ptest
END: /usr/lib/pstore-save/ptest
2022-08-19T20:51
STOP: ptest-runner
````