### PR TITLE
ni-rtfeatures: do not warn about missing reset_source

### DIFF
--- a/recipes-ni/ni-rtfeatures/files/ni-rtfeatures.initd
+++ b/recipes-ni/ni-rtfeatures/files/ni-rtfeatures.initd
@@ -30,7 +30,6 @@ log_reset_source () {
 	local RESET_SOURCE="${DEV_NIRTFEATURES}/reset_source"
 
 	if [ ! -r "${RESET_SOURCE}" ]; then
-		log WARNING "reset_source sysfs not found or not readable."
 		return
 	fi
 


### PR DESCRIPTION
Some hardware (PXIe) use the nirtfeatures driver, but do not use ni
watchdog hardware. In these cases, the reset_source sysfs entry doesn't
exist.

This is an expected case, so remove the warning log so as to not confuse
users.

NI AZDO: https://dev.azure.com/ni/DevCentral/_workitems/edit/2002357

# Testing
* [x] Tested new package on a PXIe controller.
    * PXIe-8821 no longer prints a warning about missing the `reset_source` sysfs.
* [x] Tested new package on a cRIO controller.
    * cRIO-9042 still prints the `reset_source`.