### PR TITLE
sysvinit: enable unlimited core dumps

### DIFF
--- a/recipes-core/sysvinit/sysvinit/initscript
+++ b/recipes-core/sysvinit/sysvinit/initscript
@@ -1,0 +1,4 @@
+ulimit -c unlimited
+
+# Execute the initscript.
+eval exec "$4"

--- a/recipes-core/sysvinit/sysvinit_2.%.bbappend
+++ b/recipes-core/sysvinit/sysvinit_2.%.bbappend
@@ -2,9 +2,16 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 DEPENDS += "shadow-native pseudo-native niacctbase"
 
-RDEPENDS_${PN} += "niacctbase"
+SRC_URI += "file://initscript"
+
 
 do_install_append() {
 	chmod 4550 ${D}${base_sbindir}/halt
 	chown 0:${LVRT_GROUP} ${D}${base_sbindir}/halt
+
+	install -d "${D}${sysconfdir}"
+	install -m 0754 ${WORKDIR}/initscript "${D}${sysconfdir}/initscript"
 }
+
+
+RDEPENDS_${PN} += "niacctbase"


### PR DESCRIPTION
NILRT users probably want crashing processes to create core dumps.
The default core dump size is controlled by PID 1, which in the case of
NILRT is init.sysvinit.

Add an /etc/initscript wrapper which sets the system core dump size to
unlimited.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

# Testing
* Built and installed this `sysvinit` IPK to a 9042. Confirmed that it creates the `/etc/initscript` wrapper scriplet and that - upon reboot - core dumps are set to `unlimited` for both initscripts, and user shells.

```
admin@NI-cRIO-9042-01E4AFBF:/var/local/natinst/log# ulimit -a
real-time non-blocking time  (microseconds, -R) unlimited
core file size              (blocks, -c) unlimited
data seg size               (kbytes, -d) unlimited
scheduling priority                 (-e) 0
file size                   (blocks, -f) unlimited
pending signals                     (-i) 15035
max locked memory           (kbytes, -l) 64
max memory size             (kbytes, -m) unlimited
open files                          (-n) 1024
pipe size                (512 bytes, -p) 8
POSIX message queues         (bytes, -q) 819200
real-time priority                  (-r) 0
stack size                  (kbytes, -s) 512
cpu time                   (seconds, -t) unlimited
max user processes                  (-u) 15035
virtual memory              (kbytes, -v) unlimited
file locks                          (-x) unlimited
```