### PR TITLE
[sumo] linux: Staple kernel recipes to 22.8 branches and hashes.

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-debug_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-debug_git.bb
@@ -12,7 +12,7 @@ SRC_URI += "\
 
 # This is the place to overwrite the source AUTOREV from linux-nilrt.inc, if
 # the kernel recipe requires a particular ref.
-#SRCREV = ""
+SRCREV_xilinx-zynq = "bc0d982eacfb9764302e888ea6d9f3d3bb4a5cc9"
 
 # Move vmlinux-${KERNEL_VERSION_NAME} from /boot to /lib/modules/${KERNEL_VERSION}/build/
 # to avoid filling the /boot partition.

--- a/recipes-kernel/linux/linux-nilrt-debug_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-debug_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "NILRT linux kernel debug build"
-NI_RELEASE_VERSION = "master"
+NI_RELEASE_VERSION = "22.8"
 LINUX_VERSION = "5.10"
 LINUX_VERSION_xilinx-zynq = "4.14"
 LINUX_KERNEL_TYPE = "debug"

--- a/recipes-kernel/linux/linux-nilrt-next_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-next_git.bb
@@ -7,4 +7,4 @@ require linux-nilrt-alternate.inc
 
 # This is the place to overwrite the source AUTOREV from linux-nilrt.inc, if
 # the kernel recipe requires a particular ref.
-#SRCREV = ""
+SRCREV = "378d8fbcc32082ee008a0df967ebd0f41a182877"

--- a/recipes-kernel/linux/linux-nilrt-next_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-next_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "NILRT linux kernel next development build"
-NI_RELEASE_VERSION = "master"
+NI_RELEASE_VERSION = "22.8"
 LINUX_VERSION = "5.15"
 LINUX_KERNEL_TYPE = "next"
 

--- a/recipes-kernel/linux/linux-nilrt-nohz_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-nohz_git.bb
@@ -19,4 +19,4 @@ do_install_append() {
 
 # This is the place to overwrite the source AUTOREV from linux-nilrt.inc, if
 # the kernel recipe requires a particular ref.
-#SRCREV = ""
+SRCREV = "9ab416c284b7f19102e9bcdf8320f3112a0450b5"

--- a/recipes-kernel/linux/linux-nilrt-nohz_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-nohz_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "NILRT linux kernel full dynamic ticks (NO_HZ_FULL) build"
-NI_RELEASE_VERSION = "master"
+NI_RELEASE_VERSION = "22.8"
 LINUX_VERSION = "5.10"
 LINUX_KERNEL_TYPE = "nohz"
 

--- a/recipes-kernel/linux/linux-nilrt_git.bb
+++ b/recipes-kernel/linux/linux-nilrt_git.bb
@@ -7,4 +7,4 @@ require linux-nilrt.inc
 
 # This is the place to overwrite the source AUTOREV from linux-nilrt.inc, if
 # the kernel recipe requires a particular ref.
-#SRCREV = ""
+SRCREV_xilinx-zynq = "bc0d982eacfb9764302e888ea6d9f3d3bb4a5cc9"

--- a/recipes-kernel/linux/linux-nilrt_git.bb
+++ b/recipes-kernel/linux/linux-nilrt_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "Linux kernel based on nilrt branch"
-NI_RELEASE_VERSION = "master"
+NI_RELEASE_VERSION = "22.8"
 LINUX_VERSION = "5.10"
 LINUX_VERSION_xilinx-zynq = "4.14"
 


### PR DESCRIPTION
Stapling the sumo master branch to the 22.8 ni/linux release branches to reduce long-term overhead.

## Testing: 
Build linux-nilrt locally. 