### PR TITLE
[hardknott] lsb: Explicitly use new main branch name.

### DIFF
--- a/recipes-extended/lsb/lsbinitscripts_10.04.bb
+++ b/recipes-extended/lsb/lsbinitscripts_10.04.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 DEPENDS = "popt glib-2.0"
 
-SRC_URI = "git://github.com/fedora-sysv/initscripts;protocol=https"
+SRC_URI = "git://github.com/fedora-sysv/initscripts;protocol=https;branch=main"
 SRCREV = "d2243a0912bbad57b1b413f2c15599341cb2aa76"
 UPSTREAM_CHECK_GITTAGREGEX = "^(?P<pver>\d+(\.\d+)+)"
 


### PR DESCRIPTION
Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

Upstream renamed `master` branch to `main`. This fixes that so that external users can build.