### PR TITLE
[sumo] nilrt.conf: Dont overwrite NILRT_FEED_NAME

### DIFF
--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -4,7 +4,7 @@ DISTRO_NAME = "NI Linux Real-Time"
 
 DISTRO_VERSION = "8.14"
 
-NILRT_FEED_NAME = "2023Q1"
+NILRT_FEED_NAME ?= "2023Q1"
 
 DISTRO_FEATURES_append_x64 = "\
         x11 \


### PR DESCRIPTION
Don't overwrite previously set NILRT_FEED_NAME.
This enables pipelines to set it through local.conf.

WI: [2163365](https://dev.azure.com/ni/DevCentral/_workitems/edit/2163365)

### Testing
Built locally with `NILRT_FEED_NAME` set in local.conf and verified it propagates to `/etc/opkg/base-feeds.conf`.