### PR TITLE
nilrt-academic: Move 'require nilrt.inc' to EOF

### DIFF
--- a/conf/distro/nilrt-academic.conf
+++ b/conf/distro/nilrt-academic.conf
@@ -1,5 +1,3 @@
-require nilrt.inc
-
 DISTRO_NAME = "NI Linux Real-Time - Academic"
 
 DISTRO_VERSION = "8.14"
@@ -33,3 +31,5 @@ IMAGE_LINGUAS ?= "en-us en-us.iso-8859-1"
 # own release namespace.
 NILRT_FEEDS_URI_RELEASE = "${NILRT_FEEDS_URI}/academic/${NILRT_FEED_NAME}"
 PACKAGE_FEED_URIS = "${NILRT_FEEDS_URI_RELEASE}"
+
+require nilrt.inc


### PR DESCRIPTION
Move 'require nilrt.inc' to end of file for better readability.
This doesn't affect functionality.

WI: [2163365](https://dev.azure.com/ni/DevCentral/_workitems/edit/2163365)

### Testing
Built locally