### PR TITLE
util-linux-nilrt-ptest: Removing dependency on non-existent util-linux-nilrt.

### DIFF
--- a/recipes-core/util-linux/util-linux-nilrt.bb
+++ b/recipes-core/util-linux/util-linux-nilrt.bb
@@ -18,3 +18,4 @@ do_install_ptest() {
 }
 
 RDEPENDS:${PN}-ptest += " bash "
+RDEPENDS:${PN}-ptest:remove = "${PN}"


### PR DESCRIPTION
The util-linux-nilrt-ptest package depends on util-linux nilrt, which does not exist. This currently makes the package impossible to install normally. This change removes the default ${PN} dependency inherited from ptest for that recipe.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

## Testing:
Built locally and confirmed `util-linux-nilrt` was no longer listed as a dependency in the control file. 