### PR TITLE
[academic] add ffmpeg to extras feed

### DIFF
--- a/classes/nilrt-permit-commercial.bbclass
+++ b/classes/nilrt-permit-commercial.bbclass
@@ -1,0 +1,15 @@
+# Some recipes - notably ffmpeg - are marked as containing "commercial"
+# licenses. In order for NILRT to distribute these recipes, you must inherit
+# this bbclass and implement a sanity check to verify that the resulting
+# package doesn't violate the recipe's redistributability requirements.
+
+LICENSE_FLAGS_WHITELIST += "commercial_${BPN}"
+
+
+do_sanity_check_commercial() {
+	# Fail by default. Overwrite this function to implement a proper sanity
+	# check for the recipe.
+	bbfatal_log "do_sanity_check_commercial() is not defined for ${PN}."
+}
+
+addtask do_sanity_check_commercial after do_package before do_build

--- a/recipes-core/packagegroups/packagegroup-ni-desirable.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-desirable.bb
@@ -25,12 +25,16 @@ RDEPENDS_${PN} += "\
 	cgdb \
 	cifs-utils \
 	elfutils \
+	ffmpeg \
 	file \
 	g++ \
 	gcc \
 	gdb \
 	git \
 	gperf \
+	gstreamer1.0-libav \
+	gstreamer1.0-plugins-good \
+	gstreamer1.0-rtsp-server \
 	htop \
 	iperf2 \
 	iperf3 \

--- a/recipes-multimedia/ffmpeg/ffmpeg_%.bbappend
+++ b/recipes-multimedia/ffmpeg/ffmpeg_%.bbappend
@@ -1,0 +1,7 @@
+
+inherit nilrt-permit-commercial
+
+python do_sanity_check_commercial() {
+    if '--enable-nonfree' in d.getVar('EXTRA_OECONF'):
+        bb.fatal('ffmpeg may not enable nonfree codecs.')
+}

--- a/recipes-multimedia/gstreamer/gstreamer1.0-libav_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-libav_%.bbappend
@@ -1,0 +1,8 @@
+
+inherit nilrt-permit-commercial
+
+do_sanity_check_commercial() {
+	# gstreamer components are distributed under either GPL or LGPL licenses,
+	# which are generally compatible with NILRT's distribution strategy.
+	exit 0
+}

--- a/recipes-multimedia/x264/x264_%.bbappend
+++ b/recipes-multimedia/x264/x264_%.bbappend
@@ -1,0 +1,7 @@
+
+inherit nilrt-permit-commercial
+
+do_sanity_check_commercial() {
+	# x264 is distributed under GPLv2 - which is fine.
+	exit 0
+}


### PR DESCRIPTION
FRC users desire to have ffmpeg and gstreamer packages available in the extras feed, for use in their applications. However, some configurations of ffmpeg include nonfree licenses, which are generally non-redistributable in NILRT. Further: ffmpeg, gstreamer1.0-libav, and x264 are marked as "commercially" licensed, which prompts bitbake to reject building them by default.

This PR adds a new bbclass to the meta-nilrt layer (`nilrt-permit-commercial.bbclass`) which, when included, adds the recipe to the `LICENSE_FLAG_WHITELIST` variable (allowing it to be built), but requires that the meta-nilrt layer implement a sanity check for the recipe - to detect invalid configurations.

This PR then implements this class for the `ffmpeg`, `gstreamer1.0-libav`, and `x264` recipes; and adds them to `packagegroup-ni-desirable`.

The change to add these packages to the extras feed was originally split from jhershberger's pr #454.

NI AZDO: https://dev.azure.com/ni/DevCentral/_workitems/edit/2173762

# Testing
When `nilrt-permit-commercial.bbclass` is inherited by a recipe which does not define `sanity_check_commercial()`, bitbake fails with output like...
```
ERROR: x264-r2854+gitAUTOINC+e9a5903edf-r0 do_sanity_check_commercial: do_sanity_check_commercial() is not defined for x264.
ERROR: x264-r2854+gitAUTOINC+e9a5903edf-r0 do_sanity_check_commercial: Function failed: do_sanity_check_commercial (log file is located at /home/usr0/fast/nilrt-sumo/build-academic/tmp-glibc/work/cortexa9-vfpv3-nilrt-linux-gnueabi/x264/r2854+gitAUTOINC+e9a5903edf-r0/temp/log.do_sanity_check_commercial.440)
ERROR: Logfile of failure stored in: /home/usr0/fast/nilrt-sumo/build-academic/tmp-glibc/work/cortexa9-vfpv3-nilrt-linux-gnueabi/x264/r2854+gitAUTOINC+e9a5903edf-r0/temp/log.do_sanity_check_commercial.440
Log data follows:
| DEBUG: Executing shell function do_sanity_check_commercial
| ERROR: do_sanity_check_commercial() is not defined for x264.
| WARNING: exit code 1 from a shell command.
| ERROR: Function failed: do_sanity_check_commercial (log file is located at /home/usr0/fast/nilrt-sumo/build-academic/tmp-glibc/work/cortexa9-vfpv3-nilrt-linux-gnueabi/x264/r2854+gitAUTOINC+e9a5903edf-r0/temp/log.do_sanity_check_commercial.440)
ERROR: Task (/home/usr0/fast/nilrt-sumo/sources/openembedded-core/meta/recipes-multimedia/x264/x264_git.bb:do_sanity_check_commercial) failed with exit code '1'
```

When building `ffmpeg` with `PACKAGECONFIG_append = "openssl"` (ie. with nonfree software), bitbake fails with output like...
```
ERROR: ffmpeg-4.2.1-r0 do_sanity_check_commercial: ffmpeg may not enable nonfree codecs.
ERROR: ffmpeg-4.2.1-r0 do_sanity_check_commercial: Function failed: do_sanity_check_commercial
ERROR: Logfile of failure stored in: /home/usr0/fast/nilrt-sumo/build-academic/tmp-glibc/work/cortexa9-vfpv3-nilrt-linux-gnueabi/ffmpeg/4.2.1-r0/temp/log.do_sanity_check_commercial.441
ERROR: Task (/home/usr0/fast/nilrt-sumo/sources/openembedded-core/meta/recipes-multimedia/ffmpeg/ffmpeg_4.2.1.bb:do_sanity_check_commercial) failed with exit code '1'
```

When building `ffmpeg` with the package configuration in the sumo mainline (free software only), bitbake does not fail.