### PR TITLE
kernel-performace-tests: Update iperf server configuration

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/iperf.cfg
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/iperf.cfg
@@ -1,4 +1,4 @@
 # Server configuration for iperf test
 #
-# IPERF_SERVER=foo
-# IPERF_PORT=5201
+IPERF_SERVER=CATS-iperf-1.ni.systems
+IPERF_PORT=6003

--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/test_kernel_cyclictest_iperf.sh
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/test_kernel_cyclictest_iperf.sh
@@ -11,6 +11,12 @@ if [ -z "$IPERF_SERVER" ]; then
 fi
 
 if [ ! -z "$IPERF_PORT" ]; then
+    iperf3 -c "$IPERF_SERVER" -p "$IPERF_PORT" -t 1 > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "ERROR: iperf server not reachable; skipping iperf based network load test."
+        echo "SKIP: test_kernel_cyclictest_iperf"
+        exit 77
+    fi
 	iperf3 -c "$IPERF_SERVER" -p "$IPERF_PORT" -t 36000 --logfile "$LOG_DIR/iperf-`date +'%Y_%m_%d-%H_%M_%S'`.log" &
     else
 	iperf3 -c "$IPERF_SERVER" -t 36000 --logfile "$LOG_DIR/iperf-`date +'%Y_%m_%d-%H_%M_%S'`.log" &

--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/test_kernel_cyclictest_iperf.sh
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/test_kernel_cyclictest_iperf.sh
@@ -17,9 +17,9 @@ if [ ! -z "$IPERF_PORT" ]; then
         echo "SKIP: test_kernel_cyclictest_iperf"
         exit 77
     fi
-	iperf3 -c "$IPERF_SERVER" -p "$IPERF_PORT" -t 36000 --logfile "$LOG_DIR/iperf-`date +'%Y_%m_%d-%H_%M_%S'`.log" &
-    else
-	iperf3 -c "$IPERF_SERVER" -t 36000 --logfile "$LOG_DIR/iperf-`date +'%Y_%m_%d-%H_%M_%S'`.log" &
+    iperf3 -c "$IPERF_SERVER" -p "$IPERF_PORT" -t 36000 --logfile "$LOG_DIR/iperf-`date +'%Y_%m_%d-%H_%M_%S'`.log" &
+else
+    iperf3 -c "$IPERF_SERVER" -t 36000 --logfile "$LOG_DIR/iperf-`date +'%Y_%m_%d-%H_%M_%S'`.log" &
 fi
 
 # measure the system latency under network load


### PR DESCRIPTION
Update iperf server configuration to our new rack-mounted iperf server and port.

One less thing for dashboard to orchestrate if I hard code the server into the test configuration. I was thinking that we could start with this and then figure out a way for dashboard to pass this to the test.