### PR TITLE
 [hardknott] audit 2-6: deprecated logic

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-safemode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-safemode.bb
@@ -20,7 +20,3 @@ RDEPENDS:${PN} = " \
 	ni-systemimage \
 	sysconfig-settings-ssh \
 "
-
-RDEPENDS:${PN}:append:armv7a = " \
-	nisdbootconfig \
-"

--- a/recipes-core/packagegroups/packagegroup-ni-xfce.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-xfce.bb
@@ -11,21 +11,19 @@ inherit packagegroup
 
 RDEPENDS:${PN} = "\
 	packagegroup-xfce-base \
-	xf86-input-evdev \
-	xfce4-xkb-plugin \
-	xserver-xfce-init \
-	xrdb \
-	xfce-nilrt-settings \
 	font-cursor-misc \
 	font-misc-misc \
-	xorg-fonts-100dpi \
-	xfontsel \
 	fontconfig-overrides \
 	mousepad \
 	ttf-pt-sans \
-"
-RDEPENDS:${PN}:append:x64 += "\
+	xf86-input-evdev \
 	xf86-video-ati \
 	xf86-video-intel \
 	xf86-video-vesa \
+	xfce-nilrt-settings \
+	xfce4-xkb-plugin \
+	xfontsel \
+	xorg-fonts-100dpi \
+	xrdb \
+	xserver-xfce-init \
 "

--- a/recipes-ni/base-files-nilrt/base-files-nilrt.bb
+++ b/recipes-ni/base-files-nilrt/base-files-nilrt.bb
@@ -21,7 +21,7 @@ PACKAGES = "${PN}-dbg ${PN}-staticdev ${PN}-dev ${PN} ${PN}-doc ${PN}-locale"
 FILES:${PN} += "README_File_Paths.txt \
 		README_File_Transfer.txt \
 		/usr/share/doc/LICENSES \
-		/usr/lib/${TARGET_ARCH}-linux-gnu${ARCH_ABI_EXT} \
+		/usr/lib/${TARGET_ARCH}-linux-gnu${ABIEXTENSION} \
 		/etc/ld.so.conf.d/multiarch_libs.conf \
 		/usr/local/natinst/bin \
 		/usr/local/natinst/lib \
@@ -30,8 +30,6 @@ FILES:${PN} += "README_File_Paths.txt \
 "
 
 S = "${WORKDIR}"
-
-ARCH_ABI_EXT="${ABIEXTENSION}${@bb.utils.contains('TUNE_FEATURES','callconvention-hard','hf','',d)}"
 
 RDEPENDS:${PN} += "procps"
 DEPENDS += "niacctbase"
@@ -62,14 +60,14 @@ do_install () {
 
 	# Create multiarch installation directory and write proper path to
 	# multiarch.conf
-	install -d ${D}/usr/lib/${TARGET_ARCH}-linux-gnu${ARCH_ABI_EXT}
+	install -d ${D}/usr/lib/${TARGET_ARCH}-linux-gnu${ABIEXTENSION}
 
 	# ld.so.conf includes the directory /etc/ld.so.conf.d, a standard
 	# practice in linux distros, adding extra files to map our directories
 	install -d ${D}${sysconfdir}/ld.so.conf.d/
 	install -m 0644 ${WORKDIR}/natinst_libs.conf ${D}${sysconfdir}/ld.so.conf.d/
 	install -m 0644 ${WORKDIR}/local_libs.conf ${D}${sysconfdir}/ld.so.conf.d/
-	echo /usr/lib/${TARGET_ARCH}-linux-gnu${ARCH_ABI_EXT} > ${D}${sysconfdir}/ld.so.conf.d/multiarch_libs.conf
+	echo /usr/lib/${TARGET_ARCH}-linux-gnu${ABIEXTENSION} > ${D}${sysconfdir}/ld.so.conf.d/multiarch_libs.conf
 
 	install -d ${D}${sysconfdir}/profile.d/
 

--- a/recipes-ni/initscripts-nilrt/initscripts-nilrt-safemode.bb
+++ b/recipes-ni/initscripts-nilrt/initscripts-nilrt-safemode.bb
@@ -9,9 +9,6 @@ DEPENDS += "shadow-native pseudo-native update-rc.d-native niacctbase"
 RDEPENDS:${PN} += "bash niacctbase update-rc.d"
 
 SRC_URI = " \
-"
-
-SRC_URI:append:x64 = " \
 	file://mountcompatibility \
 	file://mountuserfs \
 	file://nisafemodereason \
@@ -22,16 +19,13 @@ S = "${WORKDIR}"
 
 do_install () {
 	install -d ${D}${sysconfdir}/init.d/
-}
-
-do_install:append:x64 () {
-	install -m 0755   ${WORKDIR}/niselectnetnaming      ${D}${sysconfdir}/init.d
-	install -m 0755   ${WORKDIR}/nisafemodereason       ${D}${sysconfdir}/init.d
-	install -m 0755   ${WORKDIR}/mountuserfs            ${D}${sysconfdir}/init.d
 	install -m 0755   ${WORKDIR}/mountcompatibility     ${D}${sysconfdir}/init.d
+	install -m 0755   ${WORKDIR}/mountuserfs            ${D}${sysconfdir}/init.d
+	install -m 0755   ${WORKDIR}/nisafemodereason       ${D}${sysconfdir}/init.d
+	install -m 0755   ${WORKDIR}/niselectnetnaming      ${D}${sysconfdir}/init.d
 
-	update-rc.d -r ${D} niselectnetnaming start 3 S .
-	update-rc.d -r ${D} nisafemodereason start 60 S .
-	update-rc.d -r ${D} mountuserfs start 82 S .
 	update-rc.d -r ${D} mountcompatibility start 97 S .
+	update-rc.d -r ${D} mountuserfs start 82 S .
+	update-rc.d -r ${D} nisafemodereason start 60 S .
+	update-rc.d -r ${D} niselectnetnaming start 3 S .
 }

--- a/recipes-ni/initscripts-nilrt/initscripts-nilrt.bb
+++ b/recipes-ni/initscripts-nilrt/initscripts-nilrt.bb
@@ -97,27 +97,7 @@ pkg_postinst_ontarget:${PN} () {
 	# Use persistent names on PXI, not on any other targets
 	if [ "$class" != "PXI" -a "$class" != "USRP Stand-Alone Devices" ]; then
 		touch /etc/udev/rules.d/80-net-name-slot.rules
-
-		# Since the network is already brought up on the first boot, reload the network to get the new rules
-		if ${@oe.utils.conditional('DISTRO', 'nilrt-nxg', 'true', 'false', d)}; then
-
-			NXG_ETHERNET_DRIVERS="igb e1000 virtio-pci"
-			active_drivers=""
-			for driver in $NXG_ETHERNET_DRIVERS; do
-				if `lsmod | grep -q "$driver"`; then
-					active_drivers="$active_drivers $driver"
-				fi
-			done
-
-			/etc/init.d/udev stop
-			for mod in $active_drivers; do
-				modprobe -r "$mod"
-				modprobe "$mod"
-			done
-			/etc/init.d/udev start
-		fi
 	fi
-
 
 	# Enable core dumps on PXI, not on any other targets
 	[ "$class" = "PXI" ] && echo "* soft core unlimited" > /etc/security/limits.d/allow-core-dumps.conf

--- a/recipes-ni/initscripts-nilrt/initscripts-nilrt.bb
+++ b/recipes-ni/initscripts-nilrt/initscripts-nilrt.bb
@@ -40,15 +40,12 @@ do_install () {
 
 	install -m 0755 ${WORKDIR}/firewall              ${D}${sysconfdir}/init.d
 
-	# this logic is only for nilrt and nilrt-xfce, not for nilrt-nxg
-	if ${@oe.utils.conditional('DISTRO', 'nilrt-nxg', 'false', 'true', d)}; then
-		# Substitute configfs paths
-		sed -i 's|^IPTABLES_CONF=.*$|IPTABLES_CONF=/etc/natinst/share/iptables.conf|g' ${D}${sysconfdir}/init.d/firewall
-		sed -i 's|^IP6TABLES_CONF=.*$|IP6TABLES_CONF=/etc/natinst/share/ip6tables.conf|g' ${D}${sysconfdir}/init.d/firewall
+	# Substitute configfs paths
+	sed -i 's|^IPTABLES_CONF=.*$|IPTABLES_CONF=/etc/natinst/share/iptables.conf|g' ${D}${sysconfdir}/init.d/firewall
+	sed -i 's|^IP6TABLES_CONF=.*$|IP6TABLES_CONF=/etc/natinst/share/ip6tables.conf|g' ${D}${sysconfdir}/init.d/firewall
 
-		# sanity check: break build if new _CONF vars exist which aren't substituted above
-		! egrep '^[a-zA-Z0-9]*_CONF=.*$' ${D}${sysconfdir}/init.d/firewall | egrep -v '^(IPTABLES_CONF)|(IP6TABLES_CONF)=.*$'
-	fi
+	# sanity check: break build if new _CONF vars exist which aren't substituted above
+	! egrep '^[a-zA-Z0-9]*_CONF=.*$' ${D}${sysconfdir}/init.d/firewall | egrep -v '^(IPTABLES_CONF)|(IP6TABLES_CONF)=.*$'
 
 	install -m 0755 ${WORKDIR}/mountconfig           ${D}${sysconfdir}/init.d
 	install -m 0755 ${WORKDIR}/mountdebugfs          ${D}${sysconfdir}/init.d

--- a/recipes-ni/initscripts-nilrt/initscripts-nilrt.bb
+++ b/recipes-ni/initscripts-nilrt/initscripts-nilrt.bb
@@ -37,46 +37,49 @@ S = "${WORKDIR}"
 
 do_install () {
 	install -d ${D}${sysconfdir}/init.d/
+	install -m 0755 ${WORKDIR}/cleanvarcache         ${D}${sysconfdir}/init.d
+	install -m 0755 ${WORKDIR}/mountconfig           ${D}${sysconfdir}/init.d
+	install -m 0755 ${WORKDIR}/mountdebugfs          ${D}${sysconfdir}/init.d
+	install -m 0755 ${WORKDIR}/nicheckbiosconfig     ${D}${sysconfdir}/init.d
+	install -m 0755 ${WORKDIR}/nicleanefivars        ${D}${sysconfdir}/init.d
+	install -m 0755 ${WORKDIR}/nicleanstalelinks     ${D}${sysconfdir}/init.d
+	install -m 0755 ${WORKDIR}/nicreatecpuacctgroups ${D}${sysconfdir}/init.d
+	install -m 0755 ${WORKDIR}/nicreatecpusets       ${D}${sysconfdir}/init.d
+	install -m 0755 ${WORKDIR}/nidisablecstates      ${D}${sysconfdir}/init.d
+	install -m 0755 ${WORKDIR}/nipopulateconfigdir   ${D}${sysconfdir}/init.d
+	install -m 0755 ${WORKDIR}/nisetcommitratio      ${D}${sysconfdir}/init.d
+	install -m 0755 ${WORKDIR}/nisetreboottype       ${D}${sysconfdir}/init.d
+	install -m 0755 ${WORKDIR}/nisetupkernelconfig   ${D}${sysconfdir}/init.d
+	install -m 0755 ${WORKDIR}/populateconfig        ${D}${sysconfdir}/init.d
+	install -m 0755 ${WORKDIR}/wirelesssetdomain     ${D}${sysconfdir}/init.d
 
 	install -m 0755 ${WORKDIR}/firewall              ${D}${sysconfdir}/init.d
-
 	# Substitute configfs paths
 	sed -i 's|^IPTABLES_CONF=.*$|IPTABLES_CONF=/etc/natinst/share/iptables.conf|g' ${D}${sysconfdir}/init.d/firewall
 	sed -i 's|^IP6TABLES_CONF=.*$|IP6TABLES_CONF=/etc/natinst/share/ip6tables.conf|g' ${D}${sysconfdir}/init.d/firewall
-
 	# sanity check: break build if new _CONF vars exist which aren't substituted above
 	! egrep '^[a-zA-Z0-9]*_CONF=.*$' ${D}${sysconfdir}/init.d/firewall | egrep -v '^(IPTABLES_CONF)|(IP6TABLES_CONF)=.*$'
 
-	install -m 0755 ${WORKDIR}/mountconfig           ${D}${sysconfdir}/init.d
-	install -m 0755 ${WORKDIR}/mountdebugfs          ${D}${sysconfdir}/init.d
-	install -m 0755 ${WORKDIR}/nicleanstalelinks     ${D}${sysconfdir}/init.d
-	install -m 0755 ${WORKDIR}/nicreatecpusets       ${D}${sysconfdir}/init.d
-	install -m 0755 ${WORKDIR}/nicreatecpuacctgroups ${D}${sysconfdir}/init.d
-	install -m 0755 ${WORKDIR}/nipopulateconfigdir   ${D}${sysconfdir}/init.d
-	install -m 0755 ${WORKDIR}/populateconfig        ${D}${sysconfdir}/init.d
-	install -m 0755 ${WORKDIR}/nisetupkernelconfig   ${D}${sysconfdir}/init.d
-	install -m 0755 ${WORKDIR}/nisetcommitratio      ${D}${sysconfdir}/init.d
-	install -m 0755 ${WORKDIR}/nisetreboottype       ${D}${sysconfdir}/init.d
-	install -m 0755 ${WORKDIR}/wirelesssetdomain     ${D}${sysconfdir}/init.d
-	install -m 0755 ${WORKDIR}/cleanvarcache         ${D}${sysconfdir}/init.d
+	update-rc.d -r ${D} cleanvarcache         start 38 0 6 S .
+	update-rc.d -r ${D} firewall              start 39 S .
+	update-rc.d -r ${D} mountconfig           start 35 S .
+	update-rc.d -r ${D} mountdebugfs          start 82 S .
+	update-rc.d -r ${D} nicheckbiosconfig     start 99 4 5 .
+	update-rc.d -r ${D} nicleanefivars        start 10 S .
+	update-rc.d -r ${D} nicleanstalelinks     start 5  S .
+	update-rc.d -r ${D} nicreatecpuacctgroups start 2  4 5 .
+	update-rc.d -r ${D} nicreatecpusets       start 1  4 5 .
+	update-rc.d -r ${D} nidisablecstates      start 2 3 4 5 S .
+	update-rc.d -r ${D} nipopulateconfigdir   start 35 S .
+	update-rc.d -r ${D} nisetcommitratio      start 99 S .
+	update-rc.d -r ${D} nisetreboottype       stop  55 6 .
+	update-rc.d -r ${D} nisetupkernelconfig   start 3  5 .
+	update-rc.d -r ${D} populateconfig        start 35 S . start 30 0 6 .
+	update-rc.d -r ${D} wirelesssetdomain     start 36 S .
 
 	install -d ${D}${sysconfdir}/natinst
 	install -m 0644 ${WORKDIR}/iso3166-translation.txt ${D}${sysconfdir}/natinst
 
-	update-rc.d -r ${D} nicreatecpusets       start 1  4 5 .
-	update-rc.d -r ${D} nicreatecpuacctgroups start 2  4 5 .
-	update-rc.d -r ${D} nisetupkernelconfig   start 3  5 .
-	update-rc.d -r ${D} nicleanstalelinks     start 5  S .
-	update-rc.d -r ${D} nipopulateconfigdir   start 35 S .
-	update-rc.d -r ${D} mountconfig           start 35 S .
-	update-rc.d -r ${D} populateconfig        start 35 S . start 30 0 6 .
-	update-rc.d -r ${D} wirelesssetdomain     start 36 S .
-	update-rc.d -r ${D} cleanvarcache         start 38 0 6 S .
-	update-rc.d -r ${D} firewall              start 39 S .
-	update-rc.d -r ${D} mountdebugfs          start 82 S .
-	update-rc.d -r ${D} nisetcommitratio      start 99 S .
-
-	update-rc.d -r ${D} nisetreboottype       stop  55 6 .
 }
 
 pkg_postinst_ontarget:${PN} () {
@@ -121,16 +124,6 @@ pkg_postinst_ontarget:${PN} () {
 
 	# Restore the original state of /boot
 	[ $mountstate == 0 ] && umount /boot || true
-}
-
-do_install:append:x64 () {
-	install -m 0755   ${WORKDIR}/nidisablecstates      ${D}${sysconfdir}/init.d
-	update-rc.d -r ${D} nidisablecstates start 2 3 4 5 S .
-	install -m 0755   ${WORKDIR}/nicheckbiosconfig      ${D}${sysconfdir}/init.d
-	update-rc.d -r ${D} nicheckbiosconfig start 99 4 5 .
-
-	install -m 0755   ${WORKDIR}/nicleanefivars  ${D}${sysconfdir}/init.d
-	update-rc.d -r ${D} nicleanefivars start 10 S .
 }
 
 do_install_ptest () {


### PR DESCRIPTION
This PR removes branching logic from recipes which behave differently when the `MACHINE` type is set to `arm` or the `DISTRO` is set to `nilrt-nxg`. The former is inappropriate because the hardknott mainline does not support ARM; the later is inappropriate because the `nilrt-nxg` distro has been deprecated for years.

In a couple recipes (`initscripts-nilrt*` and `packagegroup-ni-xfce`), when I collapsed the branching logic into a generic variable, I also sorted the variable's elements - which is why some variable diffs show more changes than you would otherwise expect. They're just sorts.

# Testing
* Rebuilt the core packagefeed and images with these changes and created a VM. The VM boots and gettys correctly.