### PR TITLE
Revert "conf/distro/nilrt.inc: Set PACKAGE_ENABLE_FILELIST="True""

### DIFF
--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -134,9 +134,6 @@ NILRT_GIT ?= "git://github.com/ni"
 # Creates ``*-lic`` subpackages for all OE recipes if enabled
 LICENSE_CREATE_PACKAGE ?= "1"
 
-# Create Packages.filelist for each feed
-PACKAGE_ENABLE_FILELIST ?= "True"
-
 
 ## OPKG SOURCE FEEDS ##
 


### PR DESCRIPTION
There don't seem to be any uses of Packages.filelist.

NI's PACKAGE_ENABLE_FILELIST implementation is being removed from oe-core. So remove setting PACKAGE_ENABLE_FILELIST here.

This reverts commit 5295e17df7c5f10de5fc16e011aa13a05652415f.

### Testing

Ran `bitbake package-index` without issues.
Hardknott https://github.com/ni/openembedded-core/pull/70 for a few weeks without issues.