### PR TITLE
meta-toolchain: Permit outgoing symlinks

### DIFF
--- a/recipes-core/meta/meta-toolchain.bbappend
+++ b/recipes-core/meta/meta-toolchain.bbappend
@@ -1,13 +1,4 @@
-
-# Clean-up dangling and escaping symlinks which would fail `tar -h` for
-# Windows SDK builds. We should try to clean-up recipes that install
-# broken files whenever possible instead of doing it here, but that's
-# not an option in some cases.
-create_sdk_files:append() {
-    rm -f "${SDK_OUTPUT}/${SDKPATH}/sysroots/${SDK_SYS}/etc/ld.so.cache"
-    rm -f "${SDK_OUTPUT}/${SDKTARGETSYSROOT}/etc/mtab"
-    rm -f "${SDK_OUTPUT}/${SDKTARGETSYSROOT}/var/lock"
-}
-
-# Error if SDK sysroots contain broken symlinks
-CHECK_SDK_SYSROOTS = "1"
+# The installation script redirects symlinks that point to
+# /usr/local/oe-sdk-hardcoded-buildpath, so avoid causing errors for
+# outgoing symlinks that are there by design.
+CHECK_SDK_SYSROOTS = "0"


### PR DESCRIPTION
As part of the cross-compile toolchain work ([AB#1242721](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1242721)), we want to resolve the "escaping symlink" errors signaled when building meta-toolchain. The referenced errors arise from various links pointing to locations under `/usr/local/oe-sdk-hardcoded-buildpath`, which get replaced by the script that installs the toolchain--so they aren't really "escaping," just unconfigured.

This change also removes the existing symlink cleanup which seems intended for fixing Windows builds. I don't mind leaving it there, but the follow-up work for the Windows toolchain ([AB#2105299](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2105299)) will likely encounter the issue again if it's still a problem.