### PR TITLE
conf/local.conf.sample: Set SDKMACHINE to x86_64

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -75,7 +75,7 @@ DISTRO ?= "nilrt"
 # you can build the SDK packages for architectures other than the machine you are
 # running the build on (i.e. building i686 packages on an x86_64 host).
 # Supported values are i686 and x86_64
-#SDKMACHINE ?= "i686"
+SDKMACHINE ?= "x86_64"
 
 #
 # Extra image configuration defaults


### PR DESCRIPTION
As part of the cross-compile toolchain work ([AB#1242721](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1242721)), it is necessary to specify this variable. It is more appropriate to set it here than to make the tweak in the build directory at build time.