### PR TITLE
bblayers.conf: Add meta-mingw layer

### DIFF
--- a/conf/bblayers.conf.sample
+++ b/conf/bblayers.conf.sample
@@ -8,6 +8,7 @@ BBFILES ?= ""
 BBLAYERS ?= " \
 	${GIT_REPODIR}/meta-cloud-services \
 	${GIT_REPODIR}/meta-cloud-services/meta-openstack \
+	${GIT_REPODIR}/meta-mingw \
 	${GIT_REPODIR}/meta-nilrt \
 	${GIT_REPODIR}/meta-openembedded/meta-filesystems \
 	${GIT_REPODIR}/meta-openembedded/meta-gnome \


### PR DESCRIPTION
This layer is needed for SDK cross-compiling on Windows.

AzDO [2105299](https://ni.visualstudio.com/DevCentral/_workitems/edit/2105299)