### PR TITLE
mesa: Remove extra gallium from PACKAGECONFIG

### DIFF
--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -1,5 +1,4 @@
 # PXIe-88XX series hardware requires the r600_dri driver for hardware rendering
 PACKAGECONFIG:append = "\
-	gallium \
 	r600 \
 "


### PR DESCRIPTION
We have pulled upstream commit [bfa40b777f08][1] which adds gallium unconditionally, so it is now unnecessary to append it here.

[AB#2104905](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2104905)

[1]: <https://github.com/ni/openembedded-core/commit/bfa40b777f08bab97263559a1f91200005eb180c>