### PR TITLE
Replace distutils dependency in python3-pycrypto

### DIFF
--- a/recipes-devtools/python/python3-pycrypto_2.6.1.bb
+++ b/recipes-devtools/python/python3-pycrypto_2.6.1.bb
@@ -7,7 +7,7 @@ DEPENDS += " gmp"
 
 export HOST_SYS
 
-inherit pypi autotools-brokensep distutils3
+inherit pypi autotools-brokensep setuptools3_legacy
 
 SRC_URI += "file://cross-compiling.patch \
             file://CVE-2013-7459.patch \
@@ -23,7 +23,7 @@ do_compile[noexec] = "1"
 # *don't* want the autotools install to run, since this package doesn't
 # provide a "make install" target.
 do_install() {
-       distutils3_do_install
+        setuptools3_legacy_do_install
 }
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
## Reason

- distutils is deprecated and now showing a warning for this, it's a simple fix: you can just replace it with setuptools (legacy) instead

## Implementation:

- replace distutils inherit with setuptools legacy
- replace distutils install with setuptools legacy install

Note:

- Doesn't depend on other packages using setuptools too or anything. It's just this change
- The removal of distutils from meta-openembedded is not necessary
- setuptools3, setuptools3-base, and setuptools3_legacy are all already a part of openembedded-core

## Testing:
With the changes, bitbake packagefeed-ni-core does not produce any new errors
