### PR TITLE
[kirkstone] syslog-ng: Update conf file to use recipe version

### DIFF
--- a/recipes-support/syslog-ng/files/syslog-ng.conf.sysvinit
+++ b/recipes-support/syslog-ng/files/syslog-ng.conf.sysvinit
@@ -1,4 +1,4 @@
-@version: 3.31
+@version: @VERSION@
 # syslog-ng config file for NI RT targets
 
 options {

--- a/recipes-support/syslog-ng/syslog-ng_3.%.bbappend
+++ b/recipes-support/syslog-ng/syslog-ng_3.%.bbappend
@@ -28,6 +28,13 @@ do_install:append (){
    install -m 0644 ${WORKDIR}/logrotate.d-auth.conf ${D}${sysconfdir}/logrotate.d/auth.conf
    install -m 0644 ${WORKDIR}/logrotate.d-cron.conf ${D}${sysconfdir}/logrotate.d/cron.conf
    install -m 0644 ${WORKDIR}/logrotate.d-messages.conf ${D}${sysconfdir}/logrotate.d/messages.conf
+
+   # NILRT has a custom conf file for sysvinit systems.
+   # If using sysvinit, update the conf file with the current version.
+   if ${@bb.utils.contains('DISTRO_FEATURES','systemd','false','true',d)}; then
+      # syslog-ng expects the version to be MAJ.MIN, so filter out the patch version from ${PV}.
+      sed -i -e "s/@VERSION@/$(echo ${PV} | grep -oE ^[0-9]+.[0-9]+)/g" ${D}${sysconfdir}/${BPN}/${BPN}.conf
+   fi
 }
 
 INITSCRIPT_PARAMS = "start 19 2 3 4 5 . stop 90 0 1 6 ."


### PR DESCRIPTION
kirkstone is now shipping syslog-ng version 3.36.1. The conf file was still version 3.31 which caused a warning to print at boot. This updates the version tag in the conf file to use the recipe version to resolve the warning. This should prevent the need to update the recipe every release.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

AzDO Work Item: https://dev.azure.com/ni/DevCentral/_workitems/edit/2212522

## Testing:
Build base system image locally with the change and installed to a target. Confirmed the warning no longer appears. 