### PR TITLE
[kirkstone] glibc: use image/ source for locale.alias

### DIFF
--- a/recipes-core/glibc/glibc_2.%.bbappend
+++ b/recipes-core/glibc/glibc_2.%.bbappend
@@ -35,6 +35,6 @@ PACKAGE_NO_LOCALE = "1"
 # directory from the package/ staging area before it can be allocated to
 # ni-locale-alias. Restore it before splitting subpackages.
 restore_locale_alias() {
-	install -D ${LOCALESTASH}${datadir}/locale/locale.alias ${PKGD}${datadir}/locale/locale.alias
+	install -D ${D}${datadir}/locale/locale.alias ${PKGD}${datadir}/locale/locale.alias
 }
 PACKAGE_PREPROCESS_FUNCS += " restore_locale_alias "


### PR DESCRIPTION
When trying to build the `glibc` recipe on my dev machine, it will sometimes fail `do_package` with an error like..
```
ERROR: glibc-2.35-r0 do_package: ExecutionError('/home/usr0/fast/nilrt-kirkstone/build/tmp-glibc/work/core2-64-nilrt-linux/glibc/2.35-r0/temp/run.restore_locale_alias.580', 1, None, None)
<snip>
| DEBUG: Executing shell function restore_locale_alias
| install: cannot stat '/home/usr0/fast/nilrt-kirkstone/build/tmp-glibc/work/core2-64-nilrt-linux/glibc/2.35-r0/stashed-locale/usr/share/locale/locale.alias': No such file or directory
| WARNING: exit code 1 from a shell command.
| DEBUG: Python function do_package finished
ERROR: Task (/home/usr0/fast/nilrt-kirkstone/sources/openembedded-core/meta/recipes-core/glibc/glibc_2.35.bb:do_package) failed with exit code '1'
```

The reason is that the `restore_locale_alias` function added by meta-nilrt #394 tries to source `locale.alias` from a transient directory (`stashed-locale`) in the `glibc` workspace. When building the recipe from scratch, this works fine. But when running the do_package task from sstate, the locale stash directory has already been deleted by the `state_locale_cleanup` function.

But the `locale.alias` file *is* properly sstate-cached, and is restored to the recipe `image/` directory. So I think we can just use this as the source, and it should work for both the virgin-build and sstate-build cases.

@SparkingSpork: was there some compelling reason that you used `${LOCALESTASH}` originally?

NI AZDO: https://dev.azure.com/ni/DevCentral/_workitems/edit/2226367

# Testing
* Rebuild the glibc recipe from scratch and from the sstate and confirmed that it still builds correctly in both cases.
* Diffed the `ni-locale-alias` IPK that comes out of the kirkstone mainline, with this change; and the hardknott mainline, without this change; and confirmed that they only differ by copyright comment info.

# Meta
I think this bug exists in hardknott as well. If this gets merged, I'll also cherry-pick into hardknott.