### PR TITLE
Fix recipes to use correct override syntax

### DIFF
--- a/recipes-bsp/grub/grub-efi_2.%.bbappend
+++ b/recipes-bsp/grub/grub-efi_2.%.bbappend
@@ -6,7 +6,7 @@ GRUB_BUILDIN += "smbios chain multiboot efi_uga font gfxterm gfxmenu terminal \
                 regexp probe"
 
 # Downstream NI-branch code quality is not yet ready to build with -Werror
-CFLAGS:append += "-Wno-error"
+CFLAGS:append = " -Wno-error"
 
 PACKAGES:prepend = "${PN}-nilrt "
 

--- a/recipes-core/busybox/busybox_1.%.bbappend
+++ b/recipes-core/busybox/busybox_1.%.bbappend
@@ -13,11 +13,11 @@ SRC_URI =+ " \
             file://login-utilities.cfg \
             file://udhcpd.wlan0.conf"
 
-SRC_URI:append:x64 += "file://enable_ar_create_fragment.cfg"
+SRC_URI:append:x64 = " file://enable_ar_create_fragment.cfg"
 
 # we're using syslog-ng, don't build busybox syslog (avoids build warnings)
-SRC_URI:remove += "file://syslog.cfg"
-INITSCRIPT_PACKAGES:remove += "${PN}-syslog"
+SRC_URI:remove = "file://syslog.cfg"
+INITSCRIPT_PACKAGES:remove = "${PN}-syslog"
 
 # Do not perform update-rc.d actions on the hwclock.sh initscript in this
 # package. We only wish to call hwclock.sh from /etc/init.d/bootmisc manually.

--- a/recipes-core/gnuradio/gnuradio_git.bbappend
+++ b/recipes-core/gnuradio/gnuradio_git.bbappend
@@ -1,1 +1,1 @@
-PACKAGECONFIG:remove += "uhd"
+PACKAGECONFIG:remove = "uhd"

--- a/recipes-core/images/nilrt-safemode-initramfs.bb
+++ b/recipes-core/images/nilrt-safemode-initramfs.bb
@@ -22,7 +22,7 @@ IMAGE_INSTALL_NODEPS += "\
 	${NI_PROPRIETARY_SAFEMODE_PACKAGES} \
 "
 
-BAD_RECOMMENDATIONS:append:pn-${PN} += "shared-mime-info"
+BAD_RECOMMENDATIONS:append:pn-${PN} = " shared-mime-info"
 
 # Do not allow python to be installed into safemode ramdisk due to size
 PACKAGE_EXCLUDE += "python-core python3-core"

--- a/recipes-core/initrdscripts/init-restore-mode.bb
+++ b/recipes-core/initrdscripts/init-restore-mode.bb
@@ -55,4 +55,4 @@ do_install:append:xilinx-zynqhf() {
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 FILES:${PN} += " /init /ni_provisioning* /disk_config /efifix /etc/profile.d/00-init-restore-mode.sh"
-FILES:${PN}:append:x64 += " /grub.cfg "
+FILES:${PN}:append:x64 = " /grub.cfg "

--- a/recipes-core/packagegroups/packagefeed-ni-extra.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-extra.bb
@@ -302,7 +302,7 @@ RDEPENDS:${PN} += "\
 "
 
 # meta-openembedded/meta-oe/recipes-devtools
-RDEPENDS:${PN}:append:x64 += "\
+RDEPENDS:${PN}:append:x64 = "\
 	concurrencykit \
 	msr-tools \
 "
@@ -350,7 +350,7 @@ RDEPENDS:${PN} += "\
 
 # meta-openembedded/meta-oe/recipes-graphics
 # meta-oe/recipes-graphics
-RDEPENDS:${PN}:append:x64 += "\
+RDEPENDS:${PN}:append:x64 = "\
 	jasper \
 	packagegroup-fonts-truetype \
 	terminus-font \
@@ -457,7 +457,7 @@ RDEPENDS:${PN} += "\
 	vim \
 "
 
-RDEPENDS:${PN}:append:x64 += "\
+RDEPENDS:${PN}:append:x64 = "\
 	edac-utils \
 	lcms \
 	mcelog \
@@ -748,7 +748,7 @@ RDEPENDS:${PN} += "\
 	tgt \
 "
 
-RDEPENDS:${PN}:append:x64 += "\
+RDEPENDS:${PN}:append:x64 = "\
 	chef \
 	puppet \
 "
@@ -767,7 +767,7 @@ RDEPENDS:${PN} += "\
 	openvswitch \
 "
 
-RDEPENDS:${PN}:append:x64 += "\
+RDEPENDS:${PN}:append:x64 = "\
 	ipxe \
 "
 

--- a/recipes-core/packagegroups/packagegroup-base.bbappend
+++ b/recipes-core/packagegroups/packagegroup-base.bbappend
@@ -3,5 +3,5 @@
 # regulatory negotiation. NILRT uses CRDA for run-time negotiation, so these
 # databse files are superfluous. They also CONFLICT with `wireless-regdb` and
 # so need to be removed.
-RDEPENDS:packagegroup-base-wifi:remove += "wireless-regdb-static"
+RDEPENDS:packagegroup-base-wifi:remove = "wireless-regdb-static"
 RDEPENDS:packagegroup-base-wifi += "wireless-regdb"

--- a/recipes-core/udev/eudev_3.%.bbappend
+++ b/recipes-core/udev/eudev_3.%.bbappend
@@ -1,7 +1,7 @@
 EXTRA_OECONF =+ "--disable-mtd_probe"
 
 # we don't use the hwdb and it consumes around 10mb of space so disable it
-PACKAGECONFIG:remove += "hwdb"
+PACKAGECONFIG:remove = "hwdb"
 
 # in NILRT we use another network interface naming scheme than the eudev
 # default (network interfaces are renamed via initscripts)

--- a/recipes-core/util-linux/util-linux_2.%.bbappend
+++ b/recipes-core/util-linux/util-linux_2.%.bbappend
@@ -1,8 +1,8 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-DEPENDS:append:class-target += "shadow-native pseudo-native"
+DEPENDS:append:class-target = " shadow-native pseudo-native"
 
-RDEPENDS:${PN}-hwclock:append += "niacctbase busybox-hwclock"
+RDEPENDS:${PN}-hwclock:append = " niacctbase busybox-hwclock"
 RDEPENDS:${PN}-ptest += "${PN}-nilrt-ptest"
 
 pkg_postinst:${PN}-hwclock () {

--- a/recipes-kernel/kernel-tests/kernel-performance-tests.bb
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests.bb
@@ -12,8 +12,8 @@ S = "${WORKDIR}"
 
 DEPENDS = "virtual/kernel"
 RDEPENDS:${PN}-ptest += "bash rt-tests fio iperf3 python3 python3-pip"
-RDEPENDS:${PN}-ptest:append:x64 += "fw-printenv"
-RDEPENDS:${PN}-ptest:append:armv7a += "u-boot-fw-utils"
+RDEPENDS:${PN}-ptest:append:x64 = " fw-printenv"
+RDEPENDS:${PN}-ptest:append:armv7a = " u-boot-fw-utils"
 
 ALLOW_EMPTY:${PN} = "1"
 

--- a/recipes-kernel/kernel-tests/kernel-test-nohz.bb
+++ b/recipes-kernel/kernel-tests/kernel-test-nohz.bb
@@ -11,7 +11,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}-files:"
 S = "${WORKDIR}"
 
 RDEPENDS:${PN}-ptest += "bash coreutils procps rt-tests"
-RDEPENDS:${PN}-ptest:append:x64 += "packagegroup-ni-nohz-kernel"
+RDEPENDS:${PN}-ptest:append:x64 = " packagegroup-ni-nohz-kernel"
 ALLOW_EMPTY:${PN} = "1"
 
 SRC_URI += "\

--- a/recipes-kernel/linux/kernel-devsrc-nilrt.inc
+++ b/recipes-kernel/linux/kernel-devsrc-nilrt.inc
@@ -19,10 +19,10 @@ pkg_prerm:${PN} () {
 	fi
 }
 
-RDEPENDS:${PN}:append += "binutils gcc-symlinks"
+RDEPENDS:${PN}:append = " binutils gcc-symlinks"
 
 # "make prepare" skips building objtool if elfutils-dev is not installed at
 # postinst time; however if you install elfutils-dev later, then when dkms
 # tries to build modules it expects objtool to be available, but it's not.
 # Depending on elfutils-dev forces it to be there during postinst.
-RDEPENDS:${PN}:append += "${@bb.utils.contains('ARCH', 'x86', 'elfutils-dev', '', d)}"
+RDEPENDS:${PN}:append = " ${@bb.utils.contains('ARCH', 'x86', 'elfutils-dev', '', d)}"

--- a/recipes-kernel/perf/perf.bbappend
+++ b/recipes-kernel/perf/perf.bbappend
@@ -2,4 +2,4 @@
 # NILRT ARM images use linux kernel 4.14 - which does not support perf
 # scripting using python3. Disable `scripting` PACKAGECONFIG in that case, to
 # keep python3 out of the perf config.
-PACKAGECONFIG:remove:xilinx-zynq += "scripting"
+PACKAGECONFIG:remove:xilinx-zynq = "scripting"

--- a/recipes-ni/ni-hw-scripts/ni-hw-scripts-common.bb
+++ b/recipes-ni/ni-hw-scripts/ni-hw-scripts-common.bb
@@ -47,7 +47,7 @@ pkg_postrm:${PN} () {
 
 
 PACKAGE_ARCH = "all"
-PACKAGES:remove += "${PN}-staticdev ${PN}-dev ${PN}-dbg"
+PACKAGES:remove = "${PN}-staticdev ${PN}-dev ${PN}-dbg"
 
 FILES:${PN} += "\
 	${sysconfdir}/init.d/ni-rename-ifaces \

--- a/recipes-ni/ni-rtfeatures/ni-rtfeatures.bb
+++ b/recipes-ni/ni-rtfeatures/ni-rtfeatures.bb
@@ -51,7 +51,7 @@ pkg_postrm:${PN} () {
 
 
 PACKAGE_ARCH = "all"
-PACKAGES:remove += "${PN}-staticdev ${PN}-dev ${PN}-dbg"
+PACKAGES:remove = "${PN}-staticdev ${PN}-dev ${PN}-dbg"
 
 FILES:${PN} += "\
 	${sysconfdir}/init.d/* \

--- a/recipes-ni/ni-utils/ni-utils.bb
+++ b/recipes-ni/ni-utils/ni-utils.bb
@@ -26,7 +26,7 @@ DEPENDS += "shadow-native pseudo-native niacctbase update-rc.d-native"
 
 RDEPENDS:${PN} += "niacctbase bash"
 
-RDEPENDS:${PN}:append:x64 += "fw-printenv"
+RDEPENDS:${PN}:append:x64 = " fw-printenv"
 
 S = "${WORKDIR}"
 

--- a/recipes-support/onboard/onboard_%.bbappend
+++ b/recipes-support/onboard/onboard_%.bbappend
@@ -1,6 +1,6 @@
 # Onboard uses unicode glyphs in its key_defs.xml file, which means
 # we need a font that has those glyphs present.
-RDEPENDS:${PN}:append += "ttf-dejavu-sans"
+RDEPENDS:${PN}:append = " ttf-dejavu-sans"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 


### PR DESCRIPTION
Fixed usages of `remove +=` and `append +=` as they are not the recommended syntax and cause build warnings.

WI: [2105137](https://dev.azure.com/ni/DevCentral/_workitems/edit/2105137)

### Testing
Built `nilrt-safemode-rootfs` and `nilrt-base-system-image`.