### PR TITLE
nilrt.conf: squash meta-security warning 

### DIFF
--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -15,6 +15,8 @@ VIRTUAL-RUNTIME_xserver_common = "xserver-common"
 
 VIRTUAL-RUNTIME_mountpoint ?= "busybox"
 
+SKIP_META_SECURITY_SANITY_CHECK = "1"
+
 # on older NILRT distro flavors the kernel is installed in non-standard paths
 # for backward compatibility
 KERNEL_IMAGEDEST = "boot/runmode"


### PR DESCRIPTION
As per the meta-security README for kirkstone, various bbs require that the "security" feature be enabled now.

This appears to be a change from hardknott, so it makes sense to now enable it