### PR TITLE
Add irq_work priority and fix kthread_test_priority.sh test

### DIFF
--- a/recipes-rt/rt-tests/files/kthread_test_priority.sh
+++ b/recipes-rt/rt-tests/files/kthread_test_priority.sh
@@ -43,7 +43,7 @@ check_prio_for_task ksoftirqd/0 FIFO 8
 ptest_report
 
 ptest_change_subtest 3 irq
-check_prio_for_task irq FIFO 15
+check_prio_for_task irq/ FIFO 15
 ptest_report
 
 exit $rc_first

--- a/recipes-rt/rt-tests/files/kthread_test_priority.sh
+++ b/recipes-rt/rt-tests/files/kthread_test_priority.sh
@@ -46,4 +46,8 @@ ptest_change_subtest 3 irq
 check_prio_for_task irq/ FIFO 15
 ptest_report
 
+ptest_change_subtest 4 irq_work
+check_prio_for_task irq_work/ FIFO 12
+ptest_report
+
 exit $rc_first

--- a/recipes-rt/rtctl/files/rtgroups
+++ b/recipes-rt/rtctl/files/rtgroups
@@ -40,5 +40,6 @@
 # Default policy
 kthreadd:f:25:*:\[kthreadd\]$
 irqthread:f:15:*:\[irq\/.+\]$
+irq_work:f:12:*:\[irq_work\/.+\]$
 ksoftirqd:f:8:*:\[ksoftirqd\/.+\]$
 


### PR DESCRIPTION
kthread_test_priority.sh expects threads starting with "irq" to have priority 15. In older kernels (i.e., 4.14) this was true as only "irq/x" threads were present. But on newer kernels (5.10, 5.15, etc), there are also "irq_work/x" threads which have priority 1 which fails the test.

So fixed the test to check for "irq/" instead of "irq", added priority for irq_work in rtgroups and added a test for irq_work.

### Testing
The test is passing on a cRIO-9042 with current and next kernels with these changes.