### PR TITLE
util-linux: busybox dependency to squash warning

### DIFF
--- a/recipes-core/util-linux/util-linux_2.%.bbappend
+++ b/recipes-core/util-linux/util-linux_2.%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-DEPENDS:append:class-target = " shadow-native pseudo-native"
+DEPENDS:append:class-target = " shadow-native pseudo-native busybox"
 
 RDEPENDS:${PN}-hwclock:append = " niacctbase busybox-hwclock"
 RDEPENDS:${PN}-ptest += "${PN}-nilrt-ptest"


### PR DESCRIPTION
Getting a warning where util-linux-hwclock (which is RPROVIDES by util-linux) depends on busybox-hwclock (RDEPENDS by busybox):

```
WARNING: util-linux-2.37.4-r0 do_package_qa: QA Issue: util-linux-hwclock rdepends on busybox-hwclock, but it isn't a build dependency, missing busybox in DEPENDS or PACKAGECONFIG? [build-deps]
```

Adding a dependency here squashes warning