### PR TITLE
kernel_dmesg_diff: Add a static first log

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-tests-files/kernel_dmesg_diff.py
+++ b/recipes-kernel/kernel-tests/kernel-tests-files/kernel_dmesg_diff.py
@@ -156,7 +156,8 @@ replacement_patterns = [
         [r'audit\(\d+\.\d+:\d+\):', 'audit():'],
         [r', CDC EEM Device, \S+', ', CDC EEM Device, '],
         [r' HOST MAC \S+', ' HOST MAC '],
-        [r'NODE_DATA\(0\) allocated \[mem .*\]', 'NODE_DATA(0) allocated [mem ]']
+        [r'NODE_DATA\(0\) allocated \[mem .*\]', 'NODE_DATA(0) allocated [mem ]'],
+        [r'ACPI: SSDT 0x.*', 'ACPI: SSDT 0x']
 ]
 
 def strip_known_differences(log):


### PR DESCRIPTION
- Add a summary first log with kernel versions and diff hash to help streak indexer group like results.
- Add a replacement pattern to ignore "ACPI: SSDT " differences in logs.

### Testing
Ran on a VM