### PR TITLE
python3-pycrypto: adapt license name to new term

### DIFF
--- a/recipes-devtools/python/python3-pycrypto_2.6.1.bb
+++ b/recipes-devtools/python/python3-pycrypto_2.6.1.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Cryptographic modules for Python."
 HOMEPAGE = "http://www.pycrypto.org/"
-LICENSE = "PSFv2"
+LICENSE = "PSF-2.0"
 LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=35f354d199e8cb7667b059a23578e63d"
 
 DEPENDS += " gmp"


### PR DESCRIPTION
Many licenses have been renamed in kirkstone, and it appears the PSFv2 license that python3-pycrypto previously used is now refered to as PSF-2.0 as per the listt of acceptable licenses:

https://git.yoctoproject.org/poky/tree/meta/files/common-licenses?h=kirkstone

Simple rename is all that's required
