### PR TITLE
run-postinsts: add ptest to ptest-packagelists

### DIFF
--- a/recipes-devtools/run-postinsts/run-postinsts_%.bbappend
+++ b/recipes-devtools/run-postinsts/run-postinsts_%.bbappend
@@ -9,7 +9,7 @@ SRC_URI:append = " \
 "
 
 inherit ptest
-
+PTESTS_FAST += "${PN}-ptest"
 
 do_install:append() {
 


### PR DESCRIPTION
This is a script that we have and it produces a warning because run-postints-ptest is not a part of the larger ptest-packagelists.inc file. We need to add it to a variable in that file.

Warning:

```
WARNING: run-postinsts-1.0-r10 do_package_qa: QA Issue: supports ptests but is not included in oe-core's ptest-packagelists.inc [missing-ptest]
```

It should be noted we are appending the variable that is in that file instead of adding run-postints-ptest directly as run-postints is a part of our changes, not openembedded-core