### PR TITLE
Drop rauc support

### DIFF
--- a/recipes-core/dist-nilrt/dist-nilrt-efi-ab.bb
+++ b/recipes-core/dist-nilrt/dist-nilrt-efi-ab.bb
@@ -7,7 +7,7 @@ LICENSE_CREATE_PACKAGE = "0"
 PV = "${DISTRO_VERSION}"
 BUNDLE = "minimal-nilrt-bundle"
 DEPENDS = "${BUNDLE}"
-RDEPENDS:${PN} += "bash rauc"
+RDEPENDS:${PN} += "bash"
 ALLOW_EMPTY:${PN}-dbg = "0"
 ALLOW_EMPTY:${PN}-dev = "0"
 
@@ -27,11 +27,9 @@ do_install:x64() {
     install -d ${D}/usr/share/licenses/${PN}
     install -m 0755 ${WORKDIR}/${PN}-install  ${D}/usr/share/nilrt/nilrt-install
     install -m 0755 ${WORKDIR}/MIT ${D}/usr/share/licenses/${PN}/MIT
-    install -m 0755 ${DEPLOY_DIR_IMAGE}/${BUNDLE}-${MACHINE}.raucb ${D}/usr/share/nilrt
 }
 
 FILES:${PN} = "\
-    /usr/share/nilrt/${BUNDLE}-${MACHINE}.raucb \
     /usr/share/nilrt/nilrt-install \
     /usr/share/licenses/${PN}/MIT \
 "

--- a/recipes-core/dist-nilrt/files/dist-nilrt-efi-ab-install
+++ b/recipes-core/dist-nilrt/files/dist-nilrt-efi-ab-install
@@ -3,4 +3,3 @@ set -euo pipefail
 
 readonly SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 
-rauc --no-signatures install "$SCRIPT_DIR/minimal-nilrt-bundle-x64.raucb" 2>&1

--- a/recipes-core/images/rauc/nilrt-base-image.bb
+++ b/recipes-core/images/rauc/nilrt-base-image.bb
@@ -4,8 +4,6 @@ IMAGE_FEATURES += "x11"
 
 # boot management
 IMAGE_INSTALL = "\
-	rauc \
-	rauc-mark-good \
 "
 
 # user software

--- a/recipes-core/initrdscripts/init-restore-mode.bb
+++ b/recipes-core/initrdscripts/init-restore-mode.bb
@@ -26,7 +26,7 @@ SRC_URI:append:x64 = "\
 	file://grub.cfg	\
 "
 
-RDEPENDS:${PN} += "bash rauc"
+RDEPENDS:${PN} += "bash"
 
 do_install() {
 	install -d ${D}${sysconfdir}/ni-provisioning

--- a/recipes-core/packagegroups/packagefeed-ni-core.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-core.bb
@@ -26,8 +26,6 @@ RDEPENDS:${PN} = "\
 
 RDEPENDS:${PN}:append:x64 = "\
 	init-nilrt-ramfs \
-	rauc \
-	rauc-mark-good \
 	nilrt-grub-runmode \
 	nilrt-grub-safemode \
 "


### PR DESCRIPTION
Rauc is creating a warning:
```
WARNING: rauc-1.8-r0 do_install: Please overwrite example ca.cert.pem with a project specific one, or set the RAUC_KEYRING_FILE variable with your file! 
```
Since we are not currently using its functionality, we should drop it.

These commits prevent rauc from being built