### PR TITLE
[hardknott] Revert "Revert "opkg: populate keys even if creation data is in the future""

### DIFF
--- a/recipes-devtools/opkg/files/0001-opkg-key-add-keys-even-if-creation-date-is-in-the-fu.patch
+++ b/recipes-devtools/opkg/files/0001-opkg-key-add-keys-even-if-creation-date-is-in-the-fu.patch
@@ -1,0 +1,31 @@
+From e33cbfc0c983fda5c4efa13444efb8584dde7d2b Mon Sep 17 00:00:00 2001
+From: Alejandro del Castillo <alejandro.delcastillo@ni.com>
+Date: Fri, 22 Feb 2019 11:35:04 -0600
+Subject: [PATCH] opkg-key: add keys even if creation date is in the future
+
+Targets without a hwclock may fail during key population. Add flag to
+tell gpg to ignore future creation date errors.
+
+Signed-off-by: Alejandro del Castillo <alejandro.delcastillo@ni.com>
+
+Upstream-Status: Inappropiate
+---
+ utils/opkg-key | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/utils/opkg-key b/utils/opkg-key
+index 8550ea9..7212255 100755
+--- a/utils/opkg-key
++++ b/utils/opkg-key
+@@ -96,7 +96,7 @@ case "$command" in
+     populate)
+         for f in $ROOT/usr/share/opkg/keyrings/*.gpg; do
+             echo "Importing keys from '`basename $f`'..."
+-            $GPG --quiet --batch --import "$f"
++            $GPG --quiet --batch --ignore-time-conflict --import "$f"
+         done
+         echo "OK"
+         ;;
+-- 
+2.20.1
+

--- a/recipes-devtools/opkg/opkg_%.bbappend
+++ b/recipes-devtools/opkg/opkg_%.bbappend
@@ -5,6 +5,7 @@ SRC_URI += " \
 	file://opkg-signing.conf \
 	file://gpg.conf \
 	file://run-ptest \
+	file://0001-opkg-key-add-keys-even-if-creation-date-is-in-the-fu.patch \
 "
 
 inherit ptest


### PR DESCRIPTION
This reverts commit ccae7a71997dc5e25c42dc98d9fae3d9d751b5e4.

AzDO#2251378

opkg-key currently calls gpg with the --no-options flag, which results in /etc/opg/gpg/gpg.conf not being applied with the ignore-time-conflict flag on NI devices. This patch previously applied the flag directly in opkg-key so temporarily reverting it until a long-term fix can be identified.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

AzDO Work Item: https://dev.azure.com/ni/DevCentral/_workitems/edit/2251378/

## Testing: 
Built and installed a new BSI with the changes and confirmed that opkg update worked. Messages about keys being created in the future are still printed but the actual `opkg-key populate` call succeeds now and `opkg update` works on initial boot. 

## Note:
This will need cherry-picked into the 23.0 branch and we'll need to update out release build to use the new commit. 