### PR TITLE
[kirkstone] Set the feed name to 2023Q2

### DIFF
--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -4,7 +4,7 @@ DISTRO_VERSION = "10.0"
 
 DISTRO_CODENAME = "${LAYERSERIES_COMPAT_meta-nilrt}"
 
-NILRT_FEED_NAME ?= "next"
+NILRT_FEED_NAME ?= "2023Q2"
 
 DISTRO_FEATURES:append:x64 = "\
         x11 \


### PR DESCRIPTION
This was set to "next" in 23a181e8663d3df2670d050d5cd0190c810e8d8e but should be set to the usual Y+Q format so that the correct feeds can be pulled.

[AB#2105165](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2105165)