### PR TITLE
[hardknott] kernel-tests: Include OS version in dmesg log compare criteria.

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-tests.bb
+++ b/recipes-kernel/kernel-tests/kernel-tests.bb
@@ -11,7 +11,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}-files:"
 S = "${WORKDIR}"
 
 DEPENDS = "virtual/kernel libcap"
-RDEPENDS:${PN}-ptest += "bash libcap kmod dmidecode python3-pymongo"
+RDEPENDS:${PN}-ptest += "bash libcap kmod dmidecode python3-pymongo os-release"
 
 ALLOW_EMPTY:${PN} = "1"
 


### PR DESCRIPTION
Currently, if there are two OS versions running in the ATS the test_kernel_dmesg_diff test will use the latest dmesg log in the database regardless of which OS version it came from. This can result in failures due to changes between the OS versions when there are overlaps.

This change updates the test python script to prefer logs from the same OS version when available.

[AB#2279632](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2279632)

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>
(cherry picked from commit 82dd0c807da4989899075d38ece2053f47d93e33)

## Testing:
See #525 