### PR TITLE
[hardknott] kernel-tests: Prefer older kernels for dmesg comparison.

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-tests-files/kernel_dmesg_diff.py
+++ b/recipes-kernel/kernel-tests/kernel-tests-files/kernel_dmesg_diff.py
@@ -106,7 +106,7 @@ def get_old_dmesg_log(db, logger):
     query = {}
     kernel_version = KernelVersion()
     os_version = OsVersion()
-    query['kernel_version_full'] = {'$ne': kernel_version.full}
+    query['kernel_version_full'] = {'$lt': kernel_version.full}
     query['device_desc'] = get_device_desc()
     query['kernel_version_major_minor'] = kernel_version.major_minor
     query['os_version_major_minor'] = os_version.major_minor


### PR DESCRIPTION
Instead of looking for kernel versions that are not equal to the unit under test, look for kernel versions that are less than the current version. This prevents cases where an older kernel version's dmesg is compared against a newer versions.

[AB#2282279](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2282279)

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>
(cherry picked from commit 42b68d56564232c56548b982c0f117d530abc9a8)

## Testing:
See #527 