### PR TITLE
[kirkstone] nilrt.conf: Update path for feed versions.

### DIFF
--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -4,7 +4,7 @@ DISTRO_VERSION = "10.0"
 
 DISTRO_CODENAME = "${LAYERSERIES_COMPAT_meta-nilrt}"
 
-NILRT_FEED_NAME ?= "next"
+NILRT_FEED_NAME ?= "next/2023Q2"
 
 DISTRO_FEATURES:append:x64 = "\
         x11 \


### PR DESCRIPTION
Our internal dist next feeds are at "next/<version>", not "next". This change corrects the path to fix developer builds.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

## Testing:
Built `nilrt-base-system-image` and confirmed it was able to access the internal feeds while building.