### PR TITLE
[hardknott] kernel-performance-tests: Add conditional publishing and whitespace fixes 

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/run-cyclictest
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/run-cyclictest
@@ -56,9 +56,15 @@ function add_system_info()
 function run_cyclictest()
 {
     LOG="$LOG_DIR/cyclictest-$1-`date +'%Y_%m_%d-%H_%M_%S'`.log"
+    INFLUXDB_INFO="/home/admin/.influxdb.info"
     cyclictest --smp --priority=98 --mlockall --interval=997 --quiet --duration="$TEST_DURATION" --histofall=1000 --histfile="$LOG" > /dev/null
     add_system_info "$LOG"
-    python3 upload_cyclictest_results.py "-i $LOG" "-s dso-db-influx-1.ni.systems" "-p 8086"
+    if [[ -f "$INFLUXDB_INFO" ]]; then
+        source "$INFLUXDB_INFO"
+        python3 upload_cyclictest_results.py "-i $LOG" "-s $INFLUXDB_SERVER" "-p $INFLUXDB_PORT"
+    else
+        echo "INFO: No InfluxDB Connection Info. Results will not be published."
+    fi
 
     LATENCY=$(grep -sw "# Max Latencies:" "$LOG" | awk '{max=$4; for(i=4; i<=NF; i++) if ($i>max) max=$i; gsub("^0*", "", max); print max}')
     if [ "$LATENCY" -le "$MAX_LATENCY" ]; then

--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/run-cyclictest
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/run-cyclictest
@@ -3,7 +3,7 @@ source ./common.cfg
 
 function add_system_info()
 {
-    {
+	{
 	DESC=$(fw_printenv DeviceDesc)
 	DEVICE=${DESC#*=}
 	echo "# Device: $DEVICE"
@@ -17,67 +17,67 @@ function add_system_info()
 	# save info on the current security mitigations
 	echo "# Security vulnerabilities settings: "
 	if [ -d "/sys/devices/system/cpu/vulnerabilities" ]; then
-	    for f in  /sys/devices/system/cpu/vulnerabilities/*; do
+		for f in  /sys/devices/system/cpu/vulnerabilities/*; do
 		VULN=$(basename "$f")
 		if [ -f "$f" ]; then
-		    echo -n -e "#     $VULN:\t"
-		    cat "$f"
+			echo -n -e "#	 $VULN:\t"
+			cat "$f"
 		fi
-	    done
+		done
 	else
-	    echo "#     vulnerability information not published"
+		echo "#	 vulnerability information not published"
 	fi
 
 	# save info on the current C state settings
 	echo "# C-states settings: "
 	for CPU in /sys/devices/system/cpu/cpu[0-9]; do
-	    NCPU=$(basename "$CPU")
-	    echo "#     [$NCPU]"
-	    for CSTATE in $CPU/cpuidle/state[0-9]; do
+		NCPU=$(basename "$CPU")
+		echo "#	 [$NCPU]"
+		for CSTATE in $CPU/cpuidle/state[0-9]; do
 		NSTATE=$(basename "$CSTATE")
 		if [ -f "$CSTATE/name" ] && [ -f "$CSTATE/disable" ]; then
-                    NAME=$(cat "$CSTATE/name" 2>/dev/null)
-                    STATUS=$(cat "$CSTATE/disable" 2>/dev/null)
+					NAME=$(cat "$CSTATE/name" 2>/dev/null)
+					STATUS=$(cat "$CSTATE/disable" 2>/dev/null)
 
-                    echo -n "#     $NSTATE: $NAME: "
-                    if [ "$STATUS" = "0" ]; then
-                        echo "enabled"
-                    else
-                        echo "disabled"
-                    fi
+					echo -n "#	 $NSTATE: $NAME: "
+					if [ "$STATUS" = "0" ]; then
+						echo "enabled"
+					else
+						echo "disabled"
+					fi
 		else
-                    echo "#     information not available"
+					echo "#	 information not available"
 		fi
-	    done
+		done
 	done
-    } >> "$1"
+	} >> "$1"
 }
 
 function run_cyclictest()
 {
-    LOG="$LOG_DIR/cyclictest-$1-`date +'%Y_%m_%d-%H_%M_%S'`.log"
-    INFLUXDB_INFO="/home/admin/.influxdb.info"
-    cyclictest --smp --priority=98 --mlockall --interval=997 --quiet --duration="$TEST_DURATION" --histofall=1000 --histfile="$LOG" > /dev/null
-    add_system_info "$LOG"
-    if [[ -f "$INFLUXDB_INFO" ]]; then
-        source "$INFLUXDB_INFO"
-        python3 upload_cyclictest_results.py "-i $LOG" "-s $INFLUXDB_SERVER" "-p $INFLUXDB_PORT"
-    else
-        echo "INFO: No InfluxDB Connection Info. Results will not be published."
-    fi
+	LOG="$LOG_DIR/cyclictest-$1-`date +'%Y_%m_%d-%H_%M_%S'`.log"
+	INFLUXDB_INFO="/home/admin/.influxdb.info"
+	cyclictest --smp --priority=98 --mlockall --interval=997 --quiet --duration="$TEST_DURATION" --histofall=1000 --histfile="$LOG" > /dev/null
+	add_system_info "$LOG"
+	if [[ -f "$INFLUXDB_INFO" ]]; then
+		source "$INFLUXDB_INFO"
+		python3 upload_cyclictest_results.py "-i $LOG" "-s $INFLUXDB_SERVER" "-p $INFLUXDB_PORT"
+	else
+		echo "INFO: No InfluxDB Connection Info. Results will not be published."
+	fi
 
-    LATENCY=$(grep -sw "# Max Latencies:" "$LOG" | awk '{max=$4; for(i=4; i<=NF; i++) if ($i>max) max=$i; gsub("^0*", "", max); print max}')
-    if [ "$LATENCY" -le "$MAX_LATENCY" ]; then
+	LATENCY=$(grep -sw "# Max Latencies:" "$LOG" | awk '{max=$4; for(i=4; i<=NF; i++) if ($i>max) max=$i; gsub("^0*", "", max); print max}')
+	if [ "$LATENCY" -le "$MAX_LATENCY" ]; then
 	echo "cyclictest with $1 load latency: $LATENCY (usec) is less than max latency: $MAX_LATENCY (usec)"
 	echo "histogram log file: $LOG"
 	echo "PASS: test_kernel_cyclictest_$1"
 	CYCLICTEST_RESULT=0
-    else
+	else
 	echo "cyclictest with $1 load latency: $LATENCY (usec) is above the expected max latency: $MAX_LATENCY (usec)"
 	echo "histogram log file: $LOG"
 	echo "FAIL: test_kernel_cyclictest_$1"
 	CYCLICTEST_RESULT=1
-    fi
+	fi
 }
 
 mkdir -p "$LOG_DIR"


### PR DESCRIPTION
There are two changes made in this PR:

1. Conditionally publish test results from the kernel-performance-tests ptests only if a server configuration file exists. If it does not, the user will be notified. This allows developers to run the tests without publishing.
2. Fix-up whitespace in the run-cyclictest bash script.

[AB#2222201](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2222201)

## Testing:
See #530 