### PR TITLE
ni-base-system-image-tests: Add filesystem permissions ptest

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-tests-files/kernel_dmesg_diff.py
+++ b/recipes-kernel/kernel-tests/kernel-tests-files/kernel_dmesg_diff.py
@@ -1,5 +1,4 @@
 import argparse
-from bson.binary import Binary
 import datetime
 import difflib
 import hashlib
@@ -16,7 +15,7 @@ class DB:
 
     def __init__(self, server, user, password):
         mongo_client = pymongo.MongoClient("mongodb://{user}:{pwd}@{server}".format(
-            user=args.user, pwd=args.password, server=args.server
+            user=user, pwd=password, server=server
             ),
             w=1)
         db = mongo_client[self.mongo_db_name]
@@ -107,11 +106,7 @@ def upload_log(db, dmesg_log, logger):
     logger.log('INFO: Uploaded dmesg log of "{}" kernel {} from {} with _id {}'.format(data['kernel_type'], data['kernel_version_full'], data['date'], record.inserted_id))
 
 def strip_headers(dmesg_log):
-    output = ''
-    for line in dmesg_log.splitlines():
-        if not line.startswith('#'):
-            output = output + line + '\n'
-    return output
+    return ''.join(line + '\n' for line in dmesg_log.splitlines() if not line.startswith('#'))
 
 def get_old_dmesg_log(db, logger):
     query = {}

--- a/recipes-ni/ni-base-system-image-tests/files/fs_permissions_diff.py
+++ b/recipes-ni/ni-base-system-image-tests/files/fs_permissions_diff.py
@@ -1,0 +1,240 @@
+import argparse
+import datetime
+import difflib
+import hashlib
+import mmap
+import os
+import pymongo
+import re
+import subprocess
+import sys
+
+class DB:
+    mongo_db_name = 'rtos'
+    mongo_db_collection_name = 'dmesg_logs'
+
+    def __init__(self, server, user, password):
+        mongo_client = pymongo.MongoClient("mongodb://{user}:{pwd}@{server}".format(
+            user=user, pwd=password, server=server
+            ),
+            w=1)
+        db = mongo_client[self.mongo_db_name]
+        self.dmesg_logs_collection = db[self.mongo_db_collection_name]
+
+    def insert(self, data):
+        return self.dmesg_logs_collection.insert_one(data)
+
+    def find(self, query):
+        return self.dmesg_logs_collection.find(query)
+
+    def count_documents(self, query):
+        return self.dmesg_logs_collection.count_documents(query)
+
+class Logger:
+    logs = []
+    def log(self, log):
+        self.logs.append(log)
+
+    def first_log(self, log):
+        self.logs.insert(0, log)
+
+    def report(self):
+        for log in self.logs:
+            print(log)
+
+def run_cmd(cmd):
+    output = subprocess.check_output(cmd).strip()
+    return output.decode('utf-8')
+
+def get_device_desc():
+    cmdoutput = run_cmd(['fw_printenv', 'DeviceDesc'])
+    return cmdoutput.split('=')[1]
+
+class SemanticVersion:
+    def __init__(self, versionString):
+        # Regex below copied from https://semver.org/.
+        version = re.search(r'^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$', versionString)
+        self.full = version.group()
+        self.major = int(version.group('major'))
+        self.minor = int(version.group('minor'))
+        self.patch = int(version.group('patch'))
+        self.prerelease = version.group('prerelease')
+        self.build_metadata = version.group('buildmetadata')
+
+class KernelVersion(SemanticVersion):
+    def __init__(self):
+        version =run_cmd(['uname', '-r'])
+        SemanticVersion.__init__(self, version)
+        self.type = 'next' if self.build_metadata else 'current'
+        prerelease_version = int(re.search(r'0|[1-9]\d*', self.prerelease).group())
+        self.version_dict = { 'major': self.major, 'minor': self.minor, "patch": self.patch, 'prerelease': prerelease_version }
+
+class OsVersion:
+    def __init__(self):
+        with open('/etc/os-release', 'rb') as file, mmap.mmap(file.fileno(), 0, access=mmap.ACCESS_READ) as mfile:
+            build_id = re.search(br'BUILD_ID=\"((\d+\.\d+).*)\"', mfile)
+            self.full = build_id.group(1).decode()
+            self.major_minor = build_id.group(2).decode()
+
+def get_architecture():
+    return run_cmd(['uname', '-m'])
+
+def get_dmesg_log():
+    dmesg_log = run_cmd(['dmesg'])
+    return dmesg_log
+
+def upload_log(db, dmesg_log, logger):
+    data = {}
+    kernel_version = KernelVersion()
+    os_version = OsVersion()
+    data['kernel_version_full'] = kernel_version.full
+    data['kernel_version'] = kernel_version.version_dict
+    data['kernel_type'] = kernel_version.type
+    data['device_desc'] = get_device_desc()
+    data['architecture'] = get_architecture()
+    data['os_version'] = os_version.full
+    data['os_version_major_minor'] = os_version.major_minor
+    data['date'] = str(datetime.datetime.now())
+
+    header = ''
+    for key, val in data.items():
+        header = header + '# {}: {}\n'.format(key, val)
+
+    data['dmesg_log'] = header + dmesg_log
+
+    record = db.insert(data)
+    logger.log('INFO: Uploaded dmesg log of "{}" kernel {} from {} with _id {}'.format(data['kernel_type'], data['kernel_version_full'], data['date'], record.inserted_id))
+
+def strip_headers(dmesg_log):
+    return ''.join(line + '\n' for line in dmesg_log.splitlines() if not line.startswith('#'))
+
+def get_old_dmesg_log(db, logger):
+    query = {}
+    kernel_version = KernelVersion()
+    os_version = OsVersion()
+    query['kernel_version'] = { '$lt': kernel_version.version_dict }
+    query['device_desc'] = get_device_desc()
+    query['kernel_version.major'] = kernel_version.major
+    query['kernel_version.minor'] = kernel_version.minor
+    query['os_version_major_minor'] = os_version.major_minor
+
+    if db.count_documents(query):
+        results = db.find(query).sort('date', pymongo.DESCENDING).limit(1)
+    else:
+        # If there are no results, there may not be a run from the current os version.
+        # Remove that requirement.
+        del query['os_version_major_minor']
+        logger.log('INFO: No prior logs from this OS Version found. Using previous version.')
+
+        if db.count_documents(query):
+            results = db.find(query).sort('date', pymongo.DESCENDING).limit(1)
+        else:
+            # If there still aren't any results matching the kernel major minor version, broaden the
+            # search but limit it to same kernel type
+            del query['kernel_version.major']
+            del query['kernel_version.minor']
+            query['kernel_type'] = kernel_version.type
+
+            if db.count_documents(query):
+                results = db.find(query).sort('date', pymongo.DESCENDING).limit(1)
+            else:
+                # Keep this log in first line to help streak indexer group results. Diff hash will be populated at end.
+                logger.first_log('INFO: dmesg_diff: {} against <empty>, diff hash '.format(kernel_version.full))
+
+                logger.log('INFO: No suitable previous dmesg log found')
+                return ''
+
+    result = next(results)
+
+    # Keep this log in first line to help streak indexer group results. Diff hash will be populated at end.
+    logger.first_log('INFO: dmesg_diff: {} against older log of {}, diff hash '.format(kernel_version.full, result['kernel_version_full']))
+
+    logger.log('INFO: Using previous dmesg log of "{}" kernel {} from {} with _id {}'.format(result['kernel_type'], result['kernel_version_full'], result['date'], result['_id']))
+    dmesg_log = result['dmesg_log']
+    return strip_headers(dmesg_log)
+
+def strip_timestamps(log):
+    return re.sub(r'^\[.+?\] ', '', log, flags=re.MULTILINE)
+
+replacement_patterns = [
+        [r'Linux version \S+', 'Linux version '],
+        [r'root=PARTUUID=.+? ', 'root=PARTUUID= '],
+        [r'setting system clock to .*', 'setting system clock to '],
+        [r'sched_clock: Marking stable.*', 'sched_clock: Marking stable '],
+        [r'udevd\[\d+\]: ', 'udevd[]: '],
+        [r'ACPI: Core revision \d+', 'ACPI: Core revision '],
+        [r'Built 1 zonelists, mobility grouping on.  Total pages: \d+', 'Built 1 zonelists, mobility grouping on.  Total pages: '],
+        [r'Freeing unused kernel image .* memory: \S+', 'Freeing unused kernel image : '],
+        [r'SMP PREEMPT_RT .* UTC \d+', 'SMP PREEMPT_RT '],
+        [r'Memory: .* available \(.*\)', 'Memory: available ()'],
+        [r'Write protecting the kernel read-only data: \S+', 'Write protecting the kernel read-only data: '],
+        [r'ftrace: allocated \d+ pages with \d+ groups', 'ftrace: allocated pages with groups'],
+        [r'ftrace: allocating \d+ entries in \d+ pages', 'ftrace: allocating entries in pages'],
+        [r'pcpu-alloc: .*alloc=\S+', 'pcpu-alloc: '],
+        [r'percpu: Embedded .*', 'percpu: Embedded '],
+        [r'tcp_listen_portaddr_hash hash table entries: .*', 'tcp_listen_portaddr_hash hash table entries: '],
+        [r'hash table entries: .*', 'hash table entries: '],
+        [r'succeeded in \d+ usecs', 'succeeded in usecs'],
+        [r'audit\(\d+\.\d+:\d+\):', 'audit():'],
+        [r', CDC EEM Device, \S+', ', CDC EEM Device, '],
+        [r' HOST MAC \S+', ' HOST MAC '],
+        [r'NODE_DATA\(0\) allocated \[mem .*\]', 'NODE_DATA(0) allocated [mem ]'],
+        [r'ACPI: SSDT 0x.*', 'ACPI: SSDT 0x']
+]
+
+def strip_known_differences(log):
+    for pattern in replacement_patterns:
+        log = re.sub(pattern[0], pattern[1], log, flags=re.MULTILINE)
+    return log
+
+def prepare_log_for_diff(log):
+    log = strip_timestamps(log)
+    log = strip_known_differences(log)
+    log = log.splitlines()
+    log.sort()
+    return log
+
+def diff_logs(current_log, old_log, logger):
+    current_log = prepare_log_for_diff(current_log)
+    old_log = prepare_log_for_diff(old_log)
+    diff = list(difflib.unified_diff(old_log, current_log, n=0))
+    if diff:
+        # Add diff hash to first log
+        logger.logs[0] += hashlib.md5(''.join(diff).encode('utf-8')).hexdigest()
+
+        logger.log('INFO: Starting diff')
+        for line in diff:
+            logger.log(line)
+        logger.log('INFO: End of diff')
+        return False
+
+    # Add diff hash to first log
+    logger.logs[0] += '0'
+
+    logger.log('INFO: Empty diff')
+    return True
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='diff dmesg log with a previous log')
+    parser.add_argument('--server', required=True, help='Mongo server hostname')
+    parser.add_argument('--user', required=True, help='Mongo server username')
+    parser.add_argument('--password', required=True, help='Mongo server password')
+
+    return parser.parse_args()
+
+logger = Logger()
+args = parse_args()
+db = DB(args.server, args.user, args.password)
+old_dmesg_log = get_old_dmesg_log(db, logger)
+
+dmesg_log = get_dmesg_log()
+upload_log(db, dmesg_log, logger)
+
+result = diff_logs(dmesg_log, old_dmesg_log, logger)
+
+logger.report()
+
+if result:
+    sys.exit(os.EX_OK)
+else:
+    sys.exit(os.EX_SOFTWARE)

--- a/recipes-ni/ni-base-system-image-tests/files/fs_permissions_diff.py
+++ b/recipes-ni/ni-base-system-image-tests/files/fs_permissions_diff.py
@@ -1,6 +1,6 @@
 import argparse
+import csv
 import datetime
-import difflib
 import hashlib
 import mmap
 import os
@@ -11,7 +11,7 @@ import sys
 
 class DB:
     mongo_db_name = 'rtos'
-    mongo_db_collection_name = 'dmesg_logs'
+    mongo_db_collection_name = 'fs_permissions'
 
     def __init__(self, server, user, password):
         mongo_client = pymongo.MongoClient("mongodb://{user}:{pwd}@{server}".format(
@@ -19,16 +19,16 @@ class DB:
             ),
             w=1)
         db = mongo_client[self.mongo_db_name]
-        self.dmesg_logs_collection = db[self.mongo_db_collection_name]
+        self.fs_permissions_collection = db[self.mongo_db_collection_name]
 
     def insert(self, data):
-        return self.dmesg_logs_collection.insert_one(data)
+        return self.fs_permissions_collection.insert_one(data)
 
     def find(self, query):
-        return self.dmesg_logs_collection.find(query)
+        return self.fs_permissions_collection.find(query)
 
     def count_documents(self, query):
-        return self.dmesg_logs_collection.count_documents(query)
+        return self.fs_permissions_collection.count_documents(query)
 
 class Logger:
     logs = []
@@ -46,77 +46,88 @@ def run_cmd(cmd):
     output = subprocess.check_output(cmd).strip()
     return output.decode('utf-8')
 
-def get_device_desc():
-    cmdoutput = run_cmd(['fw_printenv', 'DeviceDesc'])
-    return cmdoutput.split('=')[1]
-
-class SemanticVersion:
-    def __init__(self, versionString):
-        # Regex below copied from https://semver.org/.
-        version = re.search(r'^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$', versionString)
-        self.full = version.group()
-        self.major = int(version.group('major'))
-        self.minor = int(version.group('minor'))
-        self.patch = int(version.group('patch'))
-        self.prerelease = version.group('prerelease')
-        self.build_metadata = version.group('buildmetadata')
-
-class KernelVersion(SemanticVersion):
-    def __init__(self):
-        version =run_cmd(['uname', '-r'])
-        SemanticVersion.__init__(self, version)
-        self.type = 'next' if self.build_metadata else 'current'
-        prerelease_version = int(re.search(r'0|[1-9]\d*', self.prerelease).group())
-        self.version_dict = { 'major': self.major, 'minor': self.minor, "patch": self.patch, 'prerelease': prerelease_version }
-
 class OsVersion:
+    phase_number = { 'd': 0, 'a': 1, 'b': 2, 'f': 3 }
+
     def __init__(self):
         with open('/etc/os-release', 'rb') as file, mmap.mmap(file.fileno(), 0, access=mmap.ACCESS_READ) as mfile:
             build_id = re.search(br'BUILD_ID=\"((\d+\.\d+).*)\"', mfile)
             self.full = build_id.group(1).decode()
             self.major_minor = build_id.group(2).decode()
+            codename = re.search(br'VERSION_CODENAME=\"(.*)\"', mfile)
+            self.codename = codename.group(1).decode()
 
-def get_architecture():
-    return run_cmd(['uname', '-m'])
+        decomposed_version = re.match(r'(\d+).(\d+).(\d+)([dabf])(\d+)', self.full)
+        self.major = int(decomposed_version.group(1))
+        self.minor = int(decomposed_version.group(2))
+        self.patch = int(decomposed_version.group(3))
+        self.phase = decomposed_version.group(4)
+        self.build = int(decomposed_version.group(5))
+        self.version_dict = {
+            'major': self.major,
+            'minor': self.minor,
+            'patch': self.patch,
+            'phase': self.phase_number[self.phase],
+            'build': self.build
+        }
 
-def get_dmesg_log():
-    dmesg_log = run_cmd(['dmesg'])
-    return dmesg_log
+fs_manifest_format = '%p\t%M\t%u\t%g\t%l'
+fs_manifest_columns = ['path', 'mode', 'user', 'group', 'link_target']
+def get_fs_manifest():
+    search_dirs = ['/bin', '/boot', '/etc', '/lib', '/lib64', '/sbin', '/usr', '/var']
+    omit_dirs = ['/lib/modules', '/var/cache', '/var/run', '/var/tmp', '/var/volatile']
 
-def upload_log(db, dmesg_log, logger):
+    omit_expr = []
+    for d in omit_dirs:
+        omit_expr += ['-path', d, '-o']
+    omit_expr.pop()
+
+    fs_manifest = run_cmd(
+        ['find']
+        + search_dirs
+        + ['-printf', fs_manifest_format + '\n']
+        + ['('] + omit_expr + [')', '-prune']
+    )
+    return fs_manifest
+
+def upload_manifest(db, fs_manifest, logger):
     data = {}
-    kernel_version = KernelVersion()
     os_version = OsVersion()
-    data['kernel_version_full'] = kernel_version.full
-    data['kernel_version'] = kernel_version.version_dict
-    data['kernel_type'] = kernel_version.type
-    data['device_desc'] = get_device_desc()
-    data['architecture'] = get_architecture()
-    data['os_version'] = os_version.full
+    data['os_version_codename'] = os_version.codename
+    data['os_version_full'] = os_version.full
     data['os_version_major_minor'] = os_version.major_minor
+    data['os_version'] = os_version.version_dict
     data['date'] = str(datetime.datetime.now())
 
     header = ''
     for key, val in data.items():
         header = header + '# {}: {}\n'.format(key, val)
 
-    data['dmesg_log'] = header + dmesg_log
+    data['fs_permissions'] = header + fs_manifest
 
     record = db.insert(data)
-    logger.log('INFO: Uploaded dmesg log of "{}" kernel {} from {} with _id {}'.format(data['kernel_type'], data['kernel_version_full'], data['date'], record.inserted_id))
+    logger.log('INFO: Uploaded fs permissions of OS {} from {} with _id {}'.format(data['os_version_full'], data['date'], record.inserted_id))
 
-def strip_headers(dmesg_log):
-    return ''.join(line + '\n' for line in dmesg_log.splitlines() if not line.startswith('#'))
+def strip_headers(fs_manifest):
+    return ''.join(line + '\n' for line in fs_manifest.splitlines() if not line.startswith('#'))
 
-def get_old_dmesg_log(db, logger):
-    query = {}
-    kernel_version = KernelVersion()
+def get_old_fs_manifest(db, logger):
     os_version = OsVersion()
-    query['kernel_version'] = { '$lt': kernel_version.version_dict }
-    query['device_desc'] = get_device_desc()
-    query['kernel_version.major'] = kernel_version.major
-    query['kernel_version.minor'] = kernel_version.minor
-    query['os_version_major_minor'] = os_version.major_minor
+    query = {
+        'os_version_codename': os_version.codename,
+        'os_version_major_minor': os_version.major_minor,
+        'os_version': {
+            '$lt': {
+                'major': os_version.major,
+                'minor': os_version.minor,
+                'patch': os_version.patch,
+                # $lt considers booleans to be greater than all numbers
+                'phase': False,
+                'build': False
+            }
+        },
+        'os_version.phase': OsVersion.phase_number['f']
+    }
 
     if db.count_documents(query):
         results = db.find(query).sort('date', pymongo.DESCENDING).limit(1)
@@ -124,98 +135,86 @@ def get_old_dmesg_log(db, logger):
         # If there are no results, there may not be a run from the current os version.
         # Remove that requirement.
         del query['os_version_major_minor']
-        logger.log('INFO: No prior logs from this OS Version found. Using previous version.')
+        logger.log('INFO: No prior fs permissions from this OS Version found. Using previous version.')
 
         if db.count_documents(query):
             results = db.find(query).sort('date', pymongo.DESCENDING).limit(1)
         else:
-            # If there still aren't any results matching the kernel major minor version, broaden the
-            # search but limit it to same kernel type
-            del query['kernel_version.major']
-            del query['kernel_version.minor']
-            query['kernel_type'] = kernel_version.type
+            # Keep this log in first line to help streak indexer group results. Hashes will be populated at end.
+            logger.first_log('INFO: fs_permissions_diff: {} against <empty> '.format(os_version.full))
 
-            if db.count_documents(query):
-                results = db.find(query).sort('date', pymongo.DESCENDING).limit(1)
-            else:
-                # Keep this log in first line to help streak indexer group results. Diff hash will be populated at end.
-                logger.first_log('INFO: dmesg_diff: {} against <empty>, diff hash '.format(kernel_version.full))
-
-                logger.log('INFO: No suitable previous dmesg log found')
-                return ''
+            logger.log('INFO: No suitable previous fs permissions found')
+            return ''
 
     result = next(results)
 
-    # Keep this log in first line to help streak indexer group results. Diff hash will be populated at end.
-    logger.first_log('INFO: dmesg_diff: {} against older log of {}, diff hash '.format(kernel_version.full, result['kernel_version_full']))
+    # Keep this log in first line to help streak indexer group results. Hashes will be populated at end.
+    logger.first_log('INFO: fs_permissions_diff: {} against older log of {} '.format(os_version.full, result['os_version_full']))
 
-    logger.log('INFO: Using previous dmesg log of "{}" kernel {} from {} with _id {}'.format(result['kernel_type'], result['kernel_version_full'], result['date'], result['_id']))
-    dmesg_log = result['dmesg_log']
-    return strip_headers(dmesg_log)
+    logger.log('INFO: Using previous fs permissions of OS {} from {} with _id {}'.format(result['os_version_full'], result['date'], result['_id']))
+    fs_manifest = result['fs_permissions']
+    return strip_headers(fs_manifest)
 
-def strip_timestamps(log):
-    return re.sub(r'^\[.+?\] ', '', log, flags=re.MULTILINE)
+def prepare_manifest_for_diff(manifest):
+    reader = csv.DictReader(manifest.splitlines(), fieldnames=fs_manifest_columns, delimiter='\t')
+    return {row['path']: row for row in reader}
 
-replacement_patterns = [
-        [r'Linux version \S+', 'Linux version '],
-        [r'root=PARTUUID=.+? ', 'root=PARTUUID= '],
-        [r'setting system clock to .*', 'setting system clock to '],
-        [r'sched_clock: Marking stable.*', 'sched_clock: Marking stable '],
-        [r'udevd\[\d+\]: ', 'udevd[]: '],
-        [r'ACPI: Core revision \d+', 'ACPI: Core revision '],
-        [r'Built 1 zonelists, mobility grouping on.  Total pages: \d+', 'Built 1 zonelists, mobility grouping on.  Total pages: '],
-        [r'Freeing unused kernel image .* memory: \S+', 'Freeing unused kernel image : '],
-        [r'SMP PREEMPT_RT .* UTC \d+', 'SMP PREEMPT_RT '],
-        [r'Memory: .* available \(.*\)', 'Memory: available ()'],
-        [r'Write protecting the kernel read-only data: \S+', 'Write protecting the kernel read-only data: '],
-        [r'ftrace: allocated \d+ pages with \d+ groups', 'ftrace: allocated pages with groups'],
-        [r'ftrace: allocating \d+ entries in \d+ pages', 'ftrace: allocating entries in pages'],
-        [r'pcpu-alloc: .*alloc=\S+', 'pcpu-alloc: '],
-        [r'percpu: Embedded .*', 'percpu: Embedded '],
-        [r'tcp_listen_portaddr_hash hash table entries: .*', 'tcp_listen_portaddr_hash hash table entries: '],
-        [r'hash table entries: .*', 'hash table entries: '],
-        [r'succeeded in \d+ usecs', 'succeeded in usecs'],
-        [r'audit\(\d+\.\d+:\d+\):', 'audit():'],
-        [r', CDC EEM Device, \S+', ', CDC EEM Device, '],
-        [r' HOST MAC \S+', ' HOST MAC '],
-        [r'NODE_DATA\(0\) allocated \[mem .*\]', 'NODE_DATA(0) allocated [mem ]'],
-        [r'ACPI: SSDT 0x.*', 'ACPI: SSDT 0x']
-]
+def diff_manifests(current_manifest, old_manifest, logger):
+    current_hash = hashlib.md5(current_manifest.encode('utf-8')).hexdigest()
+    current_manifest = prepare_manifest_for_diff(current_manifest)
+    old_hash = hashlib.md5(old_manifest.encode('utf-8')).hexdigest()
+    old_manifest = prepare_manifest_for_diff(old_manifest)
 
-def strip_known_differences(log):
-    for pattern in replacement_patterns:
-        log = re.sub(pattern[0], pattern[1], log, flags=re.MULTILINE)
-    return log
+    removed_paths = old_manifest.keys() - current_manifest.keys()
+    added_paths = current_manifest.keys() - old_manifest.keys()
+    common_paths = old_manifest.keys() & current_manifest.keys()
 
-def prepare_log_for_diff(log):
-    log = strip_timestamps(log)
-    log = strip_known_differences(log)
-    log = log.splitlines()
-    log.sort()
-    return log
+    # ignores symlink targets
+    is_same = lambda old, new: (old['mode'] == new['mode']
+                                and old['user'] == new['user']
+                                and old['group'] == new['group'])
+    different_paths = set(path for path in common_paths if not is_same(old_manifest[path], current_manifest[path]))
 
-def diff_logs(current_log, old_log, logger):
-    current_log = prepare_log_for_diff(current_log)
-    old_log = prepare_log_for_diff(old_log)
-    diff = list(difflib.unified_diff(old_log, current_log, n=0))
-    if diff:
-        # Add diff hash to first log
-        logger.logs[0] += hashlib.md5(''.join(diff).encode('utf-8')).hexdigest()
+    detail_string = lambda entry: f"mode = {entry['mode']}, user = {entry['user']}, group = {entry['group']}"
 
+    any_differences = False
+
+    if 0 != len(removed_paths):
+        logger.log('INFO: Starting removed path list')
+        for path in removed_paths:
+            logger.log(f'{path}: {detail_string(old_manifest[path])}')
+        logger.log('INFO: End of removed path list')
+        any_differences = any_differences or True
+    else:
+        logger.log('INFO: No paths removed')
+
+    if 0 != len(added_paths):
+        logger.log('INFO: Starting added path list')
+        for path in added_paths:
+            logger.log(f'{path}: {detail_string(current_manifest[path])}')
+        logger.log('INFO: End of added path list')
+        any_differences = any_differences or True
+    else:
+        logger.log('INFO: No paths added')
+
+    # Add hashes to first line of log to allow review queue to distinguish runs
+    logger.logs[0] += f'(old={old_hash}, new={current_hash})'
+
+    if 0 != len(different_paths):
         logger.log('INFO: Starting diff')
-        for line in diff:
-            logger.log(line)
+        for path in different_paths:
+            logger.log('\n'.join([path,
+                                  f'\told: {detail_string(old_manifest[path])}',
+                                  f'\tnew: {detail_string(current_manifest[path])}']))
         logger.log('INFO: End of diff')
-        return False
+        any_differences = any_differences or True
+    else:
+        logger.log('INFO: Empty diff')
 
-    # Add diff hash to first log
-    logger.logs[0] += '0'
-
-    logger.log('INFO: Empty diff')
-    return True
+    return not any_differences
 
 def parse_args():
-    parser = argparse.ArgumentParser(description='diff dmesg log with a previous log')
+    parser = argparse.ArgumentParser(description='diff fs permissions with previous')
     parser.add_argument('--server', required=True, help='Mongo server hostname')
     parser.add_argument('--user', required=True, help='Mongo server username')
     parser.add_argument('--password', required=True, help='Mongo server password')
@@ -225,12 +224,12 @@ def parse_args():
 logger = Logger()
 args = parse_args()
 db = DB(args.server, args.user, args.password)
-old_dmesg_log = get_old_dmesg_log(db, logger)
+old_fs_manifest = get_old_fs_manifest(db, logger)
 
-dmesg_log = get_dmesg_log()
-upload_log(db, dmesg_log, logger)
+fs_manifest = get_fs_manifest()
+upload_manifest(db, fs_manifest, logger)
 
-result = diff_logs(dmesg_log, old_dmesg_log, logger)
+result = diff_manifests(fs_manifest, old_fs_manifest, logger)
 
 logger.report()
 

--- a/recipes-ni/ni-base-system-image-tests/files/ptest-format.sh
+++ b/recipes-ni/ni-base-system-image-tests/files/ptest-format.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Version 0.2
+# Utility script containing common functions for ptest-compatible test scripts.
+# USAGE:
+# 1) Source this file at the top of your ptest script.
+# 2) Set ptest_test to the name of your test; recommended:
+#    $(basename -s ".sh" "$0")
+# 3) Define your subtests in functions, which call ptest_pass when they pass and
+#    ptest_fail otherwise (FAIL is DEFAULT)
+# 4) Prior to calling your test function, call ptest_change_subtest
+# 5) Call your test function.
+# 6) Call ptest_report immediately after the function returns.
+
+exec 2>&1  # redirect all stderr to stdout to maintain ordering of output
+
+function ptest_report () {
+	local result='FAIL'
+	case $ptest_rc in
+		0)
+			result='PASS'
+			;;
+		77)
+			result='SKIP'
+			;;
+		*)
+			result='FAIL'
+			;;
+	esac
+
+	if [ "$#" -gt 0 ]; then
+		echo "$@"
+	fi
+
+	printf "${result}: %s" "${ptest_test}"
+	if [ -n "${ptest_subtest}" ]; then
+		printf " %d" "${ptest_subtest}"
+		if [ -n "${ptest_subtest_desc}" ]; then
+			printf " - %s" "${ptest_subtest_desc}"
+		fi
+	fi
+	printf "\n"
+}
+
+function ptest_pass () {
+	ptest_rc=0
+}
+
+function ptest_skip () {
+	ptest_rc=77
+}
+
+function ptest_fail () {
+	ptest_rc=1
+}
+
+# 1 - new test name
+# 2 - new subtest number
+# 3 - new subtest description
+function ptest_change_test () {
+	ptest_test="$1"
+	ptest_subtest="$2"
+	ptest_subtest_desc="$3"
+	ptest_fail
+}
+
+# 1 - new subtest number
+# 2 - new subtest description
+function ptest_change_subtest () {
+	ptest_subtest="$1"
+	ptest_subtest_desc="$2"
+	ptest_fail
+}
+
+ptest_test=''
+ptest_subtest=''
+ptest_subtest_desc=''
+ptest_fail  # set ptest_rc to FAIL

--- a/recipes-ni/ni-base-system-image-tests/files/run-ptest
+++ b/recipes-ni/ni-base-system-image-tests/files/run-ptest
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./test_fs_permissions_diff.sh
+
+exit 0

--- a/recipes-ni/ni-base-system-image-tests/files/test_fs_permissions_diff.sh
+++ b/recipes-ni/ni-base-system-image-tests/files/test_fs_permissions_diff.sh
@@ -2,10 +2,10 @@
 
 source $(dirname "$0")/ptest-format.sh
 
-ptest_change_test $(basename "$0" ".sh") "" "Diff dmesg log with with previous"
+ptest_change_test $(basename "$0" ".sh") "" "Diff filesystem permissions with previous"
 
 source /home/admin/.mongodb.creds
-python3 kernel_dmesg_diff.py --server $MONGO_SERVER --user $MONGO_USER --password $MONGO_PASSWORD
+python3 fs_permissions_diff.py --server $MONGO_SERVER --user $MONGO_USER --password $MONGO_PASSWORD
 
 if [ $? -eq 0 ]; then
    ptest_pass

--- a/recipes-ni/ni-base-system-image-tests/files/test_fs_permissions_diff.sh
+++ b/recipes-ni/ni-base-system-image-tests/files/test_fs_permissions_diff.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+source $(dirname "$0")/ptest-format.sh
+
+ptest_change_test $(basename "$0" ".sh") "" "Diff dmesg log with with previous"
+
+source /home/admin/.mongodb.creds
+python3 kernel_dmesg_diff.py --server $MONGO_SERVER --user $MONGO_USER --password $MONGO_PASSWORD
+
+if [ $? -eq 0 ]; then
+   ptest_pass
+else
+   ptest_fail
+fi
+
+ptest_report

--- a/recipes-ni/ni-base-system-image-tests/ni-base-system-image-tests.bb
+++ b/recipes-ni/ni-base-system-image-tests/ni-base-system-image-tests.bb
@@ -1,0 +1,46 @@
+SUMMARY = "Ptests for the nirtcfg utility"
+DESCRIPTION = "\
+Installs ptests for the nirtcfg utilty."
+
+SECTION = "tests"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI = "\
+    file://configs/ \
+    file://run-ptest \
+    file://ptest-format.sh \
+    file://section_chars \
+    file://setup.sh \
+    file://shared-functions.sh \
+    file://teardown.sh \
+    file://test_binary.sh \
+    file://test_clear.sh \
+    file://test_get.sh \
+    file://test_list.sh \
+    file://test_rm-if-empty.sh \
+    file://test_set.sh \
+"
+
+S = "${WORKDIR}"
+
+inherit ptest
+
+do_install_ptest() {
+    install -m 0755 -d ${D}${PTEST_PATH}/configs
+    install -m 0755 ${WORKDIR}/configs/*           ${D}${PTEST_PATH}/configs
+    install -m 0644 ${WORKDIR}/ptest-format.sh     ${D}${PTEST_PATH}
+    install -m 0755 ${WORKDIR}/run-ptest           ${D}${PTEST_PATH}
+    install -m 0755 ${WORKDIR}/section_chars       ${D}${PTEST_PATH}
+    install -m 0755 ${WORKDIR}/setup.sh            ${D}${PTEST_PATH}
+    install -m 0755 ${WORKDIR}/shared-functions.sh ${D}${PTEST_PATH}
+    install -m 0755 ${WORKDIR}/teardown.sh         ${D}${PTEST_PATH}
+    install -m 0755 ${WORKDIR}/test_*.sh           ${D}${PTEST_PATH}
+}
+
+# We only want to build the -ptest package
+PACKAGES:remove = "${PN}-dev ${PN}-staticdev ${PN}-dbg"
+
+RDEPENDS:${PN}-ptest:append = " bash"

--- a/recipes-ni/ni-base-system-image-tests/ni-base-system-image-tests.bb
+++ b/recipes-ni/ni-base-system-image-tests/ni-base-system-image-tests.bb
@@ -1,6 +1,6 @@
-SUMMARY = "Ptests for the nirtcfg utility"
+SUMMARY = "Ptests for the base system image"
 DESCRIPTION = "\
-Installs ptests for the nirtcfg utilty."
+Installs ptests for the base system image."
 
 SECTION = "tests"
 LICENSE = "MIT"
@@ -8,20 +8,13 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
+ALLOW_EMPTY:${PN} = "1"
+
 SRC_URI = "\
-    file://configs/ \
     file://run-ptest \
     file://ptest-format.sh \
-    file://section_chars \
-    file://setup.sh \
-    file://shared-functions.sh \
-    file://teardown.sh \
-    file://test_binary.sh \
-    file://test_clear.sh \
-    file://test_get.sh \
-    file://test_list.sh \
-    file://test_rm-if-empty.sh \
-    file://test_set.sh \
+    file://fs_permissions_diff.py \
+    file://test_fs_permissions_diff.sh \
 "
 
 S = "${WORKDIR}"
@@ -29,18 +22,13 @@ S = "${WORKDIR}"
 inherit ptest
 
 do_install_ptest() {
-    install -m 0755 -d ${D}${PTEST_PATH}/configs
-    install -m 0755 ${WORKDIR}/configs/*           ${D}${PTEST_PATH}/configs
-    install -m 0644 ${WORKDIR}/ptest-format.sh     ${D}${PTEST_PATH}
-    install -m 0755 ${WORKDIR}/run-ptest           ${D}${PTEST_PATH}
-    install -m 0755 ${WORKDIR}/section_chars       ${D}${PTEST_PATH}
-    install -m 0755 ${WORKDIR}/setup.sh            ${D}${PTEST_PATH}
-    install -m 0755 ${WORKDIR}/shared-functions.sh ${D}${PTEST_PATH}
-    install -m 0755 ${WORKDIR}/teardown.sh         ${D}${PTEST_PATH}
-    install -m 0755 ${WORKDIR}/test_*.sh           ${D}${PTEST_PATH}
+    install -m 0644 ${WORKDIR}/ptest-format.sh        ${D}${PTEST_PATH}
+    install -m 0755 ${WORKDIR}/run-ptest              ${D}${PTEST_PATH}
+    install -m 0644 ${WORKDIR}/fs_permissions_diff.py ${D}${PTEST_PATH}
+    install -m 0755 ${WORKDIR}/test_*.sh              ${D}${PTEST_PATH}
 }
 
 # We only want to build the -ptest package
 PACKAGES:remove = "${PN}-dev ${PN}-staticdev ${PN}-dbg"
 
-RDEPENDS:${PN}-ptest:append = " bash"
+RDEPENDS:${PN}-ptest:append = " bash python3-pymongo"


### PR DESCRIPTION
As part of [AB#2232369](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2232369), we want to notice when filesystem permissions change. Writing this as a ptest improves maintainability over the alternative of creating a standalone test, and allows future improvements (e.g. for isolation) to be easily utilized.

This ptest is not added to the ptest packagegroup, as the installation of other packages will alter its results.

# Behavior of the new test
This test is similar to the dmesg diff test at `recipes-kernel/kernel-tests`.

This test collects a manifest using `find`, using its `-printf` expression to generate a table in tab-separated-value format. To compare the tables, they are first converted to dictionaries and compared in Python, rather than using `diff` as in the dmesg diff test.

## Determining the previous manifest
Unlike the dmesg diff test, the kernel version is irrelevant. Instead, the OS version (retrieved from `/etc/os-release`) is used to fulfill the purpose. Since multiple variants may have similar versions (e.g. hardknott and kirkstone are now both building for 23.3.0), the codename is also extracted and used to distinguish between versions.

The version of the previous manifest must:
 - have major/minor/patch components that are lexically less than the current version
 - have a phase of "final"

It will be necessary to manually run this test on the last release version to create such a manifest to compare against.

## Directories examined
As seen in `fs_permissions_diff.py`:

```py
search_dirs = ['/bin', '/boot', '/etc', '/lib', '/lib64', '/sbin', '/usr', '/var']
omit_dirs = ['/lib/modules', '/var/cache', '/var/run', '/var/tmp', '/var/volatile']
```

Let me know if these lists should change (e.g. exclude `/etc/natinst/share`, include `/home` or `/tmp`).

## Handling of symbolic links
The test does not resolve symbolic links as their targets, though it does record the link target.  
Changing a link to/from a non-link will be noted as a difference, as that is part of the mode.  
Targets of links are not compared.

## Handling of added/removed paths
All paths present in the previous manifest but missing in the current one (or vice versa) are printed in the log and fail the test.

# Miscellaneous changes
 - dmesg diff test:
   - Removed unused import
   - Modified strip_headers to avoid bad asymptotic behavior

# Testing
 - [x] Built with `bitbake ni-base-system-image-tests`
 - [x] Installed on a NILRT VM with `opkg install ni-base-system-image-tests-ptest`
 - Ran `ptest-runner ni-base-system-image-tests` in various scenarios
   - [x] Verified that the manifest was uploaded to the Mongo database
   - Reran after changing content in `os-release` to...
      - [x] a later version; verified that the previous run was diffed against
      - [x] a different codename; verified that the previous run was *not* diffed against
    - [x] After changing permissions (mode, user, or group) on `/bin`, the test fails
    - [x] After adding files (equivalent: running without a previous manifest), the test fails
    - [x] After removing files, the test fails

# Merging
I think it is appropriate to cherry-pick this change into nilrt/master/hardknott.