### PR TITLE
pkggrp-ni-internal-deps: add Test Systems SW

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
@@ -47,3 +47,9 @@ RDEPENDS:${PN}:append:x64 = "\
 	python3-ctypes \
 	python3-threading \
 "
+
+# NI Test Systems Software
+# Contact: Christian Gutierrez <christian.gutierrez@ni.com>
+RDEPENDS:${PN} += "\
+	libxml-parser-perl \
+"


### PR DESCRIPTION
Test Systems SW internal test frameworks depend on the libxml-parser-perl package.

NATI AZDO: https://dev.azure.com/ni/DevCentral/_workitems/edit/2309949


# Testing
* [x] Built the `libxml-parser-perl` package for Christian directly and he verified that it enabled his test framework.
* [x] Built the internal deps packagegroup with/without this change and verified that the `libxml-parser-perl` package is now in the `main/core2-64` feed.

# Meta
* Will cherry-pick to the kirkstone mainline.