### PR TITLE
ni-base-system-image-tests: Perform a three-way diff

### DIFF
--- a/recipes-ni/ni-base-system-image-tests/files/fs_permissions_diff.py
+++ b/recipes-ni/ni-base-system-image-tests/files/fs_permissions_diff.py
@@ -43,7 +43,7 @@ class Logger:
             print(log)
 
 def run_cmd(cmd):
-    output = subprocess.check_output(cmd).strip()
+    output = subprocess.check_output(cmd)
     return output.decode('utf-8')
 
 class OsVersion:


### PR DESCRIPTION
As mentioned in a comment on #534, during a discussion with @jpautler we determined that we had some contradictory requirements for this test's output:
 - only list the changes since the latest M.m.p.b version (the previous run), to make test results easier to interpret
 - list all the changes since the latest M.m.p version, to avoid accidentally ignoring changes since the last "release" (which is not *released* per se, but rather the last triplet-version before a version bump)

We assessed whether we wanted to make a custom streak indexer, which could allow each path to be reported as its own test case. This was undesirable due to the probable large amount of noise and difficulty of correlating failures.

# Changes
Two manifests are retrieved from the database. (The query may find the same manifest twice, which is expected on occasion.)
They are referred to as the "basis" and "recent" manifests, with the basis manifest being at least as old as the recent manifest.

The manifests are diffed with set operations and filters, as before. However, each of the three manifests is diffed against the other two (so the diffing work has technically tripled, though the test still completes in seconds):

         current                      23.3.0d11
          ^  ^                          ^  ^
         /    \        e.g.            /    \
        v      v                      v      v
    basis <--> recent        23.0.0f100 <--> 23.3.0d10

Doing this allows all three diffs to be considered and included in the output, to meet the needs of the test.
These diffs are referred to in the code as "net" (basis <-> current), "seen" (basis <-> recent), and "unseen" (recent <-> current).
Only *net* changes cause test failures.

## Output format
Two diff summaries are printed. The second is a three-way diff, and the first is a two way diff with the "unseen" changes (essentially the subset where the relevant column has a change for the three way diff).
For both, a legend is printed first, and as indicated, the first columns of each line are used to indicate the type of difference for each path. Subsequent lines give detail about mode, user, and group.

As with the previous test, files without any differences are not printed, though now there must be no differences in any of the three diffs.

The ordering of the differences as they are printed is in order of whether they are affected by certain diffs. First "unseen" differences are shown, since they are new to the run and more likely to be interesting; then "net" differences are shown, since they are the overall differences that we'd care about for release checks; then "seen" differences are shown for completeness.  
Paths are sorted within these groups.

Here are some snippets of output as an example:

1. Oops, `/bin` is group-writable and someone renamed `/bin/vi` (**test failed**):
```
###### Differences since last test run: current vs recent ######
(Note that these are not necessarily responsible for test failure; see full diff below)
LEGEND:
c: current changed relative to recent
+: current has a path that recent does not
-: recent has a path that current does not
###### begin last-run diff ######
c /bin
  current mode = drwxrwxr-x, user = admin, group = administrators
  recent  mode = drwxr-xr-x, user = admin, group = administrators
- /bin/vi
  recent  mode = lrwxrwxrwx, user = admin, group = administrators
+ /bin/vi.bak
  current mode = lrwxrwxrwx, user = admin, group = administrators
###### end last-run diff ######


###### Full three-way diff: current vs basis, recent vs basis, current vs recent ######
(Note that only the first column is responsible for test failure)
LEGEND:
c: X changed relative to Y
+: X has a path that Y does not
-: Y has a path that X does not
*   X=current Y=basis  (new issues since the last run for previous MAJOR.MINOR.PATCH)
 *  X=recent  Y=basis  (issues seen in the last run)
  * X=current Y=recent (new issues since the last run, probably for this MAJOR.MINOR.PATCH)
###### begin full diff ######
c c /bin
    current mode = drwxrwxr-x, user = admin, group = administrators
    basis   mode = drwxr-xr-x, user = admin, group = administrators
    recent  mode = drwxr-xr-x, user = admin, group = administrators
- - /bin/vi
    basis   mode = lrwxrwxrwx, user = admin, group = administrators
    recent  mode = lrwxrwxrwx, user = admin, group = administrators
+ + /bin/vi.bak
    current mode = lrwxrwxrwx, user = admin, group = administrators
###### end full diff ######
```
2. That issue was fixed (**test passed**):
```
###### Differences since last test run: current vs recent ######
(Note that these are not necessarily responsible for test failure; see full diff below)
LEGEND:
c: current changed relative to recent
+: current has a path that recent does not
-: recent has a path that current does not
###### begin last-run diff ######
c /bin
  current mode = drwxr-xr-x, user = admin, group = administrators
  recent  mode = drwxrwxr-x, user = admin, group = administrators
+ /bin/vi
  current mode = lrwxrwxrwx, user = admin, group = administrators
- /bin/vi.bak
  recent  mode = lrwxrwxrwx, user = admin, group = administrators
###### end unseen diff ######


###### Full three-way diff: current vs basis, recent vs basis, current vs recent ######
(Note that only the first column is responsible for test failure)
LEGEND:
c: X changed relative to Y
+: X has a path that Y does not
-: Y has a path that X does not
*   X=current Y=basis  (new issues since the last run for previous MAJOR.MINOR.PATCH)
 *  X=recent  Y=basis  (issues seen in the last run)
  * X=current Y=recent (new issues since the last run, probably for this MAJOR.MINOR.PATCH)
###### begin full diff ######
 cc /bin
    current mode = drwxr-xr-x, user = admin, group = administrators
    basis   mode = drwxr-xr-x, user = admin, group = administrators
    recent  mode = drwxrwxr-x, user = admin, group = administrators
 -+ /bin/vi
    current mode = lrwxrwxrwx, user = admin, group = administrators
    basis   mode = lrwxrwxrwx, user = admin, group = administrators
 +- /bin/vi.bak
    recent  mode = lrwxrwxrwx, user = admin, group = administrators
###### end full diff ######
```

# Testing
 - Locating previous manifests:
   - [x] basis query does not find manifest with current M.m.p
   - [x] recent query finds manifest with current M.m.p if one exists
   - [x] recent query finds same manifest as basis query if none exist for current M.m.p
   - [x] recent query does not find manifest for identical M.m.p.b if the the test is rerun
   - [x] basis query finds manifest with another codename if none exist with current codename
   - [x] recent query finds manifest with another codename if none exist with current codename
 - Pass/fail:
   - [x] test fails when net diff is nonempty
   - [x] test passes when net diff is empty, even if other diffs are found

# Merging
This should be cherry-picked into nilrt/master/hardknott, as with #534. I'll rebase upon request.