### PR TITLE
packagegroup-ni-desirable: Add nvme-cli

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-desirable.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-desirable.bb
@@ -36,6 +36,7 @@ RDEPENDS:${PN} += "\
 	ltrace \
 	ntp \
 	ntpdate \
+	nvme-cli \
 	openssl-dev \
 	perf \
 	python3-nose \


### PR DESCRIPTION
This tool is useful for configuring and monitoring NVMe drives. No NI software depends on it.

I validated that I can build and install this package and use the nvme-cli tools successfully. 