### PR TITLE
kernel-tests: add test_kernel_serial_devices to run-ptest

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-tests-files/run-ptest
+++ b/recipes-kernel/kernel-tests/kernel-tests-files/run-ptest
@@ -11,3 +11,4 @@
 ./test_kernel_dmesg_diff.sh
 ./test_user_stack_size.sh
 ./test_i915_firmware.sh
+./test_kernel_serial_devices.sh


### PR DESCRIPTION
This test was added to the package, but never added to run-ptest, so it wasn't being run.

Fixes: f08425c203aa ("kernel-tests: add a test to ensure we haven't renumbered serial ports")