### PR TITLE
glibc-tests, test_floating_point: Fix CPU affinity and avoid CPU 0 if possible

### DIFF
--- a/recipes-core/glibc-tests/glibc-tests/test_floating_point.cpp
+++ b/recipes-core/glibc-tests/glibc-tests/test_floating_point.cpp
@@ -20,8 +20,6 @@
 #include <sys/utsname.h>
 #include <sys/mman.h>
 
-#define gettid() syscall(__NR_gettid)
-
 #define USEC_PER_SEC		1000000
 #define NSEC_PER_SEC		1000000000
 
@@ -59,17 +57,12 @@ static inline int64_t calcdiff_us(struct timespec *t1, struct timespec *t2)
 
 static inline double my_rand_double()
 {
-	//errno_t err;
 	double d = 0;
 	unsigned int max = 2043245235, number;
 
-	//err = rand_s(&number );
 	number = rand();
 
-	//if (err != 0)
-		//printf("The rand_s function failed!\n");
-	//else
-		d = (double) number / (double) UINT_MAX * max;
+	d = (double) number / (double) UINT_MAX * max;
 	return d;
 }
 

--- a/recipes-core/glibc-tests/glibc-tests/test_floating_point.cpp
+++ b/recipes-core/glibc-tests/glibc-tests/test_floating_point.cpp
@@ -42,11 +42,6 @@ enum operation
 	division
 };
 
-static inline void my_gettime(struct timespec *t)
-{
-	int ret = clock_gettime(CLOCK_MONOTONIC, t);
-}
-
 static inline int64_t calcdiff_us(struct timespec *t1, struct timespec *t2)
 {
 	int64_t diff;
@@ -87,7 +82,7 @@ int test_fp(int arr_size, result_t *result, operation op)
 	z = (double *) malloc(sizeof(double) * arr_size);
 
 	init_arrays(x, y, z, arr_size);
-	my_gettime(&t1);
+	clock_gettime(CLOCK_MONOTONIC, &t1);
 	switch(op)
 	{
 	case addition:
@@ -111,15 +106,14 @@ int test_fp(int arr_size, result_t *result, operation op)
 		}
 		break;
 	}
-	my_gettime(&t2);
+	clock_gettime(CLOCK_MONOTONIC, &t2);
 	op_time = calcdiff_us(&t1, &t2);
 	free(x), free(y), free(z);
 
-	if(result!=NULL)
-		{
-			result->arr_size = arr_size;
-			result->op_time = op_time;
-		}
+	if(result!=NULL) {
+		result->arr_size = arr_size;
+		result->op_time = op_time;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Based on code comments, the current implementation attempts to run the test with no CPU affinity followed by running on CPU 0 and CPU 1. However the code never calls sched_setaffinity() so the benchmark ends up running three times in a row without CPU affinity being set.

Additionally because this test runs as SCHED_FIFO with priority 50 it can create (disk) irq timeouts when it ends up monopolizing CPU 0.

Fix the CPU affinity setting and only run the test once on CPU 1 if on an SMP system. Alternatively if only one CPU is available run at reduced RT priority SCHED_FIFO/1 to avoid starving important interrupt threads which
by default on NILRT are affinitized to CPU 0.

Also remove dead code and do a bit of clean-up while we're at it.

### Testing

-  built and tested on cRIO-905x; no irq timeouts observed after 100 test runs whereas it was causing irq timeouts in less then 10 iterations before.