### PR TITLE
packagegroup-ni-core: Add packagegroup-ni-ptest-smoke

### DIFF
--- a/recipes-core/packagegroups/packagefeed-ni-core.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-core.bb
@@ -12,6 +12,7 @@ RDEPENDS:${PN} = "\
 	packagegroup-ni-graphical \
 	packagegroup-ni-internal-deps \
 	packagegroup-ni-nohz-kernel \
+	packagegroup-ni-ptest-smoke \
 	packagegroup-ni-restoremode \
 	packagegroup-ni-runmode \
 	packagegroup-ni-safemode \


### PR DESCRIPTION
Removing the overall ptest package group removed the transitive dependency from the core packagegroup to the ptest-smoke packagegroup, preventing it from building and getting published to our feeds.

Fixes: b8a8d05a0074

This should be cherry-picked to nilrt/master/hardknott, as with #542 (which caused the issue).