### PR TITLE
[kirkstone] kernel-tests: Add more dmesg_diff exclusions

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-tests-files/kernel_dmesg_diff.py
+++ b/recipes-kernel/kernel-tests/kernel-tests-files/kernel_dmesg_diff.py
@@ -179,7 +179,9 @@ replacement_patterns = [
         [r', CDC EEM Device, \S+', ', CDC EEM Device, '],
         [r' HOST MAC \S+', ' HOST MAC '],
         [r'NODE_DATA\(0\) allocated \[mem .*\]', 'NODE_DATA(0) allocated [mem ]'],
-        [r'ACPI: SSDT 0x.*', 'ACPI: SSDT 0x']
+        [r'ACPI: SSDT 0x.*', 'ACPI: SSDT 0x'],
+        [r'tsc: Refined TSC clocksource calibration: \d+.\d+ MHz', 'tsc: Refined TSC clocksource calibration: MHz'],
+        [r'software IO TLB: mapped mem .*', 'software IO TLB: mapped mem']
 ]
 
 def strip_known_differences(log):


### PR DESCRIPTION
There were a couple more dmesg log diffs that are numeric values and expected to change between runs. This change adds regexes to ensure those changes don't result in a test failure.

[AB#2329461](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2329461)

## Testing:
Confirmed the new regexes match the problematic lines. Built locally and confirmed no build errors.