### PR TITLE
[kirkstone] ni-base-system-image-tests: Add skyline cache to ignore list.

### DIFF
--- a/recipes-ni/ni-base-system-image-tests/files/fs_permissions_diff.py
+++ b/recipes-ni/ni-base-system-image-tests/files/fs_permissions_diff.py
@@ -75,7 +75,7 @@ fs_manifest_format = '%p\t%M\t%u\t%g\t%l'
 fs_manifest_columns = ['path', 'mode', 'user', 'group', 'link_target']
 def get_fs_manifest():
     search_dirs = ['/bin', '/boot', '/etc', '/lib', '/lib64', '/sbin', '/usr', '/var']
-    omit_dirs = ['/lib/modules', '/var/cache', '/var/run', '/var/tmp', '/var/volatile']
+    omit_dirs = ['/etc/natinst/niskyline/Data/Assets/Cache', '/lib/modules', '/var/cache', '/var/run', '/var/tmp', '/var/volatile']
 
     omit_expr = []
     for d in omit_dirs:


### PR DESCRIPTION
niskyline places a file with a UUID name at a location that was not filtered out from the list of directories checked during file permissions tests. Since the UUID is different each run, the name change causes a test failure.

This change adds the Cache directory containing the problematic file to the ignore list.

[AB#2333297](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2333297)

## Testing:
Built the changes into an ipk locally and installed on a PXIe-8880. After running the test, looked at the output and confirmed the flagged difference was that the files in the Cache directory were missing (as opposed to new, different ones being present in the diff)