### PR TITLE
[nilrt/23.3/hardknott] linux: Set NI_RELEASE_VERSION to 23.3

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-debug_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-debug_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "NILRT linux kernel debug build"
-NI_RELEASE_VERSION = "master"
+NI_RELEASE_VERSION = "23.3"
 LINUX_VERSION = "5.15"
 LINUX_VERSION:xilinx-zynq = "4.14"
 LINUX_KERNEL_TYPE = "debug"

--- a/recipes-kernel/linux/linux-nilrt-next_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-next_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "NILRT linux kernel next development build"
-NI_RELEASE_VERSION = "master"
+NI_RELEASE_VERSION = "23.3"
 LINUX_VERSION = "6.0"
 LINUX_KERNEL_TYPE = "next"
 

--- a/recipes-kernel/linux/linux-nilrt-nohz_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-nohz_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "NILRT linux kernel full dynamic ticks (NO_HZ_FULL) build"
-NI_RELEASE_VERSION = "master"
+NI_RELEASE_VERSION = "23.3"
 LINUX_VERSION = "5.15"
 LINUX_KERNEL_TYPE = "nohz"
 

--- a/recipes-kernel/linux/linux-nilrt_git.bb
+++ b/recipes-kernel/linux/linux-nilrt_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "Linux kernel based on nilrt branch"
-NI_RELEASE_VERSION = "master"
+NI_RELEASE_VERSION = "23.3"
 LINUX_VERSION = "5.15"
 LINUX_VERSION:xilinx-zynq = "4.14"
 


### PR DESCRIPTION
This ensures the cross-repo links are using the same (release) branches.