### PR TITLE
Test known file permissions directly instead of diffing everything in the base system image

### DIFF
--- a/recipes-ni/ni-base-system-image-tests/files/fs_permissions_diff.py
+++ b/recipes-ni/ni-base-system-image-tests/files/fs_permissions_diff.py
@@ -77,6 +77,16 @@ def get_fs_manifest():
     search_dirs = ['/bin', '/boot', '/etc', '/lib', '/lib64', '/sbin', '/usr', '/var']
     omit_dirs = ['/etc/natinst/niskyline/Data/Assets/Cache', '/lib/modules', '/var/cache', '/var/run', '/var/tmp', '/var/volatile']
 
+    # Don't diff files we know the permissions of already
+    with open('known-permissions.csv') as known_perm_file:
+        known_permissions = csv.reader(known_perm_file, delimiter = ',')
+        header_row = True
+        for row in known_permissions:
+            if header_row:
+                header_row = False
+                continue
+            omit_dirs.append(row[0])
+
     omit_expr = []
     for d in omit_dirs:
         omit_expr += ['-path', d, '-o']

--- a/recipes-ni/ni-base-system-image-tests/files/fs_permissions_known.py
+++ b/recipes-ni/ni-base-system-image-tests/files/fs_permissions_known.py
@@ -1,0 +1,153 @@
+import argparse
+import csv
+import datetime
+import hashlib
+import mmap
+import os
+import re
+import subprocess
+import sys
+
+class Logger:
+    prefix_logs = []
+    logs = []
+    def log(self, log):
+        self.logs.append(log)
+
+    def prefix_log(self, log):
+        self.prefix_logs.append(log)
+
+    def report(self):
+        for log in self.prefix_logs:
+            print(log)
+        for log in self.logs:
+            print(log)
+
+def run_cmd(cmd):
+    output = subprocess.check_output(cmd)
+    return output.decode('utf-8')
+
+# Columns: Path, Mode, User, Group, Link Target
+fs_manifest_format = '%p\t%M\t%u\t%g\t%l'
+def get_fs_manifest():
+    search_dirs = ['/bin', '/boot', '/etc', '/lib', '/lib64', '/sbin', '/usr', '/var']
+    omit_dirs = ['/etc/natinst/niskyline/Data/Assets/Cache', '/lib/modules', '/var/cache', '/var/run', '/var/tmp', '/var/volatile']
+
+    omit_expr = []
+    for d in omit_dirs:
+        omit_expr += ['-path', d, '-o']
+    omit_expr.pop()
+
+    fs_manifest = run_cmd(
+        ['find']
+        + search_dirs
+        + ['-printf', fs_manifest_format + '\n']
+        + ['('] + omit_expr + [')', '-prune']
+    )
+    entries = {}
+    for entry in fs_manifest.splitlines():
+        entry_data = entry.split('\t')
+        entries[entry_data[0]] = {
+            'mode': entry_data[1],
+            'user': entry_data[2],
+            'group': entry_data[3],
+            'link': entry_data[4]
+        }
+    return entries
+
+def log_version_info(logger, label, codename, full_version, date, db_id):
+    logger.log(f'INFO: {label} = {codename} {full_version} from {date} with _id {db_id}')
+
+def check_known_manifests(manifest, logger):
+    logger.log('###### Checking expected file permissions against actual for known folders')
+    failed = False
+    with open('known-permissions.csv') as known_perm_file:
+        permissions = csv.reader(known_perm_file, delimiter = ',')
+        header_row = True
+        for row in permissions:
+            if header_row:
+                header_row = False
+                continue
+
+            # Allow executing shell script to get path name.
+            # Useful for things like /lib/modules/$(uname -r), for example.
+            # Not using regex because multiple ones could cause issues, but
+            # equivalent regex is /\$\((\\.|[^\\\)]*\)/
+            path = row[0]
+            new_path = ''
+            building_shell = False
+            shell_cmd = ''
+            i = 0
+            while i < len(path):
+                if not building_shell \
+                and path[i] == '\\' and i + 1 < len(path):
+                    i += 1
+                    new_path += path[i]
+                elif not building_shell \
+                and path[i] == '$' \
+                and i + 1 < len(path) and path[i + 1] == '(':
+                    i += 1
+                    building_shell = True
+                    shell_cmd = ''
+                elif not building_shell:
+                    new_path += path[i]
+                elif path[i] == '\\' \
+                and i + 1 < len(path):
+                    i += 1
+                    shell_cmd += path[i]
+                elif path[i] == ')':
+                    shell_out = run_cmd(shell_cmd.split(' ')).strip()
+                    new_path += shell_out
+                    building_shell = False
+                else:
+                    shell_cmd += path[i]
+                i += 1
+            path = new_path
+
+            # Now, if the manifest has the path, compare permissions
+            if path in manifest:
+                if manifest[path]['mode'] != row[1]:
+                    logger.log(
+                        'ERROR: Expected mode \'' + row[1] + '\' but got \''
+                            + manifest[path]['mode'] + '\' for path \'' + path + '\''
+                    )
+                    failed = True
+                if manifest[path]['user'] != row[2]:
+                    logger.log(
+                        'ERROR: Expected user \'' + row[2] + '\' but got \''
+                            + manifest[path]['user'] + '\' for path \'' + path + '\''
+                    )
+                    failed = True
+                if manifest[path]['group'] != row[3]:
+                    logger.log(
+                        'ERROR: Expected group \'' + row[3] + '\' but got \''
+                            + manifest[path]['group'] + '\' for path \'' + path + '\''
+                    )
+                    failed = True
+                if manifest[path]['link'] != row[4]:
+                    logger.log(
+                        'ERROR: Expected link \'' + row[4] + '\' but got \''
+                            + manifest[path]['link'] + '\' for path \'' + path + '\''
+                    )
+                    failed = True
+            else:
+                logger.log('ERROR: System is missing expected path \'' + path + '\'')
+                failed = True
+    logger.log('###### End of known file permissions check')
+    return failed
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Check fs permissions against expectations')
+    return parser.parse_args()
+
+logger = Logger()
+args = parse_args()
+
+fs_manifest = get_fs_manifest()
+result = check_known_manifests(fs_manifest, logger)
+logger.report()
+
+if result:
+    sys.exit(os.EX_OK)
+else:
+    sys.exit(os.EX_SOFTWARE)

--- a/recipes-ni/ni-base-system-image-tests/files/known-permissions.csv
+++ b/recipes-ni/ni-base-system-image-tests/files/known-permissions.csv
@@ -1,0 +1,2 @@
+Path,Mode,User,Group,Link Target
+/etc/fstab,-rw-r--r--,admin,administrators,

--- a/recipes-ni/ni-base-system-image-tests/files/run-ptest
+++ b/recipes-ni/ni-base-system-image-tests/files/run-ptest
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-./test_fs_permissions_diff.sh
+./test_fs_permissions.sh
 
 exit 0

--- a/recipes-ni/ni-base-system-image-tests/files/test_fs_permissions.sh
+++ b/recipes-ni/ni-base-system-image-tests/files/test_fs_permissions.sh
@@ -2,9 +2,10 @@
 
 source $(dirname "$0")/ptest-format.sh
 
-ptest_change_test $(basename "$0" ".sh") "" "Diff filesystem permissions with previous"
+ptest_change_test $(basename "$0" ".sh") "" "Check known filesystem permissions and diff others with previous"
 
 source /home/admin/.mongodb.creds
+python3 fs_permissions_known.py
 python3 fs_permissions_diff.py --server $MONGO_SERVER --user $MONGO_USER --password $MONGO_PASSWORD
 
 if [ $? -eq 0 ]; then

--- a/recipes-ni/ni-base-system-image-tests/ni-base-system-image-tests.bb
+++ b/recipes-ni/ni-base-system-image-tests/ni-base-system-image-tests.bb
@@ -14,7 +14,9 @@ SRC_URI = "\
     file://run-ptest \
     file://ptest-format.sh \
     file://fs_permissions_diff.py \
-    file://test_fs_permissions_diff.sh \
+    file://fs_permissions_known.py \
+    file://known-permissions.csv \
+    file://test_fs_permissions.sh \
 "
 
 S = "${WORKDIR}"
@@ -22,10 +24,12 @@ S = "${WORKDIR}"
 inherit ptest
 
 do_install_ptest() {
-    install -m 0644 ${WORKDIR}/ptest-format.sh        ${D}${PTEST_PATH}
-    install -m 0755 ${WORKDIR}/run-ptest              ${D}${PTEST_PATH}
-    install -m 0644 ${WORKDIR}/fs_permissions_diff.py ${D}${PTEST_PATH}
-    install -m 0755 ${WORKDIR}/test_*.sh              ${D}${PTEST_PATH}
+    install -m 0644 ${WORKDIR}/ptest-format.sh         ${D}${PTEST_PATH}
+    install -m 0755 ${WORKDIR}/run-ptest               ${D}${PTEST_PATH}
+    install -m 0644 ${WORKDIR}/fs_permissions_diff.py  ${D}${PTEST_PATH}
+    install -m 0644 ${WORKDIR}/fs_permissions_known.py ${D}${PTEST_PATH}
+    install -m 0644 ${WORKDIR}/known-permissions.csv   ${D}${PTEST_PATH}
+    install -m 0755 ${WORKDIR}/test_*.sh               ${D}${PTEST_PATH}
 }
 
 # We only want to build the -ptest package


### PR DESCRIPTION
## Reason:

There are many files in the base system image that have known permissions.

When we do a diff test on the file permissions, we have to store those permissions and retrieve them from a data base and do a diff, when really, we could do a static test for many files that would be faster, have cleaner output, and require less maintenance.

## Implementation:

- Add new test (based on existing test) that checks a file permission manifest created with `find` against a csv file containing expected permissions
  + The test fails when permissions do not match expected
  + The test reports ALL differences, including if an expected path doesn't exist
  + Functionality exists in the test to insert the output of shell commands into path names so you could potentially test paths like "/lib/modules/$(uname -r)/build" and have it resolve to "/lib/modules/5.1.15/build" or something like that
- Create list of paths with known permissions in a csv file
  + Laid out as path, mode, user, group, and link status
  + Only one path exists currently, as adding the full list in a separate PR is trivial. This PR is essentially to provide the framework.
- Skip checking paths in the csv in the existing test
- Run new test along with the previous test
- Update list of installed files in the recipe

## Testing

I built and deployed a run mode in a virtual machine and tested the new known-permissions part of the test under the following conditions:
- Normal (passing) circumstances
- With a path in the csv not existing on the host
- With permissions differences, i.e. changing the files or csv, so that every combination of user, group, mode, and link being different than expected was tested against 

I also checked the output to make sure that paths in the csv are not checked by the diff part of the test