### PR TITLE
[hardknott] nilrt.conf: Bump DISTRO_VERSION

### DIFF
--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -1,6 +1,6 @@
 DISTRO_NAME = "NI Linux Real-Time"
 
-DISTRO_VERSION = "9.3"
+DISTRO_VERSION = "9.4"
 
 DISTRO_CODENAME = "${LAYERSERIES_COMPAT_meta-nilrt}"
 


### PR DESCRIPTION
Bumping version for next release.

[AB#2241963](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2241963)