### PR TITLE
Add ptest for measuring and reporting the total boot time

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-ptest-smoke.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-ptest-smoke.bb
@@ -28,6 +28,7 @@ RDEPENDS:${PN}:append = "\
     mdadm-ptest \
     nettle-ptest \
     ni-hw-scripts-ptest \
+    ni-test-boot-time-ptest \
     opkg-ptest \
     pango-ptest \
     parted-ptest \

--- a/recipes-ni/ni-test-boot-time/files/run-ptest
+++ b/recipes-ni/ni-test-boot-time/files/run-ptest
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+TEST_NAME="test_boot_time"
+TEST_LOG="/var/log/boottime"
+INFLUXDB_INFO="/home/admin/.influxdb.info"
+
+if [[ -f "$INFLUXDB_INFO" ]]; then
+	source "$INFLUXDB_INFO"
+	python3 upload_results.py "-i $TEST_LOG" "-s $INFLUXDB_SERVER" "-p $INFLUXDB_PORT"
+	RESULT=$?
+else
+	echo "INFO: InfluxDB connection information not found at '$INFLUXDB_INFO'"
+	RESULT=77
+fi
+
+case $RESULT in
+    0)
+	echo -n "PASS"
+	;;
+    77)
+	echo -n "SKIP"
+	;;
+    *)
+	echo -n "FAIL"
+	;;
+esac
+echo ": $TEST_NAME"
+exit $RESULT

--- a/recipes-ni/ni-test-boot-time/files/upload_results.py
+++ b/recipes-ni/ni-test-boot-time/files/upload_results.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Script for uploading the boot time measurement to influxdb"""
+
+import argparse
+import logging
+import mmap
+import re
+import sys
+import subprocess
+from datetime import datetime
+from influxdb import InfluxDBClient
+from influxdb.exceptions import InfluxDBClientError
+from requests.exceptions import ConnectionError
+
+def fw_printenv(key):
+    """Extract firmware information (ex. device, serial#) via fw_printenv"""
+    try:
+        process = subprocess.run(['fw_printenv', key],
+                                 check=True,
+                                 stdout=subprocess.PIPE)
+        value_str = process.stdout.strip().decode("utf-8")
+        value = value_str.split('=')[-1]
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        logging.warning("calling 'fw_printenv %s' failed", key)
+        raise
+    return value
+
+
+def get_device():
+    """Get the device description for the current system (e.g. cRIO-90xx)"""
+    return fw_printenv('DeviceDesc')
+
+
+def get_serial_number():
+    """Get the device serial number; return all-zeros if not present"""
+    try:
+        serialno = fw_printenv('serial#')
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        # Non-fatal error, some early development hardware doesn't have a serial# provisioned
+        logging.warning("serial number not found, defaulting to 00000000")
+        serialno = "00000000"
+    return serialno
+
+
+def get_hostname():
+    """Get the device hostname"""
+    try:
+        process = subprocess.run(['hostname'],
+                                 check=True,
+                                 stdout=subprocess.PIPE)
+        name = process.stdout.strip().decode("utf-8")
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        logging.warning("failed to retrieve the hostname")
+        raise
+    return name
+
+
+def get_kernel_version():
+    """Get the kernel version currently running on the system"""
+    try:
+        process = subprocess.run(['uname', '-r'],
+                                 check=True,
+                                 stdout=subprocess.PIPE)
+        kver_full = process.stdout.strip().decode("utf-8")
+        rgx = re.search(r'([0-9]+\.[0-9]+)\.([0-9]+)', kver_full)
+        kver = rgx.group(1)
+    except (FileNotFoundError, ValueError, AttributeError,
+            subprocess.CalledProcessError):
+        logging.warning("failed to read the current kernel version")
+        raise
+
+    return kver, kver_full
+
+
+def get_os_version():
+    """Extract OS version information from /etc/os-release"""
+    try:
+        with open('/etc/os-release', 'rb', 0) as file, \
+             mmap.mmap(file.fileno(), 0, access=mmap.ACCESS_READ) as mfile:
+            rgx = re.search(br'VERSION_ID=([0-9.]+)', mfile)
+            version = rgx.group(1).decode()
+
+            rgx = re.search(br'BUILD_ID="([^"]+)"', mfile)
+            build = rgx.group(1).decode()
+
+            rgx = re.search(br'VERSION_CODENAME="([^"]+)"', mfile)
+            codename = rgx.group(1).decode()
+    except (FileNotFoundError, ValueError, AttributeError):
+        logging.warning("failed to parse version information from '/etc/os-release'")
+        raise
+
+    return version, build, codename
+
+
+def get_boot_time(log_file):
+    """Extract boot time from log file"""
+    try:
+        with open(log_file, 'rb', 0) as file, \
+             mmap.mmap(file.fileno(), 0, access=mmap.ACCESS_READ) as mfile:
+            rgx = re.search(br'([0-9.]+)', mfile)
+            boot_time = float(rgx.group(1).decode())
+    except (FileNotFoundError, ValueError, AttributeError):
+        logging.warning("failed to parse boot time from '%s'", log_file)
+        raise
+
+    return boot_time
+
+
+def read_data(path):
+    """Compile test data and metadata"""
+    controller = get_device()
+    serialno = get_serial_number()
+    hostname = get_hostname()
+    kernel_version, kernel_full_version = get_kernel_version()
+    distro_version, distro_build, distro_name = get_os_version()
+    boot_time = get_boot_time(path)
+
+    print("boot time:", boot_time, "(s)")
+
+    data = {
+        "measurement": "boot_performance",
+        "tags": {
+            "controller": controller,
+            "serialno": serialno,
+            "hostname": hostname,
+            "kernel_version": kernel_version,
+            "kernel_full_version": kernel_full_version,
+            "distro_version": distro_version,
+            "distro_build": distro_build,
+            "distro_name": distro_name,
+        },
+        "fields": {
+            "boot_time": boot_time,
+        },
+        "time": str(datetime.now())
+    }
+    return data
+
+
+def upload_results(data, server, server_port):
+    """Upload results to influxdb instance"""
+    try:
+        influxdb = InfluxDBClient(host=server, port=server_port)
+        influxdb.switch_database("rtos_boot_performance")
+        if not influxdb.write_points(data):
+            logging.warning("failed to write data points to influxdb")
+        influxdb.close()
+    except (InfluxDBClientError, ConnectionError):
+        logging.warning("failed to connect to influxdb server '%s:%u'",
+                        server, server_port)
+        raise
+
+
+parser = argparse.ArgumentParser(
+    description="Upload boot time measurement.")
+parser.add_argument("-i", "--input", required=True,
+                    help="boot time log input file")
+parser.add_argument("-s", "--server", required=True,
+                    help="influxdb server")
+parser.add_argument("-p", "--port", type=int, default=8086,
+                    help="influxdb server port")
+args = parser.parse_args()
+
+results = []
+try:
+    result = read_data(args.input.strip())
+except (FileNotFoundError, AttributeError, ValueError,
+        subprocess.CalledProcessError):
+    logging.error('failed to parse test results or metadata')
+    sys.exit(1)
+results.append(result)
+
+try:
+    upload_results(results, args.server.strip(), args.port)
+except (InfluxDBClientError, ConnectionError):
+    logging.error('failed to upload test results')
+    sys.exit(1)

--- a/recipes-ni/ni-test-boot-time/files/zz-ni-record-boot-time
+++ b/recipes-ni/ni-test-boot-time/files/zz-ni-record-boot-time
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Copyright (c) 2023 National Instruments.
+# All rights reserved.
+[ "${VERBOSE}" != "no" ] && echo -n "Saving boot time:"
+
+awk '{ print $1 }' /proc/uptime > /var/log/boottime
+
+[ "${VERBOSE}" != "no" ] && echo "done"

--- a/recipes-ni/ni-test-boot-time/ni-test-boot-time.bb
+++ b/recipes-ni/ni-test-boot-time/ni-test-boot-time.bb
@@ -1,0 +1,39 @@
+SUMMARY = "Ptest for measuring and logging the boot time"
+SECTION = "tests"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit ptest
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+S = "${WORKDIR}"
+
+ALLOW_EMPTY:${PN} = "1"
+
+DEPENDS += "update-rc.d-native"
+RDEPENDS:${PN}-ptest += "bash gawk python3 python3-pip python3-requests"
+RDEPENDS:${PN}-ptest:append:x64 += "fw-printenv"
+RDEPENDS:${PN}-ptest:append:armv7a += "u-boot-fw-utils"
+
+SRC_URI = "\
+	file://run-ptest \
+	file://upload_results.py \
+	file://zz-ni-record-boot-time \
+"
+
+do_install_ptest() {
+	install -m 0755 ${S}/run-ptest		${D}${PTEST_PATH}
+	install -m 0755 ${S}/upload_results.py	${D}${PTEST_PATH}
+
+	install -d ${D}${sysconfdir}/init.d
+	install -m 0755 ${S}/zz-ni-record-boot-time	${D}${sysconfdir}/init.d
+	update-rc.d -r ${D} zz-ni-record-boot-time	start 99 4 5 .
+}
+
+pkg_postinst_ontarget:${PN}-ptest:append() {
+	python3 -m pip install influxdb
+}
+
+# We only want to build the -ptest package
+PACKAGES:remove = "${PN}-dev ${PN}-staticdev ${PN}-dbg"


### PR DESCRIPTION
Add an NI-specific ptest for logging the total boot time and uploading the data to the NI-internal influxdb data base.

### Testing

- [x] bitbake ni-boot-time
- [x] bitbake packagegroup-ni-ptest-smoke
- [x] installed from local feed and manually run on `cRIO-9042`, and `PXIe-8840`
- [x] verified that the data reported is available via Grafana/InfluxDB
- [x] verified reasonable behavior on error: the test fails if the boot time log is missing or the influxdb connection is not available