### PR TITLE
[kirkstone] salt: fix restartcheck incompatibility w/ python3.10

### DIFF
--- a/recipes-support/salt/files/0001-Fix-deprecation-warnings-for-imports-from-collection.patch
+++ b/recipes-support/salt/files/0001-Fix-deprecation-warnings-for-imports-from-collection.patch
@@ -1,0 +1,224 @@
+From 49abf954d106048f993b0aceff69627320dac883 Mon Sep 17 00:00:00 2001
+From: Benjamin Drung <benjamin.drung@cloud.ionos.com>
+Date: Fri, 21 Feb 2020 14:01:58 +0100
+Subject: [PATCH] Fix deprecation warnings for imports from collections
+
+DeprecationWarning: Using or importing the ABCs from `collections`
+instead of from `collections.abc` is deprecated since Python 3.3, and in
+3.9 it will stop working.
+
+Therefore try to import the abstract base classes from `collections.abc`
+before falling back to `collections`.
+
+Signed-off-by: Benjamin Drung <benjamin.drung@cloud.ionos.com>
+
+Rebased to salt `ni/3000.2` and fixed minor conflicts.
+
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+(cherry picked from commit 420bbe8)
+
+Upstream-Status: Inappropriate [Upstream stable EOL.]
+---
+ salt/client/mixins.py        | 17 ++++++++++++-----
+ salt/ext/tornado/httputil.py |  9 ++++++++-
+ salt/utils/jinja.py          | 22 ++++++++++++++--------
+ salt/utils/oset.py           |  9 +++++++--
+ 4 files changed, 41 insertions(+), 16 deletions(-)
+
+diff --git a/salt/client/mixins.py b/salt/client/mixins.py
+index 0eb38be744..49903b48b9 100644
+--- a/salt/client/mixins.py
++++ b/salt/client/mixins.py
+@@ -4,14 +4,14 @@ A collection of mixins useful for the various *Client interfaces
+ '''
+ 
+ # Import Python libs
+-from __future__ import absolute_import, print_function, with_statement, unicode_literals
++from __future__ import absolute_import, print_function, unicode_literals, with_statement
++
++import copy as pycopy
+ import fnmatch
+ import signal
+ import logging
+ import weakref
+ import traceback
+-import collections
+-import copy as pycopy
+ 
+ # Import Salt libs
+ import salt.exceptions
+@@ -35,6 +35,13 @@ from salt.ext import six
+ # Import 3rd-party libs
+ import salt.ext.tornado.stack_context
+ 
++try:
++    from collections.abc import Mapping, MutableMapping
++except ImportError:
++    # pylint: disable=no-name-in-module
++    from collections import Mapping, MutableMapping
++
++
+ log = logging.getLogger(__name__)
+ 
+ CLIENT_INTERNAL_KEYWORDS = frozenset([
+@@ -55,7 +62,7 @@ CLIENT_INTERNAL_KEYWORDS = frozenset([
+ ])
+ 
+ 
+-class ClientFuncsDict(collections.MutableMapping):
++class ClientFuncsDict(MutableMapping):
+     '''
+     Class to make a read-only dict for accessing runner funcs "directly"
+     '''
+@@ -141,7 +148,7 @@ class SyncClientMixin(object):
+                                                       crypt='clear',
+                                                       usage='master_call') as channel:
+             ret = channel.send(load)
+-            if isinstance(ret, collections.Mapping):
++            if isinstance(ret, Mapping):
+                 if 'error' in ret:
+                     salt.utils.error.raise_error(**ret['error'])
+             return ret
+diff --git a/salt/ext/tornado/httputil.py b/salt/ext/tornado/httputil.py
+index d49733481a..c5b9c242d5 100644
+--- a/salt/ext/tornado/httputil.py
++++ b/salt/ext/tornado/httputil.py
+@@ -36,6 +36,13 @@ from salt.ext.tornado.escape import native_str, parse_qs_bytes, utf8
+ from salt.ext.tornado.log import gen_log
+ from salt.ext.tornado.util import ObjectDict, PY3
+ 
++try:
++    from collections.abc import MutableMapping
++except ImportError:
++    # pylint: disable=no-name-in-module
++    from collections import MutableMapping
++
++
+ if PY3:
+     import http.cookies as Cookie
+     from http.client import responses
+@@ -104,7 +111,7 @@ class _NormalizedHeaderCache(dict):
+ _normalized_headers = _NormalizedHeaderCache(1000)
+ 
+ 
+-class HTTPHeaders(collections.MutableMapping):
++class HTTPHeaders(MutableMapping):
+     """A dictionary that maintains ``Http-Header-Case`` for all keys.
+ 
+     Supports multiple values per key via a pair of new methods,
+diff --git a/salt/utils/jinja.py b/salt/utils/jinja.py
+index 6e4261e68e..40bfb21bd2 100644
+--- a/salt/utils/jinja.py
++++ b/salt/utils/jinja.py
+@@ -6,7 +6,6 @@ Jinja loading utils to enable a more powerful backend for jinja templates
+ # Import python libs
+ from __future__ import absolute_import, unicode_literals
+ import atexit
+-import collections
+ import logging
+ import os.path
+ import pipes
+@@ -37,6 +36,13 @@ import salt.utils.yaml
+ from salt.utils.decorators.jinja import jinja_filter, jinja_test, jinja_global
+ from salt.utils.odict import OrderedDict
+ 
++try:
++    from collections.abc import Hashable
++except ImportError:
++    # pylint: disable=no-name-in-module
++    from collections import Hashable
++
++
+ log = logging.getLogger(__name__)
+ 
+ __all__ = [
+@@ -329,7 +335,7 @@ def to_bool(val):
+         return val.lower() in ('yes', '1', 'true')
+     if isinstance(val, six.integer_types):
+         return val > 0
+-    if not isinstance(val, collections.Hashable):
++    if not isinstance(val, Hashable):
+         return len(val) > 0
+     return False
+ 
+@@ -500,7 +506,7 @@ def unique(values):
+         ['a', 'b', 'c']
+     '''
+     ret = None
+-    if isinstance(values, collections.Hashable):
++    if isinstance(values, Hashable):
+         ret = set(values)
+     else:
+         ret = []
+@@ -564,7 +570,7 @@ def lst_avg(lst):
+ 
+         2.5
+     '''
+-    if not isinstance(lst, collections.Hashable):
++    if not isinstance(lst, Hashable):
+         return float(sum(lst)/len(lst))
+     return float(lst)
+ 
+@@ -585,7 +591,7 @@ def union(lst1, lst2):
+ 
+         [1, 2, 3, 4, 6]
+     '''
+-    if isinstance(lst1, collections.Hashable) and isinstance(lst2, collections.Hashable):
++    if isinstance(lst1, Hashable) and isinstance(lst2, Hashable):
+         return set(lst1) | set(lst2)
+     return unique(lst1 + lst2)
+ 
+@@ -606,7 +612,7 @@ def intersect(lst1, lst2):
+ 
+         [2, 4]
+     '''
+-    if isinstance(lst1, collections.Hashable) and isinstance(lst2, collections.Hashable):
++    if isinstance(lst1, Hashable) and isinstance(lst2, Hashable):
+         return set(lst1) & set(lst2)
+     return unique([ele for ele in lst1 if ele in lst2])
+ 
+@@ -627,7 +633,7 @@ def difference(lst1, lst2):
+ 
+         [1, 3, 6]
+     '''
+-    if isinstance(lst1, collections.Hashable) and isinstance(lst2, collections.Hashable):
++    if isinstance(lst1, Hashable) and isinstance(lst2, Hashable):
+         return set(lst1) - set(lst2)
+     return unique([ele for ele in lst1 if ele not in lst2])
+ 
+@@ -648,7 +654,7 @@ def symmetric_difference(lst1, lst2):
+ 
+         [1, 3]
+     '''
+-    if isinstance(lst1, collections.Hashable) and isinstance(lst2, collections.Hashable):
++    if isinstance(lst1, Hashable) and isinstance(lst2, Hashable):
+         return set(lst1) ^ set(lst2)
+     return unique([ele for ele in union(lst1, lst2) if ele not in intersect(lst1, lst2)])
+ 
+diff --git a/salt/utils/oset.py b/salt/utils/oset.py
+index acfd59b53b..9fc92ac114 100644
+--- a/salt/utils/oset.py
++++ b/salt/utils/oset.py
+@@ -22,7 +22,12 @@ Rob Speer's changes are as follows:
+     - added __getitem__
+ '''
+ from __future__ import absolute_import, unicode_literals, print_function
+-import collections
++
++try:
++    from collections.abc import MutableSet
++except ImportError:
++    # pylint: disable=no-name-in-module
++    from collections import MutableSet
+ 
+ SLICE_ALL = slice(None)
+ __version__ = '2.0.1'
+@@ -44,7 +49,7 @@ def is_iterable(obj):
+     return hasattr(obj, '__iter__') and not isinstance(obj, str) and not isinstance(obj, tuple)
+ 
+ 
+-class OrderedSet(collections.MutableSet):
++class OrderedSet(MutableSet):
+     """
+     An OrderedSet is a custom MutableSet that remembers its order, so that
+     every entry has an index that can be looked up.

--- a/recipes-support/salt/files/0002-fix-jinja2-contextfuntion-base-on-version.patch
+++ b/recipes-support/salt/files/0002-fix-jinja2-contextfuntion-base-on-version.patch
@@ -1,0 +1,30 @@
+From 6c11bab864db5c94dc4987770b4b7f5994cdc2af Mon Sep 17 00:00:00 2001
+From: jonyhy96 <hy352144278@gmail.com>
+Date: Thu, 10 Mar 2022 10:41:48 +0800
+Subject: [PATCH] fix: jinja2 contextfuntion base on version
+
+(cherry picked from commit 2c39d8626527d1d753f5447753855bc7e265874b)
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+
+Upstream-Status: Inappropriate [Upstream stable EOL.]
+---
+ salt/utils/jinja.py | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/salt/utils/jinja.py b/salt/utils/jinja.py
+index 40bfb21bd2..52a59da2d7 100644
+--- a/salt/utils/jinja.py
++++ b/salt/utils/jinja.py
+@@ -659,7 +659,11 @@ def symmetric_difference(lst1, lst2):
+     return unique([ele for ele in union(lst1, lst2) if ele not in intersect(lst1, lst2)])
+ 
+ 
+-@jinja2.contextfunction
++if jinja2.__version__ < '3.0.0' :
++    contextfunction = jinja2.contextfunction
++else:
++    contextfunction =  jinja2.pass_context
++@contextfunction
+ def show_full_context(ctx):
+     return salt.utils.data.simple_types_filter({key: value for key, value in ctx.items()})
+ 

--- a/recipes-support/salt/files/0003-fix-jinja2-DeprecationWarning.patch
+++ b/recipes-support/salt/files/0003-fix-jinja2-DeprecationWarning.patch
@@ -1,0 +1,26 @@
+From ebfd1f3a53d4df976be8fdf7ef57eae40bc44ea7 Mon Sep 17 00:00:00 2001
+From: jonyhy96 <hy352144278@gmail.com>
+Date: Thu, 3 Mar 2022 16:21:17 +0800
+Subject: [PATCH] fix: jinja2 DeprecationWarning
+
+(cherry picked from commit 90092fa126833e46475df22924bc61a6559d45a2)
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+
+Upstream-Status: Inappropriate [Upstream stable EOL.]
+---
+ salt/utils/jinja.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/salt/utils/jinja.py b/salt/utils/jinja.py
+index 52a59da2d7..7f03e10571 100644
+--- a/salt/utils/jinja.py
++++ b/salt/utils/jinja.py
+@@ -662,7 +662,7 @@ def symmetric_difference(lst1, lst2):
+ if jinja2.__version__ < '3.0.0' :
+     contextfunction = jinja2.contextfunction
+ else:
+-    contextfunction =  jinja2.pass_context
++    contextfunction = jinja2.pass_context
+ @contextfunction
+ def show_full_context(ctx):
+     return salt.utils.data.simple_types_filter({key: value for key, value in ctx.items()})

--- a/recipes-support/salt/files/0004-Use-the-correct-Markup-from-jinja-for-each-version.patch
+++ b/recipes-support/salt/files/0004-Use-the-correct-Markup-from-jinja-for-each-version.patch
@@ -1,0 +1,42 @@
+From 9d6a751eba97dd344fc54ac00e0b192f8d2303c0 Mon Sep 17 00:00:00 2001
+From: Megan Wilhite <mwilhite@vmware.com>
+Date: Fri, 25 Mar 2022 08:31:24 -0600
+Subject: [PATCH] Use the correct Markup from jinja for each version
+
+(cherry picked from commit 240e165ebcd06370a1aa47f37c6842581c82e3f8)
+
+Rebased to salt 3000.2.
+
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+
+Upstream-Status: Inappropriate [Upstream stable EOL.]
+---
+ salt/utils/jinja.py | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/salt/utils/jinja.py b/salt/utils/jinja.py
+index 7f03e10571..e3c7d955c4 100644
+--- a/salt/utils/jinja.py
++++ b/salt/utils/jinja.py
+@@ -19,7 +19,7 @@ from xml.etree.ElementTree import Element, SubElement, tostring
+ # Import third party libs
+ import jinja2
+ from salt.ext import six
+-from jinja2 import BaseLoader, Markup, TemplateNotFound, nodes
++from jinja2 import BaseLoader, TemplateNotFound, nodes
+ from jinja2.environment import TemplateModule
+ from jinja2.exceptions import TemplateRuntimeError
+ from jinja2.ext import Extension
+@@ -43,6 +43,12 @@ except ImportError:
+     from collections import Hashable
+ 
+ 
++try:
++    from jinja2 import Markup
++except ImportError:
++    # Markup moved to markupsafe in jinja>= 3.1
++    from markupsafe import Markup
++
+ log = logging.getLogger(__name__)
+ 
+ __all__ = [

--- a/recipes-support/salt/files/0005-Use-the-correct-Markup-from-jinja-for-each-version.patch
+++ b/recipes-support/salt/files/0005-Use-the-correct-Markup-from-jinja-for-each-version.patch
@@ -1,0 +1,43 @@
+From da620aadc6605d1bed9489fbd4fe4efc70e10320 Mon Sep 17 00:00:00 2001
+From: Megan Wilhite <mwilhite@vmware.com>
+Date: Fri, 25 Mar 2022 09:38:01 -0600
+Subject: [PATCH] Use the correct Markup from jinja for each version
+
+(cherry picked from commit fb3033f03213b4bb077663a89d7329f62a4941f8)
+
+Rebased to salt 3000.2.
+
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+
+Upstream-Status: Inappropriate [Upstream stable EOL.]
+---
+ changelog/61848.fixed | 1 +
+ salt/utils/jinja.py   | 4 +++-
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+ create mode 100644 changelog/61848.fixed
+
+diff --git a/changelog/61848.fixed b/changelog/61848.fixed
+new file mode 100644
+index 0000000000..e8e6fd3426
+--- /dev/null
++++ b/changelog/61848.fixed
+@@ -0,0 +1 @@
++Update Markup and contextfunction imports for jinja versions >=3.1.
+diff --git a/salt/utils/jinja.py b/salt/utils/jinja.py
+index e3c7d955c4..d2b91fb5a4 100644
+--- a/salt/utils/jinja.py
++++ b/salt/utils/jinja.py
+@@ -665,10 +665,12 @@ def symmetric_difference(lst1, lst2):
+     return unique([ele for ele in union(lst1, lst2) if ele not in intersect(lst1, lst2)])
+ 
+ 
+-if jinja2.__version__ < '3.0.0' :
++if jinja2.__version__ < "3.0.0":
+     contextfunction = jinja2.contextfunction
+ else:
+     contextfunction = jinja2.pass_context
++
++
+ @contextfunction
+ def show_full_context(ctx):
+     return salt.utils.data.simple_types_filter({key: value for key, value in ctx.items()})

--- a/recipes-support/salt/files/0006-Fix-requested-feedback.patch
+++ b/recipes-support/salt/files/0006-Fix-requested-feedback.patch
@@ -1,0 +1,47 @@
+From f0864779476b9135535908bd005e26ce57b638da Mon Sep 17 00:00:00 2001
+From: Megan Wilhite <mwilhite@vmware.com>
+Date: Fri, 25 Mar 2022 11:14:01 -0600
+Subject: [PATCH] Fix requested feedback
+
+(cherry picked from commit bb610f761e107de111fa8b4c92c60c77ff7a920e)
+
+Rebased to salt 3000.2. Removed ci/ and pytest files from the commit
+which do not exist in 3000.2.
+
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+
+Upstream-Status: Inappropriate [Upstream stable EOL.]
+---
+ salt/utils/jinja.py | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/salt/utils/jinja.py b/salt/utils/jinja.py
+index d2b91fb5a4..0861ce2a2d 100644
+--- a/salt/utils/jinja.py
++++ b/salt/utils/jinja.py
+@@ -44,10 +44,10 @@ except ImportError:
+ 
+ 
+ try:
+-    from jinja2 import Markup
+-except ImportError:
+-    # Markup moved to markupsafe in jinja>= 3.1
+     from markupsafe import Markup
++except ImportError:
++    # jinja < 3.1
++    from jinja2 import Markup
+ 
+ log = logging.getLogger(__name__)
+ 
+@@ -665,9 +665,9 @@ def symmetric_difference(lst1, lst2):
+     return unique([ele for ele in union(lst1, lst2) if ele not in intersect(lst1, lst2)])
+ 
+ 
+-if jinja2.__version__ < "3.0.0":
++try:
+     contextfunction = jinja2.contextfunction
+-else:
++except AttributeError:
+     contextfunction = jinja2.pass_context
+ 
+ 

--- a/recipes-support/salt/files/0007-Replace-deprecated-inspect.formatargspec.patch
+++ b/recipes-support/salt/files/0007-Replace-deprecated-inspect.formatargspec.patch
@@ -1,0 +1,167 @@
+From dad249590a4e5d2ac7d42d2963e3fabaa00eeee4 Mon Sep 17 00:00:00 2001
+From: Benjamin Drung <benjamin.drung@cloud.ionos.com>
+Date: Thu, 30 Jan 2020 12:17:29 +0100
+Subject: [PATCH] Replace deprecated inspect.formatargspec
+
+Python 3.7 raises a deprecation warning:
+
+salt/utils/decorators/signature.py:31: DeprecationWarning:
+`formatargspec` is deprecated since Python 3.5. Use `signature` and the
+`Signature` object directly
+
+`inspect.formatargspec` is only used in
+`salt.utils.decorators.signature.identical_signature_wrapper` which is
+only used in `salt.utils.decorators.path` for decorating the `which` and
+`which_bin` functions. The function `identical_signature_wrapper` can be
+simply replaced by Python's `functools.wraps` which is available since
+at least Python 2.7.
+
+When inspecting those wrapped functions, the underlying function (stored
+in the `__wrapped__` attribute) needs to be inspect instead.
+
+fixes #50911
+Signed-off-by: Benjamin Drung <benjamin.drung@cloud.ionos.com>
+
+(cherry picked from commit 61ec59375b6bd755b7fd73801e904d762d9008be)
+
+Rebased to salt 3000.2.
+
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+
+Upstream-Status: Inappropriate [Upstream stable EOL.]
+---
+ salt/utils/args.py                 | 10 ++++++-
+ salt/utils/decorators/path.py      | 13 ++++++---
+ salt/utils/decorators/signature.py | 43 ------------------------------
+ 3 files changed, 19 insertions(+), 47 deletions(-)
+ delete mode 100644 salt/utils/decorators/signature.py
+
+diff --git a/salt/utils/args.py b/salt/utils/args.py
+index 8cc0f35196..97af72eff7 100644
+--- a/salt/utils/args.py
++++ b/salt/utils/args.py
+@@ -241,7 +241,12 @@ if six.PY3:
+ 
+ def get_function_argspec(func, is_class_method=None):
+     '''
+-    A small wrapper around getargspec that also supports callable classes
++    A small wrapper around getargspec that also supports callable classes and wrapped functions
++
++    If the given function is a wrapper around another function (i.e. has a
++    ``__wrapped__`` attribute), return the functions specification of the underlying
++    function.
++
+     :param is_class_method: Pass True if you are sure that the function being passed
+                             is a class method. The reason for this is that on Python 3
+                             ``inspect.ismethod`` only returns ``True`` for bound methods,
+@@ -253,6 +258,9 @@ def get_function_argspec(func, is_class_method=None):
+     if not callable(func):
+         raise TypeError('{0} is not a callable'.format(func))
+ 
++    if hasattr(func, "__wrapped__"):
++        func = func.__wrapped__
++
+     if six.PY2:
+         if is_class_method is True:
+             aspec = inspect.getargspec(func)
+diff --git a/salt/utils/decorators/path.py b/salt/utils/decorators/path.py
+index 4adacf0e4e..8ee7fb1d11 100644
+--- a/salt/utils/decorators/path.py
++++ b/salt/utils/decorators/path.py
+@@ -4,10 +4,11 @@ Decorators for salt.utils.path
+ '''
+ from __future__ import absolute_import, print_function, unicode_literals
+ 
++import functools
++
+ # Import Salt libs
+ import salt.utils.path
+ from salt.exceptions import CommandNotFoundError
+-from salt.utils.decorators.signature import identical_signature_wrapper
+ 
+ 
+ def which(exe):
+@@ -15,13 +16,16 @@ def which(exe):
+     Decorator wrapper for salt.utils.path.which
+     '''
+     def wrapper(function):
++        @functools.wraps(function)
+         def wrapped(*args, **kwargs):
+             if salt.utils.path.which(exe) is None:
+                 raise CommandNotFoundError(
+                     'The \'{0}\' binary was not found in $PATH.'.format(exe)
+                 )
+             return function(*args, **kwargs)
+-        return identical_signature_wrapper(function, wrapped)
++
++        return wrapped
++
+     return wrapper
+ 
+ 
+@@ -30,6 +34,7 @@ def which_bin(exes):
+     Decorator wrapper for salt.utils.path.which_bin
+     '''
+     def wrapper(function):
++        @functools.wraps(function)
+         def wrapped(*args, **kwargs):
+             if salt.utils.path.which_bin(exes) is None:
+                 raise CommandNotFoundError(
+@@ -39,5 +44,7 @@ def which_bin(exes):
+                     )
+                 )
+             return function(*args, **kwargs)
+-        return identical_signature_wrapper(function, wrapped)
++
++        return wrapped
++
+     return wrapper
+diff --git a/salt/utils/decorators/signature.py b/salt/utils/decorators/signature.py
+deleted file mode 100644
+index 8bb6c19528..0000000000
+--- a/salt/utils/decorators/signature.py
++++ /dev/null
+@@ -1,43 +0,0 @@
+-# -*- coding: utf-8 -*-
+-'''
+-A decorator which returns a function with the same signature of the function
+-which is being wrapped.
+-'''
+-# Import Python libs
+-from __future__ import absolute_import, print_function, unicode_literals
+-import inspect
+-from functools import wraps
+-
+-# Import Salt libs
+-import salt.utils.args
+-
+-# Import 3rd-party libs
+-from salt.ext import six
+-
+-
+-def identical_signature_wrapper(original_function, wrapped_function):
+-    '''
+-    Return a function with identical signature as ``original_function``'s which
+-    will call the ``wrapped_function``.
+-    '''
+-    context = {'__wrapped__': wrapped_function}
+-    function_def = compile(
+-        'def {0}({1}):\n'
+-        '    return __wrapped__({2})'.format(
+-            # Keep the original function name
+-            original_function.__name__,
+-            # The function signature including defaults, i.e., 'timeout=1'
+-            inspect.formatargspec(
+-                *salt.utils.args.get_function_argspec(original_function)
+-            )[1:-1],
+-            # The function signature without the defaults
+-            inspect.formatargspec(
+-                formatvalue=lambda val: '',
+-                *salt.utils.args.get_function_argspec(original_function)
+-            )[1:-1]
+-        ),
+-        '<string>',
+-        'exec'
+-    )
+-    six.exec_(function_def, context)
+-    return wraps(original_function)(context[original_function.__name__])

--- a/recipes-support/salt/files/0008-Only-import-ABCs-from-collections.abc.patch
+++ b/recipes-support/salt/files/0008-Only-import-ABCs-from-collections.abc.patch
@@ -1,0 +1,990 @@
+From f542592578276ca5c2face6192d9beb3e47c4187 Mon Sep 17 00:00:00 2001
+From: Erik Johnson <palehose@gmail.com>
+Date: Sat, 9 May 2020 12:24:26 -0500
+Subject: [PATCH] Only import ABCs from collections.abc
+
+This prevents Deprecation warnings on Python 3.8. Additionally, code to
+make these ABCs successfully import in Python2 is no longer needed and
+has been removed.
+
+(cherry picked from commit f850d1796d392093ba1edd2dab7c400515629ee7)
+
+Rebased to salt 3000.2.
+
+Signed-off-by: Alex Stewart <alex.stewart@ni.com>
+
+Upstream-Status: Inappropriate [Upstream stable EOL.]
+---
+ salt/client/mixins.py                  |   8 +-
+ salt/daemons/__init__.py               |   5 +-
+ salt/ext/tornado/httputil.py           | 167 +++++++++++++++----------
+ salt/fileserver/__init__.py            |   6 +-
+ salt/loader.py                         |   5 +-
+ salt/modules/file.py                   |   3 +-
+ salt/modules/win_file.py               |   3 +-
+ salt/output/nested.py                  |   8 +-
+ salt/states/file.py                    |   3 +-
+ salt/utils/context.py                  |   6 +-
+ salt/utils/data.py                     |   6 +-
+ salt/utils/dictdiffer.py               |   3 +-
+ salt/utils/dictupdate.py               |   1 +
+ salt/utils/event.py                    |   7 +-
+ salt/utils/immutabletypes.py           |   7 +-
+ salt/utils/jinja.py                    |   8 +-
+ salt/utils/lazy.py                     |   7 +-
+ salt/utils/odict.py                    |   6 +-
+ salt/utils/oset.py                     |   6 +-
+ salt/utils/path.py                     |   1 +
+ salt/utils/ssdp.py                     |   6 +-
+ tests/integration/shell/test_syndic.py |   6 +-
+ tests/multimaster/__init__.py          |   6 +-
+ tests/support/mixins.py                |   6 +-
+ tests/unit/modules/test_debian_ip.py   |   6 +
+ tests/unit/pillar/test_pepa.py         |   6 +-
+ 26 files changed, 156 insertions(+), 146 deletions(-)
+
+diff --git a/salt/client/mixins.py b/salt/client/mixins.py
+index 49903b48b9..f43f8f39f2 100644
+--- a/salt/client/mixins.py
++++ b/salt/client/mixins.py
+@@ -12,6 +12,7 @@ import signal
+ import logging
+ import weakref
+ import traceback
++from collections.abc import Mapping, MutableMapping
+ 
+ # Import Salt libs
+ import salt.exceptions
+@@ -35,13 +36,6 @@ from salt.ext import six
+ # Import 3rd-party libs
+ import salt.ext.tornado.stack_context
+ 
+-try:
+-    from collections.abc import Mapping, MutableMapping
+-except ImportError:
+-    # pylint: disable=no-name-in-module
+-    from collections import Mapping, MutableMapping
+-
+-
+ log = logging.getLogger(__name__)
+ 
+ CLIENT_INTERNAL_KEYWORDS = frozenset([
+diff --git a/salt/daemons/__init__.py b/salt/daemons/__init__.py
+index 642100b663..ce7212f85d 100644
+--- a/salt/daemons/__init__.py
++++ b/salt/daemons/__init__.py
+@@ -6,11 +6,8 @@ Minion enabling different transports.
+ from __future__ import absolute_import, print_function, unicode_literals
+ # Import Python Libs
+ import sys
++from collections.abc import Iterable, Mapping, Sequence
+ 
+-try:
+-    from collections.abc import Iterable, Sequence, Mapping
+-except ImportError:
+-    from collections import Iterable, Sequence, Mapping
+ 
+ import logging
+ 
+diff --git a/salt/ext/tornado/httputil.py b/salt/ext/tornado/httputil.py
+index c5b9c242d5..c7a5ac7c3c 100644
+--- a/salt/ext/tornado/httputil.py
++++ b/salt/ext/tornado/httputil.py
+@@ -31,17 +31,11 @@ import email.utils
+ import numbers
+ import re
+ import time
++from collections.abc import MutableMapping
+ 
+ from salt.ext.tornado.escape import native_str, parse_qs_bytes, utf8
+ from salt.ext.tornado.log import gen_log
+-from salt.ext.tornado.util import ObjectDict, PY3
+-
+-try:
+-    from collections.abc import MutableMapping
+-except ImportError:
+-    # pylint: disable=no-name-in-module
+-    from collections import MutableMapping
+-
++from salt.ext.tornado.util import PY3, ObjectDict
+ 
+ if PY3:
+     import http.cookies as Cookie
+@@ -64,6 +58,7 @@ except ImportError:
+     # ssl is unavailable on app engine.
+     class _SSLError(Exception):
+         pass
++
+     # Hack around a mypy limitation. We can't simply put "type: ignore"
+     # on the class definition itself; must go through an assignment.
+     SSLError = _SSLError  # type: ignore
+@@ -76,7 +71,7 @@ except ImportError:
+ 
+ # RFC 7230 section 3.5: a recipient MAY recognize a single LF as a line
+ # terminator and ignore any preceding CR.
+-_CRLF_RE = re.compile(r'\r?\n')
++_CRLF_RE = re.compile(r"\r?\n")
+ 
+ 
+ class _NormalizedHeaderCache(dict):
+@@ -90,6 +85,7 @@ class _NormalizedHeaderCache(dict):
+     >>> normalized_headers["coNtent-TYPE"]
+     'Content-Type'
+     """
++
+     def __init__(self, size):
+         super(_NormalizedHeaderCache, self).__init__()
+         self.size = size
+@@ -139,12 +135,12 @@ class HTTPHeaders(MutableMapping):
+     Set-Cookie: A=B
+     Set-Cookie: C=D
+     """
++
+     def __init__(self, *args, **kwargs):
+         self._dict = {}  # type: typing.Dict[str, str]
+         self._as_list = {}  # type: typing.Dict[str, typing.List[str]]
+         self._last_key = None
+-        if (len(args) == 1 and len(kwargs) == 0 and
+-                isinstance(args[0], HTTPHeaders)):
++        if len(args) == 1 and len(kwargs) == 0 and isinstance(args[0], HTTPHeaders):
+             # Copy constructor
+             for k, v in args[0].get_all():
+                 self.add(k, v)
+@@ -160,8 +156,9 @@ class HTTPHeaders(MutableMapping):
+         norm_name = _normalized_headers[name]
+         self._last_key = norm_name
+         if norm_name in self:
+-            self._dict[norm_name] = (native_str(self[norm_name]) + ',' +
+-                                     native_str(value))
++            self._dict[norm_name] = (
++                native_str(self[norm_name]) + "," + native_str(value)
++            )
+             self._as_list[norm_name].append(value)
+         else:
+             self[norm_name] = value
+@@ -192,7 +189,7 @@ class HTTPHeaders(MutableMapping):
+         """
+         if line[0].isspace():
+             # continuation of a multi-line header
+-            new_part = ' ' + line.lstrip()
++            new_part = " " + line.lstrip()
+             self._as_list[self._last_key][-1] += new_part
+             self._dict[self._last_key] += new_part
+         else:
+@@ -345,9 +342,20 @@ class HTTPServerRequest(object):
+     .. versionchanged:: 4.0
+        Moved from ``tornado.httpserver.HTTPRequest``.
+     """
+-    def __init__(self, method=None, uri=None, version="HTTP/1.0", headers=None,
+-                 body=None, host=None, files=None, connection=None,
+-                 start_line=None, server_connection=None):
++
++    def __init__(
++        self,
++        method=None,
++        uri=None,
++        version="HTTP/1.0",
++        headers=None,
++        body=None,
++        host=None,
++        files=None,
++        connection=None,
++        start_line=None,
++        server_connection=None,
++    ):
+         if start_line is not None:
+             method, uri, version = start_line
+         self.method = method
+@@ -357,9 +365,9 @@ class HTTPServerRequest(object):
+         self.body = body or b""
+ 
+         # set remote IP and protocol
+-        context = getattr(connection, 'context', None)
+-        self.remote_ip = getattr(context, 'remote_ip', None)
+-        self.protocol = getattr(context, 'protocol', "http")
++        context = getattr(connection, "context", None)
++        self.remote_ip = getattr(context, "remote_ip", None)
++        self.protocol = getattr(context, "protocol", "http")
+ 
+         self.host = host or self.headers.get("Host") or "127.0.0.1"
+         self.host_name = split_host_and_port(self.host.lower())[0]
+@@ -369,7 +377,7 @@ class HTTPServerRequest(object):
+         self._start_time = time.time()
+         self._finish_time = None
+ 
+-        self.path, sep, self.query = uri.partition('?')
++        self.path, sep, self.query = uri.partition("?")
+         self.arguments = parse_qs_bytes(self.query, keep_blank_values=True)
+         self.query_arguments = copy.deepcopy(self.arguments)
+         self.body_arguments = {}
+@@ -413,8 +421,9 @@ class HTTPServerRequest(object):
+            to write the response.
+         """
+         assert isinstance(chunk, bytes)
+-        assert self.version.startswith("HTTP/1."), \
+-            "deprecated interface only supported in HTTP/1.x"
++        assert self.version.startswith(
++            "HTTP/1."
++        ), "deprecated interface only supported in HTTP/1.x"
+         self.connection.write(chunk, callback=callback)
+ 
+     def finish(self):
+@@ -458,16 +467,18 @@ class HTTPServerRequest(object):
+         http://docs.python.org/library/ssl.html#sslsocket-objects
+         """
+         try:
+-            return self.connection.stream.socket.getpeercert(
+-                binary_form=binary_form)
++            return self.connection.stream.socket.getpeercert(binary_form=binary_form)
+         except SSLError:
+             return None
+ 
+     def _parse_body(self):
+         parse_body_arguments(
+-            self.headers.get("Content-Type", ""), self.body,
+-            self.body_arguments, self.files,
+-            self.headers)
++            self.headers.get("Content-Type", ""),
++            self.body,
++            self.body_arguments,
++            self.files,
++            self.headers,
++        )
+ 
+         for k, v in self.body_arguments.items():
+             self.arguments.setdefault(k, []).extend(v)
+@@ -476,7 +487,10 @@ class HTTPServerRequest(object):
+         attrs = ("protocol", "host", "method", "uri", "version", "remote_ip")
+         args = ", ".join(["%s=%r" % (n, getattr(self, n)) for n in attrs])
+         return "%s(%s, headers=%s)" % (
+-            self.__class__.__name__, args, dict(self.headers))
++            self.__class__.__name__,
++            args,
++            dict(self.headers),
++        )
+ 
+ 
+ class HTTPInputError(Exception):
+@@ -485,6 +499,7 @@ class HTTPInputError(Exception):
+ 
+     .. versionadded:: 4.0
+     """
++
+     pass
+ 
+ 
+@@ -493,6 +508,7 @@ class HTTPOutputError(Exception):
+ 
+     .. versionadded:: 4.0
+     """
++
+     pass
+ 
+ 
+@@ -501,6 +517,7 @@ class HTTPServerConnectionDelegate(object):
+ 
+     .. versionadded:: 4.0
+     """
++
+     def start_request(self, server_conn, request_conn):
+         """This method is called by the server when a new request has started.
+ 
+@@ -527,6 +544,7 @@ class HTTPMessageDelegate(object):
+ 
+     .. versionadded:: 4.0
+     """
++
+     def headers_received(self, start_line, headers):
+         """Called when the HTTP headers have been received and parsed.
+ 
+@@ -567,6 +585,7 @@ class HTTPConnection(object):
+ 
+     .. versionadded:: 4.0
+     """
++
+     def write_headers(self, start_line, headers, chunk=None, callback=None):
+         """Write an HTTP header block.
+ 
+@@ -622,16 +641,20 @@ def url_concat(url, args):
+         parsed_query.extend(args)
+     else:
+         err = "'args' parameter should be dict, list or tuple. Not {0}".format(
+-            type(args))
++            type(args)
++        )
+         raise TypeError(err)
+     final_query = urlencode(parsed_query)
+-    url = urlunparse((
+-        parsed_url[0],
+-        parsed_url[1],
+-        parsed_url[2],
+-        parsed_url[3],
+-        final_query,
+-        parsed_url[5]))
++    url = urlunparse(
++        (
++            parsed_url[0],
++            parsed_url[1],
++            parsed_url[2],
++            parsed_url[3],
++            final_query,
++            parsed_url[5],
++        )
++    )
+     return url
+ 
+ 
+@@ -645,6 +668,7 @@ class HTTPFile(ObjectDict):
+     * ``body``
+     * ``content_type``
+     """
++
+     pass
+ 
+ 
+@@ -728,15 +752,14 @@ def parse_body_arguments(content_type, body, arguments, files, headers=None):
+     and ``files`` parameters are dictionaries that will be updated
+     with the parsed contents.
+     """
+-    if headers and 'Content-Encoding' in headers:
+-        gen_log.warning("Unsupported Content-Encoding: %s",
+-                        headers['Content-Encoding'])
++    if headers and "Content-Encoding" in headers:
++        gen_log.warning("Unsupported Content-Encoding: %s", headers["Content-Encoding"])
+         return
+     if content_type.startswith("application/x-www-form-urlencoded"):
+         try:
+             uri_arguments = parse_qs_bytes(native_str(body), keep_blank_values=True)
+         except Exception as e:
+-            gen_log.warning('Invalid x-www-form-urlencoded body: %s', e)
++            gen_log.warning("Invalid x-www-form-urlencoded body: %s", e)
+             uri_arguments = {}
+         for name, values in uri_arguments.items():
+             if values:
+@@ -787,16 +810,18 @@ def parse_multipart_form_data(boundary, data, arguments, files):
+         if disposition != "form-data" or not part.endswith(b"\r\n"):
+             gen_log.warning("Invalid multipart/form-data")
+             continue
+-        value = part[eoh + 4:-2]
++        value = part[eoh + 4 : -2]
+         if not disp_params.get("name"):
+             gen_log.warning("multipart/form-data value missing name")
+             continue
+         name = disp_params["name"]
+         if disp_params.get("filename"):
+             ctype = headers.get("Content-Type", "application/unknown")
+-            files.setdefault(name, []).append(HTTPFile(  # type: ignore
+-                filename=disp_params["filename"], body=value,
+-                content_type=ctype))
++            files.setdefault(name, []).append(
++                HTTPFile(  # type: ignore
++                    filename=disp_params["filename"], body=value, content_type=ctype
++                )
++            )
+         else:
+             arguments.setdefault(name, []).append(value)
+ 
+@@ -823,7 +848,8 @@ def format_timestamp(ts):
+ 
+ 
+ RequestStartLine = collections.namedtuple(
+-    'RequestStartLine', ['method', 'path', 'version'])
++    "RequestStartLine", ["method", "path", "version"]
++)
+ 
+ 
+ def parse_request_start_line(line):
+@@ -840,12 +866,14 @@ def parse_request_start_line(line):
+         raise HTTPInputError("Malformed HTTP request line")
+     if not re.match(r"^HTTP/1\.[0-9]$", version):
+         raise HTTPInputError(
+-            "Malformed HTTP version in HTTP Request-Line: %r" % version)
++            "Malformed HTTP version in HTTP Request-Line: %r" % version
++        )
+     return RequestStartLine(method, path, version)
+ 
+ 
+ ResponseStartLine = collections.namedtuple(
+-    'ResponseStartLine', ['version', 'code', 'reason'])
++    "ResponseStartLine", ["version", "code", "reason"]
++)
+ 
+ 
+ def parse_response_start_line(line):
+@@ -860,8 +888,8 @@ def parse_response_start_line(line):
+     match = re.match("(HTTP/1.[0-9]) ([0-9]+) ([^\r]*)", line)
+     if not match:
+         raise HTTPInputError("Error parsing response start line")
+-    return ResponseStartLine(match.group(1), int(match.group(2)),
+-                             match.group(3))
++    return ResponseStartLine(match.group(1), int(match.group(2)), match.group(3))
++
+ 
+ # _parseparam and _parse_header are copied and modified from python2.7's cgi.py
+ # The original 2.7 version of this code did not correctly support some
+@@ -871,11 +899,11 @@ def parse_response_start_line(line):
+ 
+ 
+ def _parseparam(s):
+-    while s[:1] == ';':
++    while s[:1] == ";":
+         s = s[1:]
+-        end = s.find(';')
++        end = s.find(";")
+         while end > 0 and (s.count('"', 0, end) - s.count('\\"', 0, end)) % 2:
+-            end = s.find(';', end + 1)
++            end = s.find(";", end + 1)
+         if end < 0:
+             end = len(s)
+         f = s[:end]
+@@ -889,17 +917,17 @@ def _parse_header(line):
+     Return the main content-type and a dictionary of options.
+ 
+     """
+-    parts = _parseparam(';' + line)
++    parts = _parseparam(";" + line)
+     key = next(parts)
+     pdict = {}
+     for p in parts:
+-        i = p.find('=')
++        i = p.find("=")
+         if i >= 0:
+             name = p[:i].strip().lower()
+-            value = p[i + 1:].strip()
++            value = p[i + 1 :].strip()
+             if len(value) >= 2 and value[0] == value[-1] == '"':
+                 value = value[1:-1]
+-                value = value.replace('\\\\', '\\').replace('\\"', '"')
++                value = value.replace("\\\\", "\\").replace('\\"', '"')
+             pdict[name] = value
+         else:
+             pdict[p] = None
+@@ -922,12 +950,13 @@ def _encode_header(key, pdict):
+             out.append(k)
+         else:
+             # TODO: quote if necessary.
+-            out.append('%s=%s' % (k, v))
+-    return '; '.join(out)
++            out.append("%s=%s" % (k, v))
++    return "; ".join(out)
+ 
+ 
+ def doctests():
+     import doctest
++
+     return doctest.DocTestSuite()
+ 
+ 
+@@ -938,7 +967,7 @@ def split_host_and_port(netloc):
+ 
+     .. versionadded:: 4.1
+     """
+-    match = re.match(r'^(.+):(\d+)$', netloc)
++    match = re.match(r"^(.+):(\d+)$", netloc)
+     if match:
+         host = match.group(1)
+         port = int(match.group(2))
+@@ -950,7 +979,7 @@ def split_host_and_port(netloc):
+ 
+ _OctalPatt = re.compile(r"\\[0-3][0-7][0-7]")
+ _QuotePatt = re.compile(r"[\\].")
+-_nulljoin = ''.join
++_nulljoin = "".join
+ 
+ 
+ def _unquote_cookie(str):
+@@ -983,7 +1012,7 @@ def _unquote_cookie(str):
+     while 0 <= i < n:
+         o_match = _OctalPatt.search(str, i)
+         q_match = _QuotePatt.search(str, i)
+-        if not o_match and not q_match:              # Neither matched
++        if not o_match and not q_match:  # Neither matched
+             res.append(str[i:])
+             break
+         # else:
+@@ -992,13 +1021,13 @@ def _unquote_cookie(str):
+             j = o_match.start(0)
+         if q_match:
+             k = q_match.start(0)
+-        if q_match and (not o_match or k < j):     # QuotePatt matched
++        if q_match and (not o_match or k < j):  # QuotePatt matched
+             res.append(str[i:k])
+             res.append(str[k + 1])
+             i = k + 2
+-        else:                                      # OctalPatt matched
++        else:  # OctalPatt matched
+             res.append(str[i:j])
+-            res.append(chr(int(str[j + 1:j + 4], 8)))
++            res.append(chr(int(str[j + 1 : j + 4], 8)))
+             i = j + 4
+     return _nulljoin(res)
+ 
+@@ -1015,13 +1044,13 @@ def parse_cookie(cookie):
+     .. versionadded:: 4.4.2
+     """
+     cookiedict = {}
+-    for chunk in cookie.split(str(';')):
+-        if str('=') in chunk:
+-            key, val = chunk.split(str('='), 1)
++    for chunk in cookie.split(str(";")):
++        if str("=") in chunk:
++            key, val = chunk.split(str("="), 1)
+         else:
+             # Assume an empty name per
+             # https://bugzilla.mozilla.org/show_bug.cgi?id=169091
+-            key, val = str(''), chunk
++            key, val = str(""), chunk
+         key, val = key.strip(), val.strip()
+         if key or val:
+             # unquote using Python's algorithm.
+diff --git a/salt/fileserver/__init__.py b/salt/fileserver/__init__.py
+index 919987e2fc..0dc0f1b593 100644
+--- a/salt/fileserver/__init__.py
++++ b/salt/fileserver/__init__.py
+@@ -13,6 +13,7 @@ import os
+ import re
+ import sys
+ import time
++from collections.abc import Sequence
+ 
+ # Import salt libs
+ import salt.loader
+@@ -24,11 +25,6 @@ import salt.utils.versions
+ from salt.utils.args import get_function_argspec as _argspec
+ from salt.utils.decorators import ensure_unicode_args
+ 
+-try:
+-    from collections.abc import Sequence
+-except ImportError:
+-    from collections import Sequence
+-
+ # Import 3rd-party libs
+ from salt.ext import six
+ 
+diff --git a/salt/loader.py b/salt/loader.py
+index 428fb338c9..5e12fc401e 100644
+--- a/salt/loader.py
++++ b/salt/loader.py
+@@ -18,6 +18,7 @@ import functools
+ import threading
+ import traceback
+ import types
++from collections.abc import MutableMapping
+ from zipimport import zipimporter
+ 
+ # Import salt libs
+@@ -51,10 +52,6 @@ else:
+     import imp
+     USE_IMPORTLIB = False
+ 
+-try:
+-    from collections.abc import MutableMapping
+-except ImportError:
+-    from collections import MutableMapping
+ 
+ try:
+     import pkg_resources
+diff --git a/salt/modules/file.py b/salt/modules/file.py
+index b5b70e2d4c..5de816bf88 100644
+--- a/salt/modules/file.py
++++ b/salt/modules/file.py
+@@ -29,7 +29,8 @@ import time
+ import glob
+ import hashlib
+ import mmap
+-from collections import Iterable, Mapping, namedtuple
++from collections import namedtuple
++from collections.abc import Iterable, Mapping
+ from functools import reduce  # pylint: disable=redefined-builtin
+ 
+ # pylint: disable=import-error,no-name-in-module,redefined-builtin
+diff --git a/salt/modules/win_file.py b/salt/modules/win_file.py
+index 4fd3eebcdd..0632ac45b4 100644
+--- a/salt/modules/win_file.py
++++ b/salt/modules/win_file.py
+@@ -17,7 +17,6 @@ import os.path
+ import logging
+ # pylint: disable=W0611
+ import operator  # do not remove
+-from collections import Iterable, Mapping  # do not remove
+ from functools import reduce  # do not remove
+ import datetime  # do not remove.
+ import tempfile  # do not remove. Used in salt.modules.file.__clean_tmp
+@@ -37,6 +36,8 @@ import glob  # do not remove, used in imported file.py functions
+ # do not remove, used in imported file.py functions
+ from salt.ext import six
+ from salt.ext.six.moves.urllib.parse import urlparse as _urlparse  # pylint: disable=import-error,no-name-in-module
++from collections.abc import Iterable, Mapping
++
+ import salt.utils.atomicfile  # do not remove, used in imported file.py functions
+ from salt.exceptions import CommandExecutionError, SaltInvocationError
+ # pylint: enable=W0611
+diff --git a/salt/output/nested.py b/salt/output/nested.py
+index 8e3cb74ce5..402354599c 100644
+--- a/salt/output/nested.py
++++ b/salt/output/nested.py
+@@ -24,6 +24,9 @@ Example output::
+                 - World
+ '''
+ from __future__ import absolute_import, print_function, unicode_literals
++
++from collections.abc import Mapping
++
+ # Import python libs
+ from numbers import Number
+ 
+@@ -34,11 +37,6 @@ import salt.utils.odict
+ import salt.utils.stringutils
+ from salt.ext import six
+ 
+-try:
+-    from collections.abc import Mapping
+-except ImportError:
+-    from collections import Mapping
+-
+ 
+ class NestDisplay(object):
+     '''
+diff --git a/salt/states/file.py b/salt/states/file.py
+index 0eca8b713f..21dced480b 100644
+--- a/salt/states/file.py
++++ b/salt/states/file.py
+@@ -291,8 +291,9 @@ import shutil
+ import sys
+ import time
+ import traceback
+-from collections import Iterable, Mapping, defaultdict
+ from datetime import datetime, date   # python3 problem in the making?
++from collections import defaultdict
++from collections.abc import Iterable, Mapping
+ 
+ # Import salt libs
+ import salt.loader
+diff --git a/salt/utils/context.py b/salt/utils/context.py
+index 948f92c5e9..3fc916df45 100644
+--- a/salt/utils/context.py
++++ b/salt/utils/context.py
+@@ -14,11 +14,7 @@ from __future__ import absolute_import, print_function, unicode_literals
+ # Import python libs
+ import copy
+ import threading
+-try:
+-    from collections.abc import MutableMapping
+-except ImportError:
+-    from collections import MutableMapping
+-
++from collections.abc import MutableMapping
+ from contextlib import contextmanager
+ 
+ from salt.ext import six
+diff --git a/salt/utils/data.py b/salt/utils/data.py
+index 8f84c2ea42..6986486a0b 100644
+--- a/salt/utils/data.py
++++ b/salt/utils/data.py
+@@ -12,11 +12,7 @@ import fnmatch
+ import logging
+ import re
+ import functools
+-
+-try:
+-    from collections.abc import Mapping, MutableMapping, Sequence
+-except ImportError:
+-    from collections import Mapping, MutableMapping, Sequence
++from collections.abc import Mapping, MutableMapping, Sequence
+ 
+ # Import Salt libs
+ import salt.utils.dictupdate
+diff --git a/salt/utils/dictdiffer.py b/salt/utils/dictdiffer.py
+index 30e87e8854..f6f6d0b48f 100644
+--- a/salt/utils/dictdiffer.py
++++ b/salt/utils/dictdiffer.py
+@@ -13,7 +13,8 @@
+ '''
+ from __future__ import absolute_import, print_function, unicode_literals
+ import copy
+-from collections import Mapping
++from collections.abc import Mapping
++
+ from salt.ext import six
+ 
+ 
+diff --git a/salt/utils/dictupdate.py b/salt/utils/dictupdate.py
+index 456e713373..94bc8e05a4 100644
+--- a/salt/utils/dictupdate.py
++++ b/salt/utils/dictupdate.py
+@@ -15,6 +15,7 @@ except ImportError:
+ # Import 3rd-party libs
+ import copy
+ import logging
++from collections.abc import Mapping
+ 
+ # Import salt libs
+ import salt.ext.six as six
+diff --git a/salt/utils/event.py b/salt/utils/event.py
+index 0a3074a6f7..50972331d7 100644
+--- a/salt/utils/event.py
++++ b/salt/utils/event.py
+@@ -59,12 +59,7 @@ import fnmatch
+ import hashlib
+ import logging
+ import datetime
+-
+-try:
+-    from collections.abc import MutableMapping
+-except ImportError:
+-    from collections import MutableMapping
+-
++from collections.abc import MutableMapping
+ from multiprocessing.util import Finalize
+ from salt.ext.six.moves import range
+ 
+diff --git a/salt/utils/immutabletypes.py b/salt/utils/immutabletypes.py
+index b474d1bd1e..610e7e372f 100644
+--- a/salt/utils/immutabletypes.py
++++ b/salt/utils/immutabletypes.py
+@@ -10,12 +10,7 @@
+ '''
+ from __future__ import absolute_import, unicode_literals
+ import copy
+-
+-# Import python libs
+-try:
+-    from collections.abc import Mapping, Sequence, Set
+-except ImportError:
+-    from collections import Mapping, Sequence, Set
++from collections.abc import Mapping, Sequence, Set
+ 
+ 
+ class ImmutableDict(Mapping):
+diff --git a/salt/utils/jinja.py b/salt/utils/jinja.py
+index 0861ce2a2d..61a0808ba5 100644
+--- a/salt/utils/jinja.py
++++ b/salt/utils/jinja.py
+@@ -12,6 +12,7 @@ import pipes
+ import pprint
+ import re
+ import uuid
++from collections.abc import Hashable
+ from functools import wraps
+ from xml.dom import minidom
+ from xml.etree.ElementTree import Element, SubElement, tostring
+@@ -36,13 +37,6 @@ import salt.utils.yaml
+ from salt.utils.decorators.jinja import jinja_filter, jinja_test, jinja_global
+ from salt.utils.odict import OrderedDict
+ 
+-try:
+-    from collections.abc import Hashable
+-except ImportError:
+-    # pylint: disable=no-name-in-module
+-    from collections import Hashable
+-
+-
+ try:
+     from markupsafe import Markup
+ except ImportError:
+diff --git a/salt/utils/lazy.py b/salt/utils/lazy.py
+index 3cd6489d2d..4f68f9b720 100644
+--- a/salt/utils/lazy.py
++++ b/salt/utils/lazy.py
+@@ -6,12 +6,9 @@ Lazily-evaluated data structures, primarily used by Salt's loader
+ # Import Python Libs
+ from __future__ import absolute_import, unicode_literals
+ import logging
+-import salt.exceptions
++from collections.abc import MutableMapping
+ 
+-try:
+-    from collections.abc import MutableMapping
+-except ImportError:
+-    from collections import MutableMapping
++import salt.exceptions
+ 
+ log = logging.getLogger(__name__)
+ 
+diff --git a/salt/utils/odict.py b/salt/utils/odict.py
+index ac27b78f5b..095a9e8bb7 100644
+--- a/salt/utils/odict.py
++++ b/salt/utils/odict.py
+@@ -22,10 +22,8 @@
+ 
+ # Import python libs
+ from __future__ import absolute_import, unicode_literals, print_function
+-try:
+-    from collections.abc import Callable
+-except ImportError:
+-    from collections import Callable
++
++from collections.abc import Callable
+ 
+ # Import 3rd-party libs
+ from salt.ext import six
+diff --git a/salt/utils/oset.py b/salt/utils/oset.py
+index 9fc92ac114..3c0f845d46 100644
+--- a/salt/utils/oset.py
++++ b/salt/utils/oset.py
+@@ -23,11 +23,7 @@ Rob Speer's changes are as follows:
+ '''
+ from __future__ import absolute_import, unicode_literals, print_function
+ 
+-try:
+-    from collections.abc import MutableSet
+-except ImportError:
+-    # pylint: disable=no-name-in-module
+-    from collections import MutableSet
++from collections.abc import MutableSet
+ 
+ SLICE_ALL = slice(None)
+ __version__ = '2.0.1'
+diff --git a/salt/utils/path.py b/salt/utils/path.py
+index 6cbbf3a08e..38c5a08ae9 100644
+--- a/salt/utils/path.py
++++ b/salt/utils/path.py
+@@ -17,6 +17,7 @@ import posixpath
+ import re
+ import string
+ import struct
++from collections.abc import Iterable
+ 
+ # Import Salt libs
+ import salt.utils.args
+diff --git a/salt/utils/ssdp.py b/salt/utils/ssdp.py
+index 26b757b738..7888cbdbe2 100644
+--- a/salt/utils/ssdp.py
++++ b/salt/utils/ssdp.py
+@@ -26,11 +26,15 @@ import logging
+ import random
+ import socket
+ import copy
+-from collections import OrderedDict
+ 
+ import salt.utils.json
+ import salt.utils.stringutils
+ 
++try:
++    from salt.utils.odict import OrderedDict
++except ImportError:
++    from collections import OrderedDict
++
+ _json = salt.utils.json.import_json()
+ if not hasattr(_json, 'dumps'):
+     _json = None
+diff --git a/tests/integration/shell/test_syndic.py b/tests/integration/shell/test_syndic.py
+index c695ca3226..1d1dde632d 100644
+--- a/tests/integration/shell/test_syndic.py
++++ b/tests/integration/shell/test_syndic.py
+@@ -10,7 +10,6 @@
+ # Import python libs
+ from __future__ import absolute_import
+ import logging
+-from collections import OrderedDict
+ 
+ # Import Salt Testing libs
+ from tests.support.case import ShellCase
+@@ -27,6 +26,11 @@ import salt.utils.platform
+ import psutil
+ #import pytest
+ 
++try:
++    from salt.utils.odict import OrderedDict
++except ImportError:
++    from collections import OrderedDict
++
+ log = logging.getLogger(__name__)
+ 
+ 
+diff --git a/tests/multimaster/__init__.py b/tests/multimaster/__init__.py
+index 0663c008cb..b0fcdcbe39 100644
+--- a/tests/multimaster/__init__.py
++++ b/tests/multimaster/__init__.py
+@@ -14,7 +14,6 @@ import stat
+ import sys
+ import threading
+ import time
+-from collections import OrderedDict
+ 
+ # Import salt tests support dirs
+ from tests.support.paths import (
+@@ -47,6 +46,11 @@ from salt.utils.verify import verify_env
+ # Import salt tests support libs
+ from tests.support.processes import SaltMaster, SaltMinion
+ 
++try:
++    from salt.utils.odict import OrderedDict
++except ImportError:
++    from collections import OrderedDict
++
+ log = logging.getLogger(__name__)
+ 
+ 
+diff --git a/tests/support/mixins.py b/tests/support/mixins.py
+index c54b8e7d6d..795fe3292e 100644
+--- a/tests/support/mixins.py
++++ b/tests/support/mixins.py
+@@ -24,7 +24,6 @@ import tempfile
+ import functools
+ import subprocess
+ import multiprocessing
+-from collections import OrderedDict
+ 
+ # Import Salt Testing Libs
+ from tests.support.mock import patch
+@@ -51,6 +50,11 @@ from salt.ext import six
+ from salt.ext.six.moves import zip  # pylint: disable=import-error,redefined-builtin
+ from salt.ext.six.moves.queue import Empty  # pylint: disable=import-error,no-name-in-module
+ 
++try:
++    from salt.utils.odict import OrderedDict
++except ImportError:
++    from collections import OrderedDict
++
+ log = logging.getLogger(__name__)
+ 
+ 
+diff --git a/tests/unit/modules/test_debian_ip.py b/tests/unit/modules/test_debian_ip.py
+index 74b4e54b68..5f8b11609a 100644
+--- a/tests/unit/modules/test_debian_ip.py
++++ b/tests/unit/modules/test_debian_ip.py
+@@ -8,6 +8,7 @@ from __future__ import absolute_import, print_function, unicode_literals
+ import tempfile
+ 
+ # Import Salt Testing Libs
++import salt.utils.files
+ from tests.support.mixins import LoaderModuleMockMixin
+ from tests.support.unit import TestCase, skipIf
+ from tests.support.mock import (
+@@ -19,6 +20,11 @@ from tests.support.mock import (
+ import salt.modules.debian_ip as debian_ip
+ import salt.utils.platform
+ 
++try:
++    from salt.utils.odict import OrderedDict as odict
++except ImportError:
++    from collections import OrderedDict as odict
++
+ # Import third party libs
+ import jinja2.exceptions
+ 
+diff --git a/tests/unit/pillar/test_pepa.py b/tests/unit/pillar/test_pepa.py
+index 79dad1af8b..820de47107 100644
+--- a/tests/unit/pillar/test_pepa.py
++++ b/tests/unit/pillar/test_pepa.py
+@@ -2,7 +2,6 @@
+ 
+ # Import python libs
+ from __future__ import absolute_import, print_function, unicode_literals
+-from collections import OrderedDict
+ 
+ # Import Salt Testing libs
+ from tests.support.unit import TestCase
+@@ -10,6 +9,11 @@ from tests.support.unit import TestCase
+ # Import Salt Libs
+ import salt.pillar.pepa as pepa
+ 
++try:
++    from salt.utils.odict import OrderedDict
++except ImportError:
++    from collections import OrderedDict
++
+ 
+ class PepaPillarTestCase(TestCase):
+     def test_repeated_keys(self):

--- a/recipes-support/salt/salt_3000.2.bb
+++ b/recipes-support/salt/salt_3000.2.bb
@@ -30,6 +30,14 @@ SRC_URI = "\
     file://cloud \
     file://roster \
     file://run-ptest \
+    file://0001-Fix-deprecation-warnings-for-imports-from-collection.patch \
+    file://0002-fix-jinja2-contextfuntion-base-on-version.patch \
+    file://0003-fix-jinja2-DeprecationWarning.patch \
+    file://0004-Use-the-correct-Markup-from-jinja-for-each-version.patch \
+    file://0005-Use-the-correct-Markup-from-jinja-for-each-version.patch \
+    file://0006-Fix-requested-feedback.patch \
+    file://0007-Replace-deprecated-inspect.formatargspec.patch \
+    file://0008-Only-import-ABCs-from-collections.abc.patch \
 "
 
 SRCREV = "${AUTOREV}"

--- a/recipes-support/salt/salt_3000.2.bb
+++ b/recipes-support/salt/salt_3000.2.bb
@@ -148,6 +148,7 @@ RDEPENDS:${PN}-common = "\
     python3-jinja2 \
     python3-pyyaml \
     python3-requests (>= 1.0.0) \
+    python3-singledispatch (>= 3.4.0.3) \
     python3-tornado (>= 4.2.1) \
 "
 RRECOMMENDS:${PN}-common = "lsb-release"

--- a/recipes-support/salt/salt_3000.2.bb
+++ b/recipes-support/salt/salt_3000.2.bb
@@ -141,7 +141,15 @@ INITSCRIPT_PARAMS:${PN}-minion = "defaults"
 SUMMARY:${PN}-common = "shared libraries that salt requires for all packages"
 DESCRIPTION:${PN}-common ="${DESCRIPTION_COMMON} This particular package provides shared libraries that \
 salt-master, salt-minion, and salt-syndic require to function."
-RDEPENDS:${PN}-common = "python3-core python3-fcntl python3-dateutil python3-jinja2 python3-pyyaml python3-requests (>= 1.0.0) python3-tornado (>= 4.2.1)"
+RDEPENDS:${PN}-common = "\
+    python3-core \
+    python3-dateutil \
+    python3-fcntl \
+    python3-jinja2 \
+    python3-pyyaml \
+    python3-requests (>= 1.0.0) \
+    python3-tornado (>= 4.2.1) \
+"
 RRECOMMENDS:${PN}-common = "lsb-release"
 RSUGGESTS:${PN}-common = "python3-mako python3-git"
 RCONFLICTS:${PN}-common = "python3-mako (< 0.7.0)"


### PR DESCRIPTION
Salt 3000.2 has been EOL for a while and lacks broad compatibility with
newer python runtimes, including the python3.10 runtime shipping with
NILRT 10 "kirkstone". As a result, simple workflows like the
restartcheck module to not properly function, causing some software
installation workflows to miss restarting the salt minion when they
should.

Backport upstream salt:master patches which accomplish some parts of
python3.10 compatibility, to at least fix the restartcheck module paths.

The .patches in this set should definitely not be carried forward
if/when we upgrade salt.

* This patchset also adds a missing `python3-singledispatch` dependency. I think this dep was being coincidentally satisfied in prior releases.

NI AZDO: https://dev.azure.com/ni/DevCentral/_workitems/edit/2341699

Work item with a sampling of errors encountered: https://dev.azure.com/ni/DevCentral/_workitems/edit/2329675

# Testing
Without this patch, running even `salt-call --local --help` fails with errors. After this patch, the `salt-call --local restartcheck.restartcheck` method, which is critical to MAX workflows, functions correctly albeit with some warnings about python3.12 incompatibility :(.

While testing this patchset, I found that I couldn't *just upgrade* salt, and have the SW install workflow correctly reboot the target. The `/var/lib/salt/restartcheck_state` data store must first be created by calling any `opkg` module method first. I'm 85% sure that, once this patchset goes in, that data store will be created by some process I don't understand in the default BSI. But I'm running that issue down separately. In either case, this patchset won't make the current broken behavior *worse*.

# Meta
* This patchset is kirkstone-specific and should not be backported to previous mainlines.