### PR TITLE
fs_permissions_known: correct file permissions

### DIFF
--- a/recipes-ni/ni-base-system-image-tests/files/fs_permissions_known.py
+++ b/recipes-ni/ni-base-system-image-tests/files/fs_permissions_known.py
@@ -19,6 +19,7 @@ def known_permissions_tree():
                 '*': system_file,
                 'grubenv': permissions(0o664, 'admin', 'ni', FT_REG),
                 'grubenv.bak': permissions(0o664, 'admin', 'ni', FT_REG),
+                'grub-ni-version': permissions(0o0444, 'admin', 'administrators', FT_REG),
                 'recoverytool-ni-version': permissions(0o0444, 'admin', 'administrators', FT_REG)
             },
             'runmode': {
@@ -28,7 +29,7 @@ def known_permissions_tree():
             }
         },
         'etc': {
-            'fstab': permissions(0o0644, 'lvuser', 'ni', FT_REG)
+            'fstab': system_file
         },
         'home': {
             '.': system_dir,


### PR DESCRIPTION
## Reason

In a previous [PR](https://github.com/ni/meta-nilrt/pull/557), two files were added to the known permissions test file tree with incorrect expected permissions:
- `/etc/fstab`:
  + wrong user
  + wrong group
- `/boot/grub/grub-ni-version`:
  + grouped with others in `/boot/grub/*` as `system_file`
  + wrong mode

This happened due to testing permissions on a VM, but was revealed when running the test on real hardware.
In order for the test to succeed in our internal ATS, the permissions need to be corrected

These need to be cherry picked back to hardknott

## Implementation

- `/etc/fstab` to `system_file`
- `/boot/grub/grub-ni-version` to 0o0444

## Testing

The test was modified as shown here and run on the ATS hardware directly