### PR TITLE
syslog-ng.conf: Update version to 3.31

### DIFF
--- a/recipes-support/syslog-ng/files/syslog-ng.conf.sysvinit
+++ b/recipes-support/syslog-ng/files/syslog-ng.conf.sysvinit
@@ -1,4 +1,4 @@
-@version: 3.8
+@version: 3.31
 # syslog-ng config file for NI RT targets
 
 options {


### PR DESCRIPTION
Since recipe (in meta-oe) is being updated to 3.31, update version in syslog-ng.conf also.

Azure WI: [2352139](https://dev.azure.com/ni/DevCentral/_workitems/edit/2352139)

### Testing
See https://github.com/ni/meta-openembedded/pull/34