### PR TITLE
Enable create-spdx when building images.

### DIFF
--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -9,7 +9,10 @@ NILRT_FEED_NAME ?= "next/2023Q3"
 DISTRO_FEATURES:append:x64 = "\
         x11 \
         opengl \
+        create-spdx \
 "
+
+INHERIT += " create-spdx "
 
 VIRTUAL-RUNTIME_xserver_common = "xserver-common"
 

--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -19,7 +19,7 @@ DISTRO_FEATURES += "\
         pam \
         ptest \
         selinux \
-	virtualization \
+        virtualization \
 "
 
 # Because NIRLT uses opkg so intimately, assert that the rootfs should always


### PR DESCRIPTION
Because [we now skip creating SPDX when a package comes from a remote feed](https://github.com/ni/openembedded-core/pull/90), we can enable creating the spdx zst archives when building images.

To enable it, we need to inherit from create-spdx at the top-level bitbake config, and add it to the list of DISTRO_FEATURES.

I verified this produces the expected archive by building `packagefeed-ni-core` followed by `nilrt-base-system-image` 