### PR TITLE
linux-nilrt-next: bump version to latest 6.1 development branch

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-next_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-next_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NILRT linux kernel next development build"
 NI_RELEASE_VERSION = "master"
-LINUX_VERSION = "6.0"
+LINUX_VERSION = "6.1"
 LINUX_KERNEL_TYPE = "next"
 
 require linux-nilrt-alternate.inc


### PR DESCRIPTION
Update our 'next' kernel recipe (linux-nilrt-next) to point to the latest 6.1 kernel branch (nilrt/master/6.1).

### Testing

- `bitbake packagegroup-ni-next-kernel`
- `opkg install packagegroup-ni-next-kernel` from local feed on a cRIO-9042 and verified it boots correctly
- verified all out-of-tree modules are versioned correctly with the exception of `ni-si514` which has a known open bug# 2364501

### Important Note

Pull only after openembedded-core PR https://github.com/ni/openembedded-core/pull/94 is merged.