### PR TITLE
nilrt-grub-runmode: Add ptest

### DIFF
--- a/recipes-bsp/grub/grub/ptest-format.sh
+++ b/recipes-bsp/grub/grub/ptest-format.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Version 1.3
+# Utility script containing common functions for ptest-compatible test scripts.
+# USAGE:
+# 1) Source this file at the top of your ptest script.
+# 2) Set ptest_test to the name of your test; recommended:
+#    $(basename -s ".sh" "$0")
+# 3) Define your subtests in functions, which call ptest_pass when they pass and
+#    ptest_fail otherwise (FAIL is DEFAULT)
+# 4) Prior to calling your test function, call ptest_change_subtest
+# 5) Call your test function.
+# 6) Call ptest_report immediately after the function returns.
+
+exec 2>&1  # redirect all stderr to stdout to maintain ordering of output
+
+declare -irx PTEST_RC_PASS=0
+declare -irx PTEST_RC_FAIL=1
+declare -irx PTEST_RC_SKIP=77
+
+function ptest_report () {
+	local result='FAIL'
+	case $ptest_rc in
+		0)
+			result='PASS'
+			;;
+		77)
+			result='SKIP'
+			;;
+		*)
+			result='FAIL'
+			;;
+	esac
+
+	if [ "$#" -gt 0 ]; then
+		echo "$@"
+	fi
+
+	printf "${result}: %s" "${ptest_test}"
+	if [ -n "${ptest_subtest}" ]; then
+		printf " %d" "${ptest_subtest}"
+		if [ -n "${ptest_subtest_desc}" ]; then
+			printf " - %s" "${ptest_subtest_desc}"
+		fi
+	fi
+	printf "\n"
+}
+
+function ptest_pass () {
+	ptest_rc=0
+}
+
+function ptest_skip () {
+	ptest_rc=77
+}
+
+function ptest_fail () {
+	ptest_rc=1
+}
+
+# 1 - new test name
+# 2 - new subtest number
+# 3 - new subtest description
+function ptest_change_test () {
+	ptest_test="$1"
+	ptest_subtest="$2"
+	ptest_subtest_desc="$3"
+	ptest_fail
+}
+
+# 1 - new subtest number
+# 2 - new subtest description
+function ptest_change_subtest () {
+	ptest_subtest="$1"
+	ptest_subtest_desc="$2"
+	ptest_fail
+}
+
+ptest_test=''
+ptest_subtest=''
+ptest_subtest_desc=''
+ptest_fail  # set ptest_rc to FAIL

--- a/recipes-bsp/grub/grub/run-ptest
+++ b/recipes-bsp/grub/grub/run-ptest
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+./test-grubcfg.sh
+
+exit 0

--- a/recipes-bsp/grub/grub/test-grubcfg.sh
+++ b/recipes-bsp/grub/grub/test-grubcfg.sh
@@ -1,0 +1,35 @@
+#! /bin/bash
+
+# Test that expected kernel cmdline parameters are being passed from grub.
+
+# This ptest is intended to be run by NI's internal ATS systems.
+
+source $(dirname "$0")/ptest-format.sh
+
+function test_default_grubcfg () {
+	ptest_pass
+
+	if ! grep -q "rootwait rw usbcore.usbfs_memory_mb=0 consoleblank=0 rcu_nocbs=all mitigations=off quiet console=tty0 console=ttyS0,115200n8 sys_reset=false" /home/admin/cmdline_default.out; then
+		echo "ERROR: unexpected arguments on default kernel cmdline" >&2
+		ptest_fail
+	fi
+}
+
+function test_mitigation_on_grubcfg () {
+	ptest_pass
+
+	if ! grep -q "rootwait rw usbcore.usbfs_memory_mb=0 consoleblank=0 rcu_nocbs=all quiet console=tty0 console=ttyS0,115200n8 sys_reset=false" /home/admin/cmdline_mitigations_on.out; then
+		echo "ERROR: unexpected arguments on kernel cmdline with mitigations on" >&2
+		ptest_fail
+	fi
+}
+
+ptest_change_subtest 1 "test_default_grubcfg"
+test_default_grubcfg
+ptest_report
+
+ptest_change_subtest 2 "test_mitigation_on_grubcfg"
+test_mitigation_on_grubcfg
+ptest_report
+
+exit $ptest_rc

--- a/recipes-bsp/grub/nilrt-grub-runmode.bb
+++ b/recipes-bsp/grub/nilrt-grub-runmode.bb
@@ -9,13 +9,26 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/grub:"
 SRC_URI += " \
     file://grub-runmode-bootimage.cfg \
     file://grub.d \
+    file://run-ptest \
+    file://ptest-format.sh \
+    file://test-grubcfg.sh \
 "
+
+inherit ptest
 
 FILES:${PN}     += "/boot/runmode/bootimage.cfg /boot/runmode/bootimage.cfg.d/*.cfg /boot/runmode/cpu-mitigations.cfg"
 CONFFILES:${PN} += "/boot/runmode/bootimage.cfg /boot/runmode/bootimage.cfg.d/*.cfg /boot/runmode/cpu-mitigations.cfg"
+
+RDEPENDS:${PN}-ptest += "bash"
 
 do_install () {
 	install -d ${D}/boot/runmode
 	install -m 0644 ${WORKDIR}/grub-runmode-bootimage.cfg ${D}/boot/runmode/bootimage.cfg
 	install -m 0644 ${WORKDIR}/grub.d/cpu-mitigations.cfg ${D}/boot/runmode
+}
+
+do_install_ptest:append () {
+    install -m 0644 ${WORKDIR}/ptest-format.sh ${D}${PTEST_PATH}
+    install -m 0755 ${WORKDIR}/run-ptest       ${D}${PTEST_PATH}
+    install -m 0755 ${WORKDIR}/test-grubcfg.sh ${D}${PTEST_PATH}
 }


### PR DESCRIPTION
Add a ptest to verify that expected cmdline parameters are being passed
to kernel in default install and with mitigations on.

WI: [2232818](https://dev.azure.com/ni/DevCentral/_workitems/edit/2232818)

# Testing
- [x] Built locally
- [x] Installed ipk on a target
- [x] Created required `cmdline*.out` files on the target and ran `ptest-runner`. The test passed.

# Note
The `cmdline*.out` files used in this test are created when mobilize plan is run. Ref [PR](https://ni.visualstudio.com/DevCentral/_git/Tools/pullrequest/479885).