### PR TITLE
util-linux: Backport fix for failing ptest

### DIFF
--- a/recipes-core/util-linux/util-linux/0001-skip-btrfs-tests-if-kernel-support-for-btrfs-is-miss.patch
+++ b/recipes-core/util-linux/util-linux/0001-skip-btrfs-tests-if-kernel-support-for-btrfs-is-miss.patch
@@ -1,0 +1,25 @@
+From 8780cf56f80853910d1bba89ac551ecba62bf059 Mon Sep 17 00:00:00 2001
+From: Anatoly Pugachev <matorola@gmail.com>
+Date: Wed, 9 Nov 2022 12:00:12 +0300
+Subject: [PATCH] skip btrfs tests if kernel support for btrfs is missing
+
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/commit/?id=8b9f571d252f921dab6cfd871bd0be20c58162a2]
+
+Signed-off-by: Chaitanya Vadrevu <chaitanya.vadrevu@ni.com>
+---
+ tests/ts/mount/fstab-btrfs | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/tests/ts/mount/fstab-btrfs b/tests/ts/mount/fstab-btrfs
+index 0003b5d65..4d45d4dd5 100755
+--- a/tests/ts/mount/fstab-btrfs
++++ b/tests/ts/mount/fstab-btrfs
+@@ -51,6 +51,8 @@ DEVICE=$TS_LODEV
+ [ -d "$TS_MOUNTPOINT_BIND" ] || mkdir -p "$TS_MOUNTPOINT_BIND"
+ mkfs.btrfs -d single -m single $DEVICE &> /dev/null || ts_die "Cannot make btrfs on $DEVICE"
+ 
++btrfs device ready $DEVICE 2>/dev/null || ts_skip "btrfs kernel support is missing"
++
+ $TS_CMD_MOUNT -o loop "$DEVICE" "$TS_MOUNTPOINT_CREATE"
+ pushd . >/dev/null
+ cd "$TS_MOUNTPOINT_CREATE"

--- a/recipes-core/util-linux/util-linux_2.%.bbappend
+++ b/recipes-core/util-linux/util-linux_2.%.bbappend
@@ -1,5 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
+SRC_URI += "file://0001-skip-btrfs-tests-if-kernel-support-for-btrfs-is-miss.patch"
+
 DEPENDS:append:class-target = " shadow-native pseudo-native busybox"
 
 RDEPENDS:${PN}-hwclock:append = " niacctbase busybox-hwclock"


### PR DESCRIPTION
btrfs related ptest in util-linux-ptest package fails when kernel doesn't support btrfs. Upstream's master branch has a fix but there is no released version that contains it.

This commit backports the patch.

Work Item: [2300512](https://dev.azure.com/ni/DevCentral/_workitems/edit/2300512)

### Testing
- [x] `bitbake util-linux`
- [x] Installed `util-linux-ptest` on a target
- [x] Ran `ptest-runner`; the previously failing test is now skipped

![image](https://user-images.githubusercontent.com/8194523/236059429-06c7fbb4-e103-489e-8991-7c94cdddf4b4.png)
