### PR TITLE
[kirkstone] Build improvements for toolchains

### DIFF
--- a/recipes-core/images/includes/nilrt-image-base.inc
+++ b/recipes-core/images/includes/nilrt-image-base.inc
@@ -6,6 +6,11 @@ do_rootfs[depends] += "shadow-native:do_populate_sysroot"
 # kernel recipe requires depmodwrapper to populate modules.dep
 do_rootfs[depends] += "depmodwrapper-cross:do_populate_sysroot"
 
+# Build package index before trying to build rootfs
+do_rootfs[depends] += "${@oe.utils.conditional('BUILD_IMAGES_FROM_FEEDS', '1', 'package-index:do_package_index', '', d)}"
+do_package_index[nostamp] = "1"
+do_package_index[depends] += "${PACKAGEINDEXDEPS}"
+
 # without package-management update-rc.d gets removed from image
 IMAGE_FEATURES += "package-management"
 

--- a/recipes-core/images/includes/nilrt-image-base.inc
+++ b/recipes-core/images/includes/nilrt-image-base.inc
@@ -11,12 +11,24 @@ do_rootfs[depends] += "${@oe.utils.conditional('BUILD_IMAGES_FROM_FEEDS', '1', '
 do_package_index[nostamp] = "1"
 do_package_index[depends] += "${PACKAGEINDEXDEPS}"
 
+# Normally no package index is created for the following DUMMYARCH but
+# we need one for building SDKs from feeds.
+PACKAGE_ARCHS:append:task-package-index = " sdk-provides-dummy-target"
+SDK_PACKAGE_ARCHS:append:task-package-index = " sdk-provides-dummy-${SDKPKGSUFFIX}"
+
 # without package-management update-rc.d gets removed from image
 IMAGE_FEATURES += "package-management"
 
 IMAGE_INSTALL += "\
 	packagegroup-ni-base \
 	packagegroup-ni-tzdata \
+"
+
+# Add the package sources needed when building the SDK
+IPK_FEED_URIS:append:task-populate-sdk = "\
+    NIOE-dummy-sdk##${NILRT_LOCAL_FEED_URI}/sdk-provides-dummy-target \
+    NIOE-nativesdk##${NILRT_LOCAL_FEED_URI}/${SDK_ARCH}-${SDKPKGSUFFIX} \
+    NIOE-dummy-nativesdk##${NILRT_LOCAL_FEED_URI}/sdk-provides-dummy-${SDKPKGSUFFIX} \
 "
 
 addtask image_build_test before do_rootfs

--- a/recipes-core/meta/meta-toolchain.bbappend
+++ b/recipes-core/meta/meta-toolchain.bbappend
@@ -2,3 +2,10 @@
 # /usr/local/oe-sdk-hardcoded-buildpath, so avoid causing errors for
 # outgoing symlinks that are there by design.
 CHECK_SDK_SYSROOTS = "0"
+
+# Add the package sources needed when building the SDK with BUILD_IMAGES_FROM_FEEDS
+IPK_FEED_URIS:append:task-populate-sdk = "${@oe.utils.conditional('BUILD_IMAGES_FROM_FEEDS', '1', '\
+    NIOE-dummy-sdk##${NILRT_LOCAL_FEED_URI}/sdk-provides-dummy-target \
+    NIOE-nativesdk##${NILRT_LOCAL_FEED_URI}/${SDK_ARCH}-${SDKPKGSUFFIX} \
+    NIOE-dummy-nativesdk##${NILRT_LOCAL_FEED_URI}/sdk-provides-dummy-${SDKPKGSUFFIX} \
+', '', d)}"

--- a/recipes-core/meta/package-index.bbappend
+++ b/recipes-core/meta/package-index.bbappend
@@ -1,0 +1,4 @@
+# Normally no package index is created for the following DUMMYARCH but
+# we need one for building SDKs and meta-toolchain from feeds.
+PACKAGE_ARCHS:append = " sdk-provides-dummy-target"
+SDK_PACKAGE_ARCHS:append = " sdk-provides-dummy-${SDKPKGSUFFIX}"


### PR DESCRIPTION
Build improvements including:
- Update `package-index` before image `do_rootfs` for our images, enabling possibility to directly `bitbake nilrt-base-system-image` without prior steps of `package-index` or `packagefeed-ni-core` builds.
- Ensure SDK packages are included in `package-index` builds
- Ensure SDK feed locations are included in `IPK_FEED_URIS` when building SDKs or `meta-toolchain`

Additional Comments:
- I wanted to get nativesdk-* packages added to the toolchain and working for opkg, cmake, and ninja but ran into issues. I don't think these are insurmountable and they should work on Linux toolchain builds. 
   - opkg won't build for mingw32 because of libpcap issues
   - CMake freaks out at Windows file paths in the format the mingw32 toolchain build populates them
   - Didn't try Ninja, but kind of pointless without CMake in there too.

## Testing:
Builds. Lots of builds. 
- From scratch (no build directory)
- In the expected ways (e.g., how our build infrastructure does it now)
- Partial builds
- Package index builds
I highly recommend someone else pulling my branch and doing some testing.