### PR TITLE
[kirkstone] packagegroups: Update packagefeeds to inherit new class.

### DIFF
--- a/recipes-core/packagegroups/packagefeed-ni-core.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-core.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Package feed which contains all packages which are supported by NI."
 LICENSE = "MIT"
 
-inherit packagegroup
+inherit packagefeed
 
 RDEPENDS:${PN} = "\
 	packagegroup-base \

--- a/recipes-core/packagegroups/packagefeed-ni-extra.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-extra.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Package feed of potentially useful, but unsupported, packages for NI Linux RT"
 LICENSE = "MIT"
 
-inherit packagegroup
+inherit packagefeed
 
 # These packages are only built for the nilrt-xfce fork of the older NILRT distro
 # as opposed to nilrt-nxg which always enables x11 support. Also only for x64


### PR DESCRIPTION
There's now a packagefeed class which will ensure package indices are built automatically. Update our packagefeed-* packagegroups to inherit from this instead.

**Note:** Do not pull this until https://github.com/ni/openembedded-core/pull/96 is submitted as this will not work until then.

## Testing:
Built locally.