### PR TITLE
linux-nilrt-next: bump version to latest 6.1 development branch

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-next_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-next_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NILRT linux kernel next development build"
 NI_RELEASE_VERSION = "master"
-LINUX_VERSION = "6.0"
+LINUX_VERSION = "6.1"
 LINUX_KERNEL_TYPE = "next"
 
 require linux-nilrt-alternate.inc


### PR DESCRIPTION
Update our 'next' kernel recipe (linux-nilrt-next) to point to the latest 6.1 kernel branch (nilrt/master/6.1).

### Testing
- [x] bitbake packagegroup-ni-next-kernel
- [x] opkg install packagegroup-ni-next-kernel from local feed on a cRIO-9034 and verified it boots correctly
- [x] verified that `nikal`, `nibds`, `ni-si514` (from custom ipk with a fix that's not in feeds) could be installed and was versioned correctly.