### PR TITLE
[nilrt/23.5/hardknott] linux: Set NI_RELEASE_VERSION to 23.5

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-debug_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-debug_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "NILRT linux kernel debug build"
-NI_RELEASE_VERSION = "master"
+NI_RELEASE_VERSION = "23.5"
 LINUX_VERSION = "5.15"
 LINUX_VERSION:xilinx-zynq = "4.14"
 LINUX_KERNEL_TYPE = "debug"

--- a/recipes-kernel/linux/linux-nilrt-next_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-next_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "NILRT linux kernel next development build"
-NI_RELEASE_VERSION = "master"
+NI_RELEASE_VERSION = "23.5"
 LINUX_VERSION = "6.1"
 LINUX_KERNEL_TYPE = "next"
 

--- a/recipes-kernel/linux/linux-nilrt-nohz_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-nohz_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "NILRT linux kernel full dynamic ticks (NO_HZ_FULL) build"
-NI_RELEASE_VERSION = "master"
+NI_RELEASE_VERSION = "23.5"
 LINUX_VERSION = "5.15"
 LINUX_KERNEL_TYPE = "nohz"
 

--- a/recipes-kernel/linux/linux-nilrt_git.bb
+++ b/recipes-kernel/linux/linux-nilrt_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "Linux kernel based on nilrt branch"
-NI_RELEASE_VERSION = "master"
+NI_RELEASE_VERSION = "23.5"
 LINUX_VERSION = "5.15"
 LINUX_VERSION:xilinx-zynq = "4.14"
 


### PR DESCRIPTION
Versioned branches have been created in ni/linux for 5.15 and 6.1, so this ensures that we're using those release branches in the recipes rather than the master branches. As with the last couple times (#551, #509), there's no special handling for zynq's 4.14 kernel (see #464).

[AB#2308603](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2308603)