### PR TITLE
[kirkstone] gnupg: Ignore incorrect flagging of CVE-2022-3515.

### DIFF
--- a/recipes-support/gnupg/gnupg_2.3.%.bbappend
+++ b/recipes-support/gnupg/gnupg_2.3.%.bbappend
@@ -1,0 +1,5 @@
+# libksba has already been upgraded to version 1.6.3 in openembedded-core.
+# However, this CVE is still getting flagged as other configurations call
+# out gnupg 2.3.0 (inclusive) - 2.4.0 (exclusive). Upstream has already
+# bumped gnupg in master so let's just ignore the CVE here.
+CVE_CHECK_IGNORE:append = " CVE-2022-3515"


### PR DESCRIPTION
The fix for CVE-2022-3515 is already in the updated version of libksba. gnupg is incorrectly being flagged as still having the issue because one of the CVE database configs for the issue include gnupg versions >= 2.3.0 and < 2.4.0. The recipes in upstream OpenEmbedded-Core have already bumped to 2.4.2, so this is only an issue for kirkstone. To avoid pulling unecessary upgrades, just ignore the CVE for now.

[AB#2408709](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2408709)

## Testing:
Built locally and confirmed the cve was no longer flagged.