### PR TITLE
kernel-performance-tests: Read iperf info from external file

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/iperf.cfg
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/iperf.cfg
@@ -1,4 +1,0 @@
-# Server configuration for iperf test
-#
-IPERF_SERVER=CATS-iperf-1.ni.systems
-IPERF_PORT=6003

--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/test_kernel_cyclictest_iperf.sh
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/test_kernel_cyclictest_iperf.sh
@@ -2,10 +2,10 @@
 source ./run-cyclictest
 
 # start background network load
-source ./iperf.cfg
+source /home/admin/.iperf.info
 if [ -z "$IPERF_SERVER" ]; then
     echo "Warning: iperf server not configured; skipping iperf based network load test."
-    echo "Edit `pwd`/iperf.cfg file to configure a server to connect to for this test."
+    echo "Create/edit /home/admin/.iperf.info file with IPERF_SERVER=<server> and IPERF_PORT=<port> to configure a server to connect to for this test."
     echo "SKIP: test_kernel_cyclictest_iperf"
     exit 77
 fi

--- a/recipes-kernel/kernel-tests/kernel-performance-tests.bb
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests.bb
@@ -23,7 +23,6 @@ SRC_URI += "\
     file://upload_cyclictest_results.py \
     file://common.cfg \
     file://fio.cfg \
-    file://iperf.cfg \
     file://test_kernel_cyclictest_idle.sh \
     file://test_kernel_cyclictest_hackbench.sh \
     file://test_kernel_cyclictest_fio.sh \
@@ -36,7 +35,6 @@ do_install_ptest:append() {
     install -m 0755 ${S}/upload_cyclictest_results.py ${D}${PTEST_PATH}
     install -m 0644 ${S}/common.cfg ${D}${PTEST_PATH}
     install -m 0644 ${S}/fio.cfg ${D}${PTEST_PATH}
-    install -m 0644 ${S}/iperf.cfg ${D}${PTEST_PATH}
     install -m 0755 ${S}/test_kernel_cyclictest_idle.sh ${D}${PTEST_PATH}
     install -m 0755 ${S}/test_kernel_cyclictest_hackbench.sh ${D}${PTEST_PATH}
     install -m 0755 ${S}/test_kernel_cyclictest_fio.sh ${D}${PTEST_PATH}


### PR DESCRIPTION
Read iperf connection info from an external file on the target rather than a static file in the ptest package. This matches how we already handle influxdb connection info.