### PR TITLE
[kirkstone] nilrt.conf: Set release version for 23Q4

### DIFF
--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -4,7 +4,7 @@ DISTRO_VERSION = "10.0"
 
 DISTRO_CODENAME = "${LAYERSERIES_COMPAT_meta-nilrt}"
 
-NILRT_FEED_NAME ?= "next/2023Q3"
+NILRT_FEED_NAME ?= "next/2023Q4"
 
 DISTRO_FEATURES:append:x64 = "\
         x11 \


### PR DESCRIPTION
Bumping feed for next release.

[AB#2308609](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2308609)