### PR TITLE
linux-nilrt: Update kernel hash

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-debug_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-debug_git.bb
@@ -13,8 +13,8 @@ SRC_URI += "\
 
 # This is the place to overwrite the source AUTOREV from linux-nilrt.inc, if
 # the kernel recipe requires a particular ref.
-SRCREV_xilinx-zynq = "4442d176ee60b472252436950058a85fce08a3a3"
-SRCREV_qemu-zynq7 = "4442d176ee60b472252436950058a85fce08a3a3"
+SRCREV_xilinx-zynq = "e167d2ccda8e812cd7aa99fefc59269c854952ce"
+SRCREV_qemu-zynq7 = "e167d2ccda8e812cd7aa99fefc59269c854952ce"
 
 # Move vmlinux-${KERNEL_VERSION_NAME} from /boot to /lib/modules/${KERNEL_VERSION}/build/
 # to avoid filling the /boot partition.

--- a/recipes-kernel/linux/linux-nilrt_git.bb
+++ b/recipes-kernel/linux/linux-nilrt_git.bb
@@ -8,5 +8,5 @@ require linux-nilrt.inc
 
 # This is the place to overwrite the source AUTOREV from linux-nilrt.inc, if
 # the kernel recipe requires a particular ref.
-SRCREV_xilinx-zynq = "4442d176ee60b472252436950058a85fce08a3a3"
-SRCREV_qemu-zynq7 = "4442d176ee60b472252436950058a85fce08a3a3"
+SRCREV_xilinx-zynq = "e167d2ccda8e812cd7aa99fefc59269c854952ce"
+SRCREV_qemu-zynq7 = "e167d2ccda8e812cd7aa99fefc59269c854952ce"


### PR DESCRIPTION
Edited the config for zynq_nati_defconfig. Point at the new hash