### PR TITLE
udev: Don't start ifplugd on socketcan interfaces

### DIFF
--- a/recipes-core/udev/udev-extraconf/hotplug.script
+++ b/recipes-core/udev/udev-extraconf/hotplug.script
@@ -14,6 +14,7 @@ if [ "$SUBSYSTEM" == "net" ]; then
   # we do not need to run ifplugd on it
   # Also we should not run ifplugd on VPN interfaces or loopback
   case $interface in
+    can[0-9].*) exit 0 ;;
     mon.*) exit 0 ;;
     tapvpn[0-9]*) exit 0 ;;
     lo) exit 0 ;;


### PR DESCRIPTION
socketcan devices don't work with DHCP, so stop trying to start up the daemon on those interfaces.