### PR TITLE
linux-nilrt-debug/nohz: Update verison to 6.1

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-debug_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-debug_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NILRT linux kernel debug build"
 NI_RELEASE_VERSION = "master"
-LINUX_VERSION = "5.15"
+LINUX_VERSION = "6.1"
 LINUX_VERSION:xilinx-zynq = "4.14"
 LINUX_KERNEL_TYPE = "debug"
 

--- a/recipes-kernel/linux/linux-nilrt-nohz_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-nohz_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NILRT linux kernel full dynamic ticks (NO_HZ_FULL) build"
 NI_RELEASE_VERSION = "master"
-LINUX_VERSION = "5.15"
+LINUX_VERSION = "6.1"
 LINUX_KERNEL_TYPE = "nohz"
 
 require linux-nilrt-alternate.inc


### PR DESCRIPTION
WI: [2302209](https://dev.azure.com/ni/DevCentral/_workitems/edit/2302209)

### Testing
- [x] `bitbake packagegroup-ni-debug-kernel`
- [x] `bitbake packagegroup-ni-nohz-kernel`
- [x] debug kernel installable on a VM, cRIO-9034, PXIe-8861
- [x] nohz kernel installable on a VM, cRIO-9034, PXIe-8861