### PR TITLE
layer.conf: Increase BBFILE_PRIORITY to 25

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -7,6 +7,6 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "meta-nilrt"
 BBFILE_PATTERN_meta-nilrt = "^${LAYERDIR}/"
-BBFILE_PRIORITY_meta-nilrt = "15"
+BBFILE_PRIORITY_meta-nilrt = "25"
 
 LAYERSERIES_COMPAT_meta-nilrt = "kirkstone"


### PR DESCRIPTION
`meta-nilrt`'s BBFILE_PRIORITY needs to be higher than all other layers.
Since `meta-qt5-extra` is at 20, increase `meta-nilrt` to 25.

### Testing
- [x] `bitbake-layers show-layers` shows `meta-nilrt` is now at 25.
- [x] `bitbake packagefeed-ni-core` and `bitbake nilrt-base-system-image`
- [x] Installed BSI on a VM