### PR TITLE
packagegroup-ni-desirable: Add ruby

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-desirable.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-desirable.bb
@@ -58,3 +58,8 @@ RDEPENDS:${PN}:append += "\
 RDEPENDS:${PN}:append:x64 += "\
 	kernel-test-nohz \
 "
+
+# Ruby: Used by setupscripts for pre-installer testing
+RDEPENDS:${PN}:append:x64 = "\
+	ruby \
+"


### PR DESCRIPTION
ruby is used by some internal teams for testing.

WI: [2459411](https://dev.azure.com/ni/DevCentral/_workitems/edit/2459411)

### Testing
- [x] `build.extra-feeds.sh -d` (i.e., built desirable package subset from extras feed)
- [x] Verified `ruby` is present in feed