### PR TITLE
[kirkstone] packagegroup-ni-internal-deps: Add lz4 package as dep

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
@@ -53,3 +53,11 @@ RDEPENDS:${PN}:append:x64 = "\
 RDEPENDS:${PN} += "\
 	libxml-parser-perl \
 "
+
+# Required for a mobilize step that installs a specific Python version 
+# and requires building Python on the test system
+# Contact: ulf.glaeser@ni.com
+# Team: DAQ.SW.Ops@ni.com
+RDEPENDS:${PN} += "\
+	lz4 \
+"


### PR DESCRIPTION
Adding the lz4 package as a required package so that it is included in the core feed. There is an internal ATS step that builds python on the target and lz4-dev is required to do so.

[AB#2458968](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2458968)

## Testing:
Build packagefeed-ni-core and confirmed it built without errors. Confirmed the lz4-dev package is present. 