### PR TITLE
Move ruby from ni-desirable to ni-internal-deps

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-desirable.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-desirable.bb
@@ -58,8 +58,3 @@ RDEPENDS:${PN}:append += "\
 RDEPENDS:${PN}:append:x64 += "\
 	kernel-test-nohz \
 "
-
-# Ruby: Used by setupscripts for pre-installer testing
-RDEPENDS:${PN}:append:x64 = "\
-	ruby \
-"

--- a/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
@@ -61,3 +61,9 @@ RDEPENDS:${PN} += "\
 RDEPENDS:${PN} += "\
 	lz4 \
 "
+
+# Required by nisetupscripts for pre-installer testing
+# Contact: Zach Hindes <zach.hindes@ni.com>
+RDEPENDS:${PN}:append:x64 = "\
+	ruby \
+"


### PR DESCRIPTION
Move ruby from ni-desirable to ni-internal-deps
Also added technical contact.

WI: [2459411](https://dev.azure.com/ni/DevCentral/_workitems/edit/2459411)

### Testing
- [x] `bitbake packagefeed-ni-core`
- [x] `ruby` is present in feed