### PR TITLE
[kirkstone] ni-test-boot-time: fix build warnings

### DIFF
--- a/recipes-ni/ni-test-boot-time/ni-test-boot-time.bb
+++ b/recipes-ni/ni-test-boot-time/ni-test-boot-time.bb
@@ -3,8 +3,6 @@ SECTION = "tests"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
-
 DEPENDS += "update-rc.d-native"
 
 

--- a/recipes-ni/ni-test-boot-time/ni-test-boot-time.bb
+++ b/recipes-ni/ni-test-boot-time/ni-test-boot-time.bb
@@ -13,8 +13,8 @@ ALLOW_EMPTY:${PN} = "1"
 
 DEPENDS += "update-rc.d-native"
 RDEPENDS:${PN}-ptest += "bash gawk python3 python3-pip python3-requests"
-RDEPENDS:${PN}-ptest:append:x64 += "fw-printenv"
-RDEPENDS:${PN}-ptest:append:armv7a += "u-boot-fw-utils"
+RDEPENDS:${PN}-ptest:append:x64 = " fw-printenv"
+RDEPENDS:${PN}-ptest:append:armv7a = " u-boot-fw-utils"
 
 SRC_URI = "\
 	file://run-ptest \

--- a/recipes-ni/ni-test-boot-time/ni-test-boot-time.bb
+++ b/recipes-ni/ni-test-boot-time/ni-test-boot-time.bb
@@ -3,18 +3,10 @@ SECTION = "tests"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-inherit ptest
-
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-S = "${WORKDIR}"
-
-ALLOW_EMPTY:${PN} = "1"
-
 DEPENDS += "update-rc.d-native"
-RDEPENDS:${PN}-ptest += "bash gawk python3 python3-pip python3-requests"
-RDEPENDS:${PN}-ptest:append:x64 = " fw-printenv"
-RDEPENDS:${PN}-ptest:append:armv7a = " u-boot-fw-utils"
+
 
 SRC_URI = "\
 	file://run-ptest \
@@ -22,18 +14,30 @@ SRC_URI = "\
 	file://zz-ni-record-boot-time \
 "
 
+S = "${WORKDIR}"
+
+
+inherit ptest
+
 do_install_ptest() {
-	install -m 0755 ${S}/run-ptest		${D}${PTEST_PATH}
-	install -m 0755 ${S}/upload_results.py	${D}${PTEST_PATH}
+	install -m 0755 ${S}/run-ptest ${D}${PTEST_PATH}
+	install -m 0755 ${S}/upload_results.py ${D}${PTEST_PATH}
 
 	install -d ${D}${sysconfdir}/init.d
-	install -m 0755 ${S}/zz-ni-record-boot-time	${D}${sysconfdir}/init.d
-	update-rc.d -r ${D} zz-ni-record-boot-time	start 99 4 5 .
+	install -m 0755 ${S}/zz-ni-record-boot-time ${D}${sysconfdir}/init.d
+	update-rc.d -r ${D} zz-ni-record-boot-time start 99 4 5 .
 }
 
 pkg_postinst_ontarget:${PN}-ptest:append() {
 	python3 -m pip install influxdb
 }
 
+
+ALLOW_EMPTY:${PN} = "1"
+
 # We only want to build the -ptest package
 PACKAGES:remove = "${PN}-dev ${PN}-staticdev ${PN}-dbg"
+
+RDEPENDS:${PN}-ptest += "bash gawk python3 python3-pip python3-requests"
+RDEPENDS:${PN}-ptest:append:x64 = " fw-printenv"
+RDEPENDS:${PN}-ptest:append:armv7a = " u-boot-fw-utils"


### PR DESCRIPTION
The current `ni-test-boot-time` recipe throws a few warnings in kirkstone.

```
WARNING: /home/usr0/fast/nilrt-kirkstone/sources/meta-nilrt/recipes-ni/ni-test-boot-time/ni-test-boot-time.bb: RDEPENDS:${PN}-ptest:append:x64 += is not a recommended operator combination, please replace it.
WARNING: /home/usr0/fast/nilrt-kirkstone/sources/meta-nilrt/recipes-ni/ni-test-boot-time/ni-test-boot-time.bb: RDEPENDS:${PN}-ptest:append:armv7a += is not a recommended operator combination, please replace it.
```

This patchset
* fixes the operator warnings above.
* re-styles the recipe to better-fit with the layer styleguide.
* removes the unnecessary `FILESEXTRAPATHS` assignment.

# Testing
* [x] Compared the bitbake environments of the `ni-test-boot-time` recipe before and after the operator change. Confirmed that the affected variables end with the same values.
* [x] Confirmed that the recipe still builds after this patchset and that the IPK contents are the same.