### PR TITLE
[kirkstone] Add aim-arinc deps to core feed

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-desirable.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-desirable.bb
@@ -52,10 +52,10 @@ RDEPENDS:${PN} += "\
 "
 
 # Testing packages
-RDEPENDS:${PN}:append += "\
+RDEPENDS:${PN} += "\
 	kernel-performance-tests \
 	ni-base-system-image-tests \
 "
-RDEPENDS:${PN}:append:x64 += "\
+RDEPENDS:${PN}:append:x64 = "\
 	kernel-test-nohz \
 "

--- a/recipes-core/packagegroups/packagegroup-ni-desirable.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-desirable.bb
@@ -6,6 +6,7 @@ inherit packagegroup
 
 # essential packagegroups
 RDEPENDS:${PN} += "\
+	packagegroup-core-buildessential \
 	packagegroup-core-tools-debug \
 	packagegroup-ni-debug-kernel \
 	packagegroup-ni-selinux \

--- a/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
@@ -1,7 +1,13 @@
 SUMMARY = "Open-source package dependencies of NI proprietary and internal products."
 LICENSE = "MIT"
 
+# Packagegroups which include recipes that dynamically rename their packages -
+# like libxkbcommon - may not use allarch.
+# https://www.mail-archive.com/openembedded-core@lists.openembedded.org/msg155223.html
+PACKAGE_ARCH = "${TUNE_PKGARCH}"
+
 inherit packagegroup
+
 
 # NI-RFSA/G
 # Contact: Dharaniprakash Kurdimath <dharaniprakash.kurdimath@ni.com>

--- a/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
@@ -73,3 +73,17 @@ RDEPENDS:${PN} += "\
 RDEPENDS:${PN}:append:x64 = "\
 	ruby \
 "
+
+# Required by aim-arinc-429
+# Maintainer: AIM GmbH
+# Contact: Karl Grosz
+RDEPENDS:${PN} += "\
+	coreutils \
+	g++ \
+	g++-symlinks \
+	gcc \
+	glibc \
+	libnl \
+	make \
+	pkgconfig \
+"


### PR DESCRIPTION
The `aim-arinc429*` third-party contributor package depends on some build tooling packages which are normally not distributed with the core feed. If the extras/ feed is not available at install-time, `aim-arinc` package will fail to install.

[NI AZDO 2461174](https://dev.azure.com/ni/DevCentral/_boards/board/t/RTOS/Work%20Items/?workitem=2461174)

This patchset declares the `aim-arinc` dependencies in `packagegroup-ni-internal-deps`, so that they are always built into the core feed. Additionally, it adds `packagegroup-core-buildessential` to the desirables packagegroup - to ensure that we at least fail the build, if some of these core build tooling packages are not built.

Incidentally, this patchset also fixes a couple assignment-operator warnings that bitbake throws about the -desirable packagegroup.

# Testing
* [x] Built `packagegroup-ni-internal-deps` after this patchset and confirmed that `aim-arinc`'s dependencies are now in the package feed.