### PR TITLE
linux-nilrt: Upgrade to 6.1 kernel

### DIFF
--- a/recipes-kernel/linux/linux-nilrt_git.bb
+++ b/recipes-kernel/linux/linux-nilrt_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Linux kernel based on nilrt branch"
 NI_RELEASE_VERSION = "master"
-LINUX_VERSION = "5.15"
+LINUX_VERSION = "6.1"
 LINUX_VERSION:xilinx-zynq = "4.14"
 
 require linux-nilrt.inc


### PR DESCRIPTION
It's time to upgrade the current kernel to the next kernel.

Testing:
 - [x] locally built kernel
 - [x] locally built safemode and runmode image
   - [x] deployed these to a VM, verified expected output from `uname -r`

This testing is not too deep, since we've already been testing kernel-next for a while now.

[AB#2302208](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2302208)