### PR TITLE
[kirkstone] pkggrp-ni-internal-deps: add PXIPS ATS deps

### DIFF
--- a/recipes-core/packagegroups/packagefeed-ni-extra.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-extra.bb
@@ -232,7 +232,6 @@ RDEPENDS:${PN} += "\
 	iperf2 \
 	iperf3 \
 	lmbench \
-	memtester \
 	nbench-byte \
 	phoronix-test-suite \
 	tiobench \

--- a/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
@@ -87,3 +87,10 @@ RDEPENDS:${PN} += "\
 	make \
 	pkgconfig \
 "
+
+# Required by PXIPS ATS events
+# Team: PXI PS
+# Contact: Kevin Khai-Wern Lim
+RDEPENDS:${PN} += "\
+	memtester \
+"


### PR DESCRIPTION
Per [NI AZDO 2463687](https://dev.azure.com/ni/DevCentral/_boards/board/t/RTOS/Work%20Items/?workitem=2463687), the PXI PS ATS depends on the `memtester` package.

Express this dependency in the internal-deps packagegroup, to ensure that it is built and included in the core feed.

# Testing
* [x] Built `packagegroup-ni-internal-deps` with this change; validated that `memtester` is built as a dependency.