### PR TITLE
Make fs permissions diff test more consistent

### DIFF
--- a/recipes-ni/ni-base-system-image-tests/files/fs_permissions_diff.py
+++ b/recipes-ni/ni-base-system-image-tests/files/fs_permissions_diff.py
@@ -157,7 +157,7 @@ def get_old_fs_manifests(db, logger):
     recent_manifest, recent_version = run_query('recent', query_build(os_version.build))
 
     # Keep this log in first line to help streak indexer group results. Overall hash will be populated at end.
-    logger.prefix_log(f'INFO: fs_permissions_diff: {os_version.full} against {basis_version} ')
+    logger.prefix_log(f'INFO: fs_permissions_diff: current against {basis_version} ')
     # Keep this log in second line to avoid using it for grouping, but keep it for tracking.
     # Individual hashes to be populated at end.
     logger.prefix_log(f'INFO:   and {recent_version} ')

--- a/recipes-ni/ni-base-system-image-tests/files/fs_permissions_diff.py
+++ b/recipes-ni/ni-base-system-image-tests/files/fs_permissions_diff.py
@@ -70,7 +70,7 @@ def get_fs_manifest():
         + ['-printf', fs_manifest_format + '\n']
         + ['('] + omit_expr + [')', '-prune']
     )
-    return fs_manifest
+    return '\n'.join(sorted(fs_manifest.splitlines()))
 
 def log_version_info(logger, label, codename, full_version, date, db_id):
     logger.log(f'INFO: {label} = {codename} {full_version} from {date} with _id {db_id}')


### PR DESCRIPTION
We've noticed in [AB#2467793](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2467793) that the hashes of the manifests differ even with equivalent content, and after a bit of debugging, it appears that this is because `find` does not reliably produce the same ordering of files. This change sorts the manifest to make it consistent run-to-run.

Also, removed the version from the first line of the log so that review queue can more easily determine whether two runs are identical failures.

## Testing
Ran on a NILRT VM and verified that the manifest uploaded to MongoDB was sorted.