### PR TITLE
kernel-tests: Add patterns for ethernet port ordering variation

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-tests-files/kernel_dmesg_diff.py
+++ b/recipes-kernel/kernel-tests/kernel-tests-files/kernel_dmesg_diff.py
@@ -181,7 +181,9 @@ replacement_patterns = [
         [r'NODE_DATA\(0\) allocated \[mem .*\]', 'NODE_DATA(0) allocated [mem ]'],
         [r'ACPI: SSDT 0x.*', 'ACPI: SSDT 0x'],
         [r'tsc: Refined TSC clocksource calibration: \d+.\d+ MHz', 'tsc: Refined TSC clocksource calibration: MHz'],
-        [r'software IO TLB: mapped mem .*', 'software IO TLB: mapped mem']
+        [r'software IO TLB: mapped mem .*', 'software IO TLB: mapped mem'],
+        [r'eth\d:', 'ethX:'],
+        [r'renamed from eth\d', 'renamed from ethX']
 ]
 
 def strip_known_differences(log):


### PR DESCRIPTION
PXI targets have a known behavior where they do not enumerate ethernet ports in a well-defined order. Further, we have a feature in NILRT to provide stable interface names even when this happens. A side effect of all this is that some dmesg content can vary slightly from boot to boot after installing a system image.

This variation in dmesg content is innocuous, but is being flagged by our test_kernel_dmesg_diff test as a failure.

[AB#2469132](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2469132)