### PR TITLE
[kirkstone] pkggrp-ni-internal-deps: add libpcap for AIM aric664

### DIFF
--- a/recipes-core/packagegroups/packagefeed-ni-extra.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-extra.bb
@@ -70,7 +70,6 @@ RDEPENDS:${PN} += "\
 	avahi \
 	bind \
 	cifs-utils \
-	libpcap \
 	ofono \
 	ppp \
 	ppp-dialin \

--- a/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
@@ -94,3 +94,10 @@ RDEPENDS:${PN} += "\
 RDEPENDS:${PN} += "\
 	memtester \
 "
+
+# Required by aim-arinc-664
+# Maintainer: AIM GmbH
+# Contact: Michael Tillerson <michael.tillerson@ni.com>
+RDEPENDS:${PN} += "\
+	libpcap \
+"


### PR DESCRIPTION
NI is going to resell a 3rd party hardware from [AIM](https://www.aim-online.com/) and libpcap is needed by systems R&D as part of the Veristand Custom Device to support that hardware. To allow offline installation of the driver, libpcap has to be part of the feeds that are part of the [NI LinuxRT Offline installation support](https://www.ni.com/en/support/downloads/software-products/download.ni-linux-real-time-offline-installation-support.html#487410)

## Testing

I haven't had the chance to test it as it's hard to setup (or I don't have the right documentation) a build toolchain on my end.