### PR TITLE
[kirkstone] onboard: RDEPEND upon dconf

### DIFF
--- a/recipes-support/onboard/onboard_%.bbappend
+++ b/recipes-support/onboard/onboard_%.bbappend
@@ -32,6 +32,7 @@ CONFFILES:${PN}:append := " \
 	${sysconfdir}/dconf/db/local.d/01-gnome-accessibility \
 "
 
+RDEPENDS:${PN}:append = " dconf"
 # Onboard uses unicode glyphs in its key_defs.xml file, which means
 # we need a font that has those glyphs present.
 RDEPENDS:${PN}:append = " ttf-dejavu-sans"

--- a/recipes-support/onboard/onboard_%.bbappend
+++ b/recipes-support/onboard/onboard_%.bbappend
@@ -1,19 +1,14 @@
-# Onboard uses unicode glyphs in its key_defs.xml file, which means
-# we need a font that has those glyphs present.
-RDEPENDS:${PN}:append = " ttf-dejavu-sans"
-
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-SRC_URI += "file://0001-add-xfce-to-autostart-onlyshowin.patch \
-            file://01-gnome-accessibility \
-            file://NI.colors \
-            file://NI.theme \
-            file://onboard-defaults.conf \
+
+SRC_URI += " \
+	file://0001-add-xfce-to-autostart-onlyshowin.patch \
+	file://01-gnome-accessibility \
+	file://NI.colors \
+	file://NI.theme \
+	file://onboard-defaults.conf \
 "
 
-CONFFILES:${PN}:append := " ${sysconfdir}/onboard/onboard-defaults.conf \
-                            ${sysconfdir}/dconf/db/local.d/01-gnome-accessibility \
-"
 
 do_install:append () {
 	install -d ${D}${sysconfdir}/dconf/db/local.d
@@ -30,3 +25,13 @@ do_install:append () {
 pkg_postinst:${PN} () {
 	dconf update
 }
+
+
+CONFFILES:${PN}:append := " \
+	${sysconfdir}/onboard/onboard-defaults.conf \
+	${sysconfdir}/dconf/db/local.d/01-gnome-accessibility \
+"
+
+# Onboard uses unicode glyphs in its key_defs.xml file, which means
+# we need a font that has those glyphs present.
+RDEPENDS:${PN}:append = " ttf-dejavu-sans"


### PR DESCRIPTION
Trying to install `onboard` to the kirkstone images will currently throw an error during postinst, where the shell cannot find `dconf` in the system PATH.

```bash
opkg install onboard
...
Configuring onboard.
//var/lib/opkg/info/onboard.postinst: line 2: dconf: command not found
 * pkg_run_script: package "onboard" postinst script returned status 127.
 * opkg_configure: onboard.postinst returned 127.
```

Trivially, this is because the onboard postinst uses `dconf`, but does not depend upon it. Add an RDEPENDS between the two to resolve the issue.

NI AZDO: https://dev.azure.com/ni/DevCentral/_workitems/edit/2478280

# Testing
* [x] Manually installing `dconf` on a test machine successfully resolves the postinst error.
* [x] `RDEPENDS:onboard` now looks like the following.
    ```
    RDEPENDS:onboard="      ncurses     python3-dbus     python3-pycairo     python3-pygobject  python3-core dconf ttf-dejavu-sans glib-2.0-utils"
    ```
* [x] Rebuilt `onboard` recipe with these changes.