### PR TITLE
Create test to ensure we don't unusually increase size of BSI

### DIFF
--- a/recipes-ni/ni-base-system-image-tests/files/disk_size.py
+++ b/recipes-ni/ni-base-system-image-tests/files/disk_size.py
@@ -1,0 +1,82 @@
+import datetime
+import subprocess
+import os
+import argparse
+import sys
+import logging
+
+logging.basicConfig(level = logging.INFO)
+
+TEST_DESC = 'Test to see that the file size of the base system image is not getting too large.'
+
+# Filled in with CLI args
+X86_MAX_SIZE_EOY = -1
+ARM_MAX_SIZE_EOY = -1
+
+def get_max_size():
+    arch = run_cmd([ 'uname', '-m' ]).strip()
+    if arch == 'x86_64':
+        return X86_MAX_SIZE_EOY
+    elif arch == 'arm':
+        return ARM_MAX_SIZE_EOY
+    else:
+        logging.error(f'ERROR: Failed to get size limit! Unknown architecture: "{arch}"')
+        return -1
+
+def run_cmd(cmd):
+    output = subprocess.run(cmd, check = False, capture_output = True)
+    return output.stdout.decode('utf-8')
+
+def du_path(path):
+    du_result = run_cmd([ 'du', '-hs', '-BM', path ]) # Format: "####M      /"
+    size_str = du_result.split('\t')[0].strip()[:-1]
+    return int(size_str)
+
+def get_disk_used():
+    root_size = du_path('/')
+    boot_size = du_path('/boot')
+    return root_size + boot_size
+
+def test_disk_size():
+    logging.info('###### Testing install size against estimated max growth')
+    
+    size_limit = get_max_size()
+    logging.info(f'Size Limit: {size_limit}')
+
+    actual_size = get_disk_used()
+    logging.info(f'Actual Size: {actual_size}')
+
+    success = actual_size < size_limit
+
+    logging.info('###### Finished testing install size')
+    return success
+
+def parse_args():
+    parser = argparse.ArgumentParser(description = TEST_DESC)
+    parser.add_argument(
+        '--x86_max_size', required = True, type = int,
+        help = 'Current size limit for x86 devices'
+    )
+    parser.add_argument(
+        '--arm_max_size', required = True, type = int,
+        help = 'Current size limit for ARM devices'
+    )
+    return parser.parse_args()
+
+def main():
+    global X86_MAX_SIZE_EOY
+    global ARM_MAX_SIZE_EOY
+    args = parse_args()
+    X86_MAX_SIZE_EOY = args.x86_max_size
+    ARM_MAX_SIZE_EOY = args.arm_max_size
+
+    result = test_disk_size()
+
+    if result:
+        sys.exit(os.EX_OK)
+    else:
+        sys.exit(os.EX_SOFTWARE)
+
+if __name__ == '__main__':
+    main()
+

--- a/recipes-ni/ni-base-system-image-tests/files/run-ptest
+++ b/recipes-ni/ni-base-system-image-tests/files/run-ptest
@@ -2,5 +2,6 @@
 
 ./test_fs_permissions_known.sh
 ./test_fs_permissions_diff.sh
+./test_disk_size.sh
 
 exit 0

--- a/recipes-ni/ni-base-system-image-tests/files/test_disk_size.sh
+++ b/recipes-ni/ni-base-system-image-tests/files/test_disk_size.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+source $(dirname "$0")/ptest-format.sh
+
+ptest_change_test $(basename "$0" ".sh") "" "Test install size against estimated max growth"
+
+# See internal wiki for how we calculate these
+X86_MAX_SIZE_EOY=1400
+ARM_MAX_SIZE_EOY=300
+
+python3 disk_size.py --x86_max_size ${X86_MAX_SIZE_EOY} --arm_max_size ${ARM_MAX_SIZE_EOY}
+
+if [ $? -eq 0 ]; then
+   ptest_pass
+else
+   ptest_fail
+fi
+
+ptest_report
+

--- a/recipes-ni/ni-base-system-image-tests/ni-base-system-image-tests.bb
+++ b/recipes-ni/ni-base-system-image-tests/ni-base-system-image-tests.bb
@@ -16,8 +16,10 @@ SRC_URI = "\
     file://fs_permissions_shared.py \
     file://fs_permissions_diff.py \
     file://fs_permissions_known.py \
+    file://disk_size.py \
     file://test_fs_permissions_diff.sh \
     file://test_fs_permissions_known.sh \
+    file://test_disk_size.sh \
 "
 
 S = "${WORKDIR}"
@@ -29,6 +31,7 @@ do_install_ptest() {
     install -m 0644 ${WORKDIR}/fs_permissions_shared.py ${D}${PTEST_PATH}
     install -m 0644 ${WORKDIR}/fs_permissions_diff.py   ${D}${PTEST_PATH}
     install -m 0644 ${WORKDIR}/fs_permissions_known.py  ${D}${PTEST_PATH}
+    install -m 0644 ${WORKDIR}/disk_size.py             ${D}${PTEST_PATH}
     install -m 0755 ${WORKDIR}/test_*.sh                ${D}${PTEST_PATH}
     install -m 0755 ${WORKDIR}/run-ptest                ${D}${PTEST_PATH}
 }


### PR DESCRIPTION
The size of our images will likely slowly grow over time, and potentially we could increase faster than we are prepared for. We need to make sure we don't exceed the storage capacity of our smaller devices anytime soon.

Using an estimation of how fast we can grow gives us a value that can be added to our current image size to set the max amount we're allowed to exceed without intervention through 2024. This value is different for ARM (~300MB) and x86_64 (~1400MB).

I've added this test to the existing base system image tests, which run on a newly installed base system image which we can get the install size of to compare against our threshold. The failure state is simply "does the install size exceed the max-size threshold."

This has been run on a cRIO-9037 to verify the test will function.