### PR TITLE
[kirkstone] Fix broken packagefeed-ni-extra build and move trace-command to desirable. 

### DIFF
--- a/recipes-core/packagegroups/packagefeed-ni-extra.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-extra.bb
@@ -237,11 +237,6 @@ RDEPENDS:${PN} += "\
 	tiobench \
 "
 
-
-# meta-openembedded/meta-oe/recipes-bsp
-RDEPENDS:${PN} += "\
-	tbtadm \
-"
 # meta-openembedded/meta-oe/recipes-connectivity
 RDEPENDS:${PN} += "\
 	gammu \

--- a/recipes-core/packagegroups/packagefeed-ni-extra.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-extra.bb
@@ -210,7 +210,6 @@ RDEPENDS:${PN} += "\
 	oprofile \
 	powertop \
 	systemtap \
-	trace-cmd \
 "
 
 # openembedded-gore/meta/recipes-multimedia

--- a/recipes-core/packagegroups/packagegroup-ni-desirable.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-desirable.bb
@@ -47,6 +47,7 @@ RDEPENDS:${PN} += "\
 	rsync \
 	sshpass \
 	strace \
+	trace-cmd \
 	valgrind \
 	vim \
 "


### PR DESCRIPTION
This PR consists of two changes:
- Remove `tbtadm` from `packagefeed-ni-extra` as the recipes for that component in both meta-nilrt and meta-openembedded no longer exist. This was causing `packagefeed-ni-extra` to fail to build as nothing RPROVIDE'd a dependency.
- Move `trace-cmd` to `packagegroup-ni-desirable`. That tool is an extremely common debugging tool for nilrt applications and failures to build `packagefeed-ni-extra` shouldn't make it inaccessible. We also want to be certain it is never dropped.

[AB#2490709](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2490709)

## Testing:
Ran `bitbake packagefeed-ni-extra` and confirmed the build at least started. 