### PR TITLE
initscripts-nilrt: add LV RT cgroup version detection to init scripts

### DIFF
--- a/recipes-ni/initscripts-nilrt/files/lvrt-cgroup
+++ b/recipes-ni/initscripts-nilrt/files/lvrt-cgroup
@@ -1,0 +1,5 @@
+# This variable can be used to explicitly set the cgroup version used by LabVIEW
+# Real-Time cgroup related init scripts. A value of '0' leaves cgroups under OS
+# control.
+#
+# LVRT_CGROUP_VERSION=0

--- a/recipes-ni/initscripts-nilrt/files/lvrt-cgroup.sh
+++ b/recipes-ni/initscripts-nilrt/files/lvrt-cgroup.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+. /etc/default/lvrt-cgroup
+
+identify_lvrt_cgroup_version()
+{
+	# Return early if a version is already set
+	[ -z "$LVRT_CGROUP_VERSION" ] || return 0
+
+	# If lvrt is not installed set version to 0, cgroups not used
+	lvrt_installed=$(opkg list-installed ni-labview-realtime)
+	if [ -z "$lvrt_installed" ]; then
+		LVRT_CGROUP_VERSION=0
+		return 1
+	fi
+
+	# By default assume LabVIEW RT uses cgroups-v1 (current situation). This
+	# will be amended when LV cgroup-v2 upgrade is implemented.
+	LVRT_CGROUP_VERSION=1
+	return 0
+}

--- a/recipes-ni/initscripts-nilrt/files/nicreatecpuacctgroups
+++ b/recipes-ni/initscripts-nilrt/files/nicreatecpuacctgroups
@@ -1,6 +1,11 @@
 #!/bin/sh
-# Copyright (c) 2012-2013 National Instruments.
+# Copyright (c) 2012-2023 National Instruments.
 # All rights reserved.
+
+# Exit early if LabVIEW RT does not use cgroup-v1
+. /usr/share/initscripts-nilrt/lvrt-cgroup.sh
+identify_lvrt_cgroup_version || exit 0
+[ "$LVRT_CGROUP_VERSION" -eq 1 ] || exit 0
 
 #echo -n "Creating cgroups for CPU accounting for National Instruments LabVIEW Real-Time:"
 [ "${VERBOSE}" != "no" ] && echo -n "Starting nicreatecpuacctgroups:"

--- a/recipes-ni/initscripts-nilrt/files/nicreatecpusets
+++ b/recipes-ni/initscripts-nilrt/files/nicreatecpusets
@@ -1,6 +1,11 @@
 #!/bin/sh
-# Copyright (c) 2012-2013 National Instruments.
+# Copyright (c) 2012-2023 National Instruments.
 # All rights reserved.
+
+# Exit early if LabVIEW RT does not use cgroup-v1
+. /usr/share/initscripts-nilrt/lvrt-cgroup.sh
+identify_lvrt_cgroup_version || exit 0
+[ "$LVRT_CGROUP_VERSION" -eq 1 ] || exit 0
 
 #echo -n "Creating CPU sets for National Instruments LabVIEW Real-Time:"
 [ "${VERBOSE}" != "no" ] && echo -n "Starting nicreatecpusets:"

--- a/recipes-ni/initscripts-nilrt/initscripts-nilrt.bb
+++ b/recipes-ni/initscripts-nilrt/initscripts-nilrt.bb
@@ -12,6 +12,8 @@ SRC_URI = "\
 	file://cleanvarcache \
 	file://firewall \
 	file://iso3166-translation.txt \
+	file://lvrt-cgroup \
+	file://lvrt-cgroup.sh \
 	file://mountconfig \
 	file://mountdebugfs \
 	file://nicheckbiosconfig \
@@ -80,6 +82,11 @@ do_install () {
 	install -d ${D}${sysconfdir}/natinst
 	install -m 0644 ${WORKDIR}/iso3166-translation.txt ${D}${sysconfdir}/natinst
 
+	install -d ${D}${sysconfdir}/default
+	install -m 0644 lvrt-cgroup ${D}${sysconfdir}/default/lvrt-cgroup
+
+	install -d ${D}${datadir}/${BPN}
+	install -m 0755 lvrt-cgroup.sh ${D}${datadir}/${BPN}/lvrt-cgroup.sh
 }
 
 pkg_postinst_ontarget:${PN} () {


### PR DESCRIPTION
The cgroup-v1 init scripts, currently used by LabVIEW RT, interfere with other uses of cgroups (ex. containers, systemd) and are run at boot regardless if LV RT is installed or not.

Selectively run the 'nicreatecpuacctgroups' and 'nicreatecpusets' init scripts only if cgroup-v1 is in use by LabVIEW RT. Currently cgroup-v1 is considered "in use" if LabVIEW RT is installed. This will change at a future date when LV RT adds cgroup-v2 support.

Additionally the new '/etc/default/lvrt-cgroup' configuration script can be used to force set the LVRT_CGROUP_VERSION to 0 and leave cgroups under OS control for testing.

Please note that the technically better alternative to make LabVIEW RT depend and directly install these scripts (instead of including them in the base image) was rejected due to the high cost of patching previous LabVIEW releases.