### PR TITLE
Create symlink to legacy status_led location

### DIFF
--- a/recipes-ni/ni-utils/ni-utils.bb
+++ b/recipes-ni/ni-utils/ni-utils.bb
@@ -20,6 +20,7 @@ FILES:${PN} += "\
 	${sysconfdir}/init.d/nisetled \
 	${sysconfdir}/init.d/nisetprimarymac \
 	${sysconfdir}/natinst/networking/functions.common \
+	/usr/local/natinst/bin/status_led \
 "
 
 DEPENDS += "shadow-native pseudo-native niacctbase update-rc.d-native"
@@ -49,4 +50,8 @@ do_install () {
 
 	chown 0:${LVRT_GROUP} ${D}${bindir}/status_led
 	chown 0:${LVRT_GROUP} ${D}${sysconfdir}/init.d/nisetbootmode
+
+	# legacy symlink location
+	install -d ${D}/usr/local/natinst/bin
+	ln -sf ${bindir}/status_led ${D}/usr/local/natinst/bin/status_led
 }


### PR DESCRIPTION
LabVIEW RT uses the older /usr/local/natinst/bin location for status_led while it now resides in /usr/bin.

Even if that gets corrected, we'll want to support earlier versions of LVRT, so the best course of action is to create a symlink to the new path at the old path.

We already [do this for niresetip](https://github.com/ni/meta-nilrt/blob/adf0240e44fbd9711895a37b0e093b82d0db9197/recipes-ni/ni-netcfgutil/ni-netcfgutil.bb#L31C16-L31C16) and other executables as well.

The change to status LED occurs in 22.5 and up, so this should be back ported to hardknott as well.

Internally tracked [here](https://dev.azure.com/ni/DevCentral/_workitems/edit/2501297/)

Tested by running `bitbake ni-utils`