### PR TITLE
kernel-test-nohz: remove extraneous output during ATS runs

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-test-nohz-files/run-ptest
+++ b/recipes-kernel/kernel-tests/kernel-test-nohz-files/run-ptest
@@ -12,9 +12,7 @@ P4NINES=3000
 
 # load device specific test parameters
 DEVICE=$(fw_printenv DeviceDesc | sed 's/DeviceDesc=//')
-if source "./$DEVICE.conf" 2>/dev/null ; then
-    echo "test parameters loaded from $DEVICE.conf"
-else
+if ! source "./$DEVICE.conf" 2>/dev/null ; then
     echo "warning: $DEVICE.conf not found; using default test parameters"
 fi
 
@@ -27,7 +25,7 @@ for file in `find /sys/devices/virtual/workqueue -name "cpumask"`; do
 done
 
 # delay the vmstat timer far away
-sysctl vm.stat_interval=999
+sysctl -q vm.stat_interval=999
 
 # create local results directory
 mkdir -p "$LOG_DIR"


### PR DESCRIPTION
During our own internal testing, the first line of output from a failed ptest is used to indicate the reason for the failure. This "always-on" output was interferring with that, so removing it.