### PR TITLE
[kirkstone] openssh: drop dsa HostKey import

### DIFF
--- a/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/recipes-connectivity/openssh/openssh_%.bbappend
@@ -37,7 +37,6 @@ do_install:append () {
 		echo                                                       >>${D}${sysconfdir}/ssh/sshd_config
 		echo "# HostKeys for protocol version 2"                   >>${D}${sysconfdir}/ssh/sshd_config
 		echo "HostKey /etc/natinst/share/ssh/ssh_host_rsa_key"     >>${D}${sysconfdir}/ssh/sshd_config
-		echo "HostKey /etc/natinst/share/ssh/ssh_host_dsa_key"     >>${D}${sysconfdir}/ssh/sshd_config
 		echo "HostKey /etc/natinst/share/ssh/ssh_host_ecdsa_key"   >>${D}${sysconfdir}/ssh/sshd_config
 		echo "HostKey /etc/natinst/share/ssh/ssh_host_ed25519_key" >>${D}${sysconfdir}/ssh/sshd_config
 }


### PR DESCRIPTION
OE-Core upstream [dropped support](https://git.openembedded.org/openembedded-core/commit/?id=e6a1c8c4ef4a1d2add6a7492d43027c4c0682300) for generating DSA host keys in their sshd_check_keys script. So the DSA key is never created, causing sshd to throw a warning during startup about not being able to import the key.

```
Unable to load host key: /etc/natinst/share/ssh/ssh_host_dsa_key
```

Drop the DSA key from the sshd_config, since it is a deprecated crypto-type in many distros and is relatively insecure.

NI AZDO: https://dev.azure.com/ni/DevCentral/_workitems/edit/2498581

# Testing
* [x] Tried this same (oneline) change on a PXIe-8880 which expressed this boot warning. Rebooted and confirmed that the warning is no longer thrown.
* [x] Built the `openssh` recipe locally. Diffed the `/etc/ssh/sshd_config` files before/after this change and confirmed that the offending `HostKey` line has been removed.