### PR TITLE
linux-nilrt-nohz: Downgrade to 5.15 kernel

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-nohz_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-nohz_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NILRT linux kernel full dynamic ticks (NO_HZ_FULL) build"
 NI_RELEASE_VERSION = "23.8"
-LINUX_VERSION = "6.1"
+LINUX_VERSION = "5.15"
 LINUX_KERNEL_TYPE = "nohz"
 
 require linux-nilrt-alternate.inc


### PR DESCRIPTION
Some NI driver teams have noticed increased jitter on the 6.1 NO_HZ kernel, which has not yet been addressed. Since this issue was not present in the 5.15 kernel, we can downgrade this recipe to 5.15 to avoid performance regressions in the 2023Q4 release.

The 5.15 kernel has received an upstream merge in ni/linux#134 and some NI commits in ni/linux#136.

[AB#2488177](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2488177)

If the issue gets fixed before release, this PR can be abandoned.