### PR TITLE
nilrt.inc: enable lvm2-udevrules package

### DIFF
--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -115,10 +115,6 @@ DISTRO_FEATURES_BACKFILL_CONSIDERED:arm = "gobject-introspection-data"
 # touchsreen calibration doesn't work with xf86-input-libinput, only with xf86-input-edev
 BAD_RECOMMENDATIONS += "xf86-input-libinput"
 
-# Do not "--enable-udev_sync" in lvm2/libdevmapper
-LVM2_PACKAGECONFIG:remove:class-target = "udev"
-RRECOMMENDS:libdevmapper:remove:class-target = "lvm2-udevrules"
-
 # these bbappends are constantly stale and since we don't use them
 # mask to avoid the bitbake warning noise
 BBMASK += "meta-cloud-services/meta-openstack/recipes-kernel"


### PR DESCRIPTION
For a while, we've had tweaks to nilrt.inc to allow us to install packages we needed in safemode for secure boot support (like cryptsetup) without needing to install the full lvm2 package. This was done because the full lvm2 package added too much to the disk footprint of safemode when our safemode partition had very limited free space.

Since we have dropped secure boot support, we no longer install cryptsetup in safemode. However, we still want to support cryptsetup in runmode where the disk footprint is not a concern. The version of cryptsetup we now include depends directly on lvm2-udevrules, which means we can't install it since we disabled lvm2-udevrules. This change drops the relevant lines from nilrt.inc to enable lvm2-udevrules again.

[AB#2521360](https://dev.azure.com/ni/DevCentral/_workitems/edit/2521360)

**Testing**
I built the safemode and runmode images before and after this commit. Confirmed the safemode and runmode images were unchanged. I rebuilt lvm2 after the commit. Then I hosted the resulting feed from my dev machine, pointed a target with a recent kirkstone image at my dev feed, and installed cryptsetup. I confirmed cryptsetup now installed with no errors, including its lvm2-udevrules dependency. Ran a couple cryptsetup commands to confirm it works.