### PR TITLE
linux-nilrt: drop "nocheckout" option to get correct source timestamps

### DIFF
--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -38,7 +38,7 @@ INHIBIT_PACKAGE_DEBUG_SPLIT="1"
 do_kernel_configme[depends] += "libgcc:do_populate_sysroot"
 
 SRC_URI = "\
-	${NILRT_GIT}/${GIT_KERNEL_REPO};protocol=https;nocheckout=1;branch=${KBRANCH} \
+	${NILRT_GIT}/${GIT_KERNEL_REPO};protocol=https;branch=${KBRANCH} \
 	file://export-kernel-headers.sh \
 "
 # Generically use the *latest* rev from the kernel source branch, if none is


### PR DESCRIPTION
kernel builds with "nocheckout=1" behave incorrectly with reproducible builds; the observed behavior is that we get:

- do_unpack happens; the git/.git directory is created, and HEAD points to the same commit as nilrt/master/4.14, but it's not actually checked out (no files are present). This is itself kind of weird, since the current default branch for linux.git on GitHub is nilrt/master/6.1.
- create_source_date_epoch_stamp happens and now the SOURCE_DATE_EPOCH is latched on this commit
- do_kernel_checkout happens after this and that's what puts us on the correct branch (which is what we build)

As a result, the SOURCE_DATE_EPOCH we get is for a completely different branch.

There doesn't seem to be any reason for why we set "nocheckout=1" at all other than "that's what we started with" (and no other recipes used in nilrt use "nocheckout=1") so take the easy solution and drop it.

Natinst-AzDO-ID: 2523534

---
Tested with `bitbake linux-nilrt` and then inspecting `$NILRT_ROOT/build/tmp-glibc/work/x64-nilrt-linux/linux-nilrt/6.1+gitAUTOINC+3494faaf50-r0/deploy-source-date-epoch/__source_date_epoch.txt`; it now reads 1694704634, which is `Thu 14 Sep 2023 10:17:14 AM CDT`, which matches the commit time of [ni/linux@3494faaf50f2](https://github.com/ni/linux/commit/3494faaf50f25d259b44bb45c2952f8ca246c1bd).