### PR TITLE
[sumo] nilrt.conf: Bump DISTRO_VERSION and NILRT_FEED_NAME

### DIFF
--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -2,9 +2,9 @@ require nilrt.inc
 
 DISTRO_NAME = "NI Linux Real-Time"
 
-DISTRO_VERSION = "8.17"
+DISTRO_VERSION = "8.18"
 
-NILRT_FEED_NAME ?= "2023Q4"
+NILRT_FEED_NAME ?= "2024Q1"
 
 DISTRO_FEATURES_append_x64 = "\
         x11 \


### PR DESCRIPTION
Bumping for next release

[AB#2401961](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2401961)

@ni/rtos 