### PR TITLE
[kirkstone] docker: move to core packagefeed

### DIFF
--- a/recipes-core/packagegroups/packagefeed-ni-core.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-core.bb
@@ -25,6 +25,10 @@ RDEPENDS:${PN} = "\
 	bolt \
 "
 
+RDEPENDS:${PN}:append = "\
+	docker \
+"
+
 RDEPENDS:${PN}:append:x64 = "\
 	init-nilrt-ramfs \
 	nilrt-grub-runmode \

--- a/recipes-core/packagegroups/packagefeed-ni-extra.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-extra.bb
@@ -750,7 +750,6 @@ RDEPENDS:${PN} += "\
 # meta-virtualization
 RDEPENDS:${PN} += "\
 	cgroup-lite \
-	docker \
 	lxc \
 	multipath-tools \
 	openvswitch \


### PR DESCRIPTION
Docker is useful enough to NILRT users that we should enable it as a core functionality of the distribution. Move the recipe family from the extras feed to the core feed, to ensure that it always builds.

NI [AB#2500846](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2500846)

# Testing
* [x] Diffed the pn-buildlist for target `packagefeed-ni-core` before and after this change. The following new recipes are added to the built tree. `docker-ce` is now built, along with other legitimate deps of the docker recipe.
```
diff <(cat ../logs/pkgfeed-core.pn-buildlist | sort) <(cat ./pn-buildlist | sort)
> bridge-utils
> cgroup-lite
> compose-file
> containerd-opencontainers
> docker-ce
> go-binary-native
> go-capability
> go-cli
> go-connections
> go-context
> go-cross-core2-64
> go-dbus
> go-distribution
> go-fsnotify
> go-logrus
> go-mux
> go-patricia
> go-pty
> go-runtime
> go-systemd
> grpc-go
> libaio
> lvm2
> notary
> runc-opencontainers
> sysfsutils
> tini
```
* [x] Built `docker-ce` in bitbake and confirmed that it builds and packages correctly, without errors.