### PR TITLE
Extend kernel-performance-tests to run in containers

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/common.cfg
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/common.cfg
@@ -1,0 +1,9 @@
+# Common configuration for all kernel performance tests
+TEST_DURATION=8h
+
+# Maximum expected latency in useconds.
+# The test will fail if cyclictest latency goes beyond this value.
+MAX_LATENCY=300
+
+# Location for benchmark logs and test results
+LOG_DIR="/var/local/ptest-results/kernel-containerized-performance-tests"

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/cyclictest-container/Dockerfile
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/cyclictest-container/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:latest
+
+# Install rt-tests, sudo, etc
+RUN DEBIAN_FRONTEND=noninteractive apt update && apt install -y \
+    rt-tests \
+    python3 \
+    python3-pip \
+    dmidecode \
+    grub-common
+
+# Need to send to InfluxDB
+RUN pip install influxdb
+
+# Script to call "run_cyclictest" from outside Docker container
+ADD --chmod=0775 call_run_ct.sh ./call_run_ct.sh
+

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/cyclictest-container/call_run_ct.sh
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/cyclictest-container/call_run_ct.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+cd /ptests
+source ./run-cyclictest
+TEST_LOG=${LOG_DIR}/run_cyclictest-`date +'%Y_%m_%d-%H_%M_%S'`-${1}.log
+run_cyclictest "${1}" > ${TEST_LOG} 2>&1
+echo "${CYCLICTEST_RESULT}"
+

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/fio.cfg
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/fio.cfg
@@ -1,0 +1,15 @@
+[global]
+directory=/var/cache/fio
+numjobs=1
+size=100M
+nrfiles=20
+openfiles=10
+direct=0
+verify=sha256
+do_verify=1
+time_based
+clocksource=clock_gettime
+bs=5k
+
+[random_rw]
+rw=randrw

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/parallel-container/Dockerfile
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/parallel-container/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:latest
+
+# Install rt-tests, sudo, etc
+RUN DEBIAN_FRONTEND=noninteractive apt update && apt install -y \
+    rt-tests \
+    fio \
+    iperf3 \
+    psmisc
+
+# Scripts to start loads from outside container
+ADD --chmod=0775 run_hackbench.sh ./run_hackbench.sh
+ADD --chmod=0775 run_fio.sh ./run_fio.sh
+ADD --chmod=0775 run_iperf.sh ./run_iperf.sh
+

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/parallel-container/run_fio.sh
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/parallel-container/run_fio.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+cd /ptests
+source run-cyclictest
+mkdir -p /var/cache/fio
+fio fio.cfg --ioengine="sync" --runtime="${TEST_DURATION}" --ramp_time=1m \
+    --output="${LOG_DIR}/fio-sync-`date +'%Y_%m_%d-%H_%M_%S'`.log" \
+    > /dev/null
+

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/parallel-container/run_hackbench.sh
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/parallel-container/run_hackbench.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+cd /ptests
+source run-cyclictest
+hackbench -l 36000000 -g 10 \
+    2>/dev/null > "${LOG_DIR}/hackbench-`date +'%Y_%m_%d-%H_%M_%S\'`.log"
+

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/parallel-container/run_iperf.sh
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/parallel-container/run_iperf.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+cd /ptests
+source run-cyclictest
+source /home/admin/.iperf.info
+if [ ! -z "${IPERF_PORT}" ]; then
+    iperf3 -c "${IPERF_SERVER}" -p "${IPERF_PORT}" -t 36000 \
+        --logfile "${LOG_DIR}/iperf-`date +'%Y_%m_%d-%H_%M_%S'`.log"
+else
+    iperf3 -c "${IPERF_SERVER}" -t 36000 \
+        --logfile "${LOG_DIR}/iperf-`date +'%Y_%m_%d-%H_%M_%S'`.log"
+fi
+

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/run-cyclictest
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/run-cyclictest
@@ -1,0 +1,83 @@
+#!/bin/bash
+source ./common.cfg
+
+function add_system_info()
+{
+	{
+	DESC=$(fw_printenv DeviceDesc)
+	DEVICE=${DESC#*=}
+	echo "# Device: $DEVICE"
+
+	echo -n "# Kernel: "
+	uname -a
+
+	echo -n "# Kernel parameters: "
+	cat /proc/cmdline
+
+	# save info on the current security mitigations
+	echo "# Security vulnerabilities settings: "
+	if [ -d "/sys/devices/system/cpu/vulnerabilities" ]; then
+		for f in  /sys/devices/system/cpu/vulnerabilities/*; do
+		VULN=$(basename "$f")
+		if [ -f "$f" ]; then
+			echo -n -e "#	 $VULN:\t"
+			cat "$f"
+		fi
+		done
+	else
+		echo "#	 vulnerability information not published"
+	fi
+
+	# save info on the current C state settings
+	echo "# C-states settings: "
+	for CPU in /sys/devices/system/cpu/cpu[0-9]; do
+		NCPU=$(basename "$CPU")
+		echo "#	 [$NCPU]"
+		for CSTATE in $CPU/cpuidle/state[0-9]; do
+		NSTATE=$(basename "$CSTATE")
+		if [ -f "$CSTATE/name" ] && [ -f "$CSTATE/disable" ]; then
+					NAME=$(cat "$CSTATE/name" 2>/dev/null)
+					STATUS=$(cat "$CSTATE/disable" 2>/dev/null)
+
+					echo -n "#	 $NSTATE: $NAME: "
+					if [ "$STATUS" = "0" ]; then
+						echo "enabled"
+					else
+						echo "disabled"
+					fi
+		else
+					echo "#	 information not available"
+		fi
+		done
+	done
+	} >> "$1"
+}
+
+function run_cyclictest()
+{
+	LOG="$LOG_DIR/cyclictest-$1-`date +'%Y_%m_%d-%H_%M_%S'`.log"
+	INFLUXDB_INFO="/home/admin/.influxdb.info"
+	cyclictest --smp --priority=98 --mlockall --interval=997 --quiet --duration="$TEST_DURATION" --histofall=1000 --histfile="$LOG" > /dev/null
+	add_system_info "$LOG"
+	if [[ -f "$INFLUXDB_INFO" ]]; then
+		source "$INFLUXDB_INFO"
+		python3 upload_cyclictest_results.py "-i $LOG" "-s $INFLUXDB_SERVER" "-p $INFLUXDB_PORT"
+	else
+		echo "INFO: No InfluxDB Connection Info. Results will not be published."
+	fi
+
+	LATENCY=$(grep -sw "# Max Latencies:" "$LOG" | awk '{max=$4; for(i=4; i<=NF; i++) if ($i>max) max=$i; gsub("^0*", "", max); print max}')
+	if [ "$LATENCY" -le "$MAX_LATENCY" ]; then
+	echo "cyclictest with $1 load latency: $LATENCY (usec) is less than max latency: $MAX_LATENCY (usec)"
+	echo "histogram log file: $LOG"
+	echo "PASS: test_kernel_cyclictest_$1"
+	CYCLICTEST_RESULT=0
+	else
+	echo "cyclictest with $1 load latency: $LATENCY (usec) is above the expected max latency: $MAX_LATENCY (usec)"
+	echo "histogram log file: $LOG"
+	echo "FAIL: test_kernel_cyclictest_$1"
+	CYCLICTEST_RESULT=1
+	fi
+}
+
+mkdir -p "$LOG_DIR"

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/run-ptest
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/run-ptest
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+./test_kernel_cyclictest_idle_containerized.sh
+./test_kernel_cyclictest_hackbench_containerized.sh
+./test_kernel_cyclictest_fio_containerized.sh
+./test_kernel_cyclictest_iperf_containerized.sh
+
+exit 0
+

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_fio_containerized.sh
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_fio_containerized.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+PTEST_LOCATION=/usr/lib/kernel-containerized-performance-tests/ptest
+
+# Build the two containers
+if [ "$(docker images -q cyclictest-container:latest)" = "" ]; then
+    echo "Building cyclictest-container..."
+    DOCKER_BUILDKIT=1 \
+        docker build -t cyclictest-container --network=host ${PTEST_LOCATION}/cyclictest-container \
+        > /dev/null
+fi
+if [ "$(docker images -q parallel-container:latest)" = "" ]; then
+    echo "Building parallel-container..."
+    DOCKER_BUILDKIT=1 \
+        docker build -t parallel-container --network=host ${PTEST_LOCATION}/parallel-container \
+        > /dev/null
+fi
+
+# Start background disk I/O load
+echo "Starting fio load..."
+LOAD_CONT=$(docker run -d --privileged -v ${PTEST_LOCATION}:/ptests -t parallel-container \
+    bash run_fio.sh)
+
+# Run cyclictest
+echo "Running cyclictest in docker container..."
+RESULT=$(docker run --privileged --network=host \
+    -v ${LOG_DIR}:${LOG_DIR} -v ${PTEST_LOCATION}:/ptests -v /home/admin:/home/admin \
+    -v /usr/share/fw_printenv:/usr/share/fw_printenv -v /sbin/fw_printenv:/sbin/fw_printenv \
+    -v /usr/share/nisysinfo:/usr/share/nisysinfo -v /dev:/dev \
+    -t cyclictest-container \
+    bash call_run_ct.sh "fio_containerized" \
+        | tr -d '\r' | tr -d '\n')
+
+# Clean up the background container
+docker exec ${LOAD_CONT} bash -c "killall -INT fio > /dev/null 2>&1"
+
+echo "Test Result: ${RESULT}"
+exit ${RESULT}
+

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_hackbench_containerized.sh
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_hackbench_containerized.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+PTEST_LOCATION=/usr/lib/kernel-containerized-performance-tests/ptest
+
+# Build the two containers
+if [ "$(docker images -q cyclictest-container:latest)" = "" ]; then
+    echo "Building cyclictest-container..."
+    DOCKER_BUILDKIT=1 \
+        docker build -t cyclictest-container --network=host ${PTEST_LOCATION}/cyclictest-container \
+        > /dev/null
+fi
+if [ "$(docker images -q parallel-container:latest)" = "" ]; then
+    echo "Building parallel-container..."
+    DOCKER_BUILDKIT=1 \
+        docker build -t parallel-container --network=host ${PTEST_LOCATION}/parallel-container \
+        > /dev/null
+fi
+
+# Start background scheduler load
+echo "Starting hackbench load..."
+LOAD_CONT=$(docker run -d --privileged -v ${PTEST_LOCATION}:/ptests -t parallel-container \
+    bash run_hackbench.sh)
+
+# Run cyclictest
+echo "Running cyclictest in docker container..."
+RESULT=$(docker run --privileged --network=host \
+    -v ${LOG_DIR}:${LOG_DIR} -v ${PTEST_LOCATION}:/ptests -v /home/admin:/home/admin \
+    -v /usr/share/fw_printenv:/usr/share/fw_printenv -v /sbin/fw_printenv:/sbin/fw_printenv \
+    -v /usr/share/nisysinfo:/usr/share/nisysinfo -v /dev:/dev \
+    -t cyclictest-container \
+    bash call_run_ct.sh "hackbench_containerized" \
+        | tr -d '\r' | tr -d '\n')
+
+# Clean up the background container
+docker exec ${LOAD_CONT} \
+    bash -c "killall -INT hackbench > /dev/null 2>&1"
+
+echo "Test Result: ${RESULT}"
+exit ${RESULT}
+

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_idle_containerized.sh
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_idle_containerized.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+PTEST_LOCATION=/usr/lib/kernel-containerized-performance-tests/ptest
+LOG_DIR="/var/local/ptest-results/kernel-containerized-performance-tests"
+
+# Build the two containers
+if [ "$(docker images -q cyclictest-container:latest)" = "" ]; then
+    echo "Building cyclictest-container..."
+    DOCKER_BUILDKIT=1 \
+        docker build -t cyclictest-container --network=host ${PTEST_LOCATION}/cyclictest-container \
+        > /dev/null
+fi
+
+# Run cyclictest
+echo "Running cyclictest in docker container..."
+RESULT=$(docker run --privileged --network=host \
+    -v ${LOG_DIR}:${LOG_DIR} -v ${PTEST_LOCATION}:/ptests -v /home/admin:/home/admin \
+    -v /usr/share/fw_printenv:/usr/share/fw_printenv -v /sbin/fw_printenv:/sbin/fw_printenv \
+    -v /usr/share/nisysinfo:/usr/share/nisysinfo -v /dev:/dev \
+    -t cyclictest-container \
+    bash call_run_ct.sh "idle_containerized" \
+        | tr -d '\r' | tr -d '\n')
+
+echo "Test result: ${RESULT}"
+exit ${RESULT}
+

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_iperf_containerized.sh
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_iperf_containerized.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+PTEST_LOCATION=/usr/lib/kernel-containerized-performance-tests/ptest
+
+source /home/admin/.iperf.info
+if [ -z "$IPERF_SERVER" ]; then
+    echo "Warning: iperf server not configured; skipping iperf based network load test."
+    echo "Create/edit /home/admin/.iperf.info file with IPERF_SERVER=<server> and IPERF_PORT=<port> to configure a server to connect to for this test."
+    echo "SKIP: test_kernel_cyclictest_iperf_containerized"
+    exit 77
+fi
+if [ ! -z "$IPERF_PORT" ]; then
+    iperf3 -c "$IPERF_SERVER" -p "$IPERF_PORT" -t 1 > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "ERROR: iperf server not reachable; skipping iperf based network load test."
+        echo "SKIP: test_kernel_cyclictest_iperf_containerized"
+        exit 77
+    fi
+fi
+
+# Build the two containers
+if [ "$(docker images -q cyclictest-container:latest)" = "" ]; then
+    echo "Building cyclictest-container..."
+    DOCKER_BUILDKIT=1 \
+        docker build -t cyclictest-container --network=host ${PTEST_LOCATION}/cyclictest-container \
+        > /dev/null
+fi
+if [ "$(docker images -q parallel-container:latest)" = "" ]; then
+    echo "Building parallel-container..."
+    DOCKER_BUILDKIT=1 \
+        docker build -t parallel-container --network=host ${PTEST_LOCATION}/parallel-container \
+        > /dev/null
+fi
+
+# Start background network load
+echo "Starting iperf load..."
+LOAD_CONT=$(docker run -d --privileged \
+    -v ${PTEST_LOCATION}:/ptests -v /home/admin:/home/admin --network=host \
+    -t parallel-container bash run_iperf.sh)
+
+# Run cyclictest
+echo "Running cyclictest in docker container..."
+RESULT=$(docker run --privileged --network=host \
+    -v ${LOG_DIR}:${LOG_DIR} -v ${PTEST_LOCATION}:/ptests -v /home/admin:/home/admin \
+    -v /usr/share/fw_printenv:/usr/share/fw_printenv -v /sbin/fw_printenv:/sbin/fw_printenv \
+    -v /usr/share/nisysinfo:/usr/share/nisysinfo -v /dev:/dev \
+    -t cyclictest-container \
+    bash call_run_ct.sh "iperf_containerized" \
+        | tr -d '\r' | tr -d '\n')
+
+# Clean up the background container
+docker exec ${LOAD_CONT} \
+    bash -c "killall -INT iperf3 > /dev/null 2>&1"
+
+echo "Test result: ${RESULT}"
+exit ${RESULT}
+

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/upload_cyclictest_results.py
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/upload_cyclictest_results.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Script for uploading a cyclictest log to influxdb"""
+
+import argparse
+import logging
+import mmap
+import re
+import subprocess
+import sys
+from pathlib import Path
+from datetime import datetime
+from influxdb import InfluxDBClient, exceptions
+import requests.exceptions
+
+
+def get_current_kernel_version():
+    """Get the kernel version currently running on the system"""
+    try:
+        process = subprocess.run(['uname', '-r'],
+                                 check=True,
+                                 stdout=subprocess.PIPE)
+        kver_full = process.stdout.strip().decode("utf-8")
+        rgx = re.search(r'([0-9]+\.[0-9]+)\.([0-9]+)', kver_full)
+        kver = rgx.group(1)
+    except (FileNotFoundError, AttributeError):
+        logging.warning("failed to read the current kernel version")
+        raise
+
+    return kver, kver_full
+
+
+def get_kernel_version(path):
+    """Get the kernel version used in cyclictest test
+
+    Read 'major.minor' and 'major.minor.patch-rt' kernel version strings from
+    cyclictest log if found or current running system otherwise.
+
+    """
+    try:
+        with open(path, 'rb', 0) as file, \
+             mmap.mmap(file.fileno(), 0, access=mmap.ACCESS_READ) as mfile:
+            kernel = re.search(br'# Kernel: Linux ([^ ]+) ([0-9]+)\.([0-9]+)\.'
+                               br'([0-9]+-rc[0-9]+-rt[0-9]+|[0-9]+-rt[0-9]+)',
+                               mfile)
+            # ignore build machine name, i.e. group(1)
+            major = kernel.group(2).decode()
+            minor = kernel.group(3).decode()
+            patch = kernel.group(4).decode()
+            version = major + '.' + minor
+            full_version = version + '.' + patch
+    except (ValueError, AttributeError):
+        logging.warning('kernel version information missing from \'%s\' '
+                        'retriving from current system.', path)
+        version, full_version = get_current_kernel_version()
+    return version, full_version
+
+
+def get_current_device():
+    """Get the device description for the current system (e.g. cRIO-90xx)"""
+    try:
+        process = subprocess.run(['fw_printenv', 'DeviceDesc'],
+                                 check=True,
+                                 stdout=subprocess.PIPE)
+        dev_str = process.stdout.strip().decode("utf-8")
+        dev = dev_str.split('=')[-1]
+    except FileNotFoundError:
+        logging.warning("failed to read the current device type")
+        raise
+
+    return dev
+
+
+def get_device(path):
+    """Get the device name used in cyclictest test
+
+    Read the device name stored in the cyclictest log file or if not available
+    retrieve the current device name.
+
+    """
+    try:
+        with open(path, 'rb', 0) as file, \
+             mmap.mmap(file.fileno(), 0, access=mmap.ACCESS_READ) as mfile:
+            rgx = re.search(br'# Device: ([a-zA-z]+-[0-9]+)', mfile)
+            device = rgx.group(1).decode()
+    except (ValueError, AttributeError):
+        logging.warning('device information missing from \'%s\' '
+                        'retriving from current system.', path)
+        device = get_current_device()
+    return device
+
+
+def get_test_params(path):
+    """Get the test name and datetime
+
+    Extract the test name and date/time from cyclictest log name.
+
+    """
+    try:
+        rgx = re.search(r'[^_]*cyclictest-([^-]+)-([^-]+)-([^\.]+).log',
+                        path.name)
+        test = rgx.group(1)
+        date = rgx.group(2).replace('_', '-')
+        time = rgx.group(3).replace('_', ':')
+        date_time = datetime.fromisoformat(date + ' ' + time)
+    except AttributeError:
+        logging.warning('failed to parse test parameters '
+                        '(i.e. test name, date, time)')
+        raise
+
+    return test, date_time
+
+
+def get_test_results(path):
+    """Extract min, avg, max latency from cyclictest log"""
+    try:
+        with open(path, 'rb', 0) as file, \
+             mmap.mmap(file.fileno(), 0, access=mmap.ACCESS_READ) as mfile:
+            rgx = re.search(br'# Max Latencies: ([^\n]+)', mfile)
+            max_list = list(map(int, rgx.group(1).decode().split()))
+            max_latency = max_list[-1]
+
+            rgx = re.search(br'# Min Latencies: ([^\n]+)', mfile)
+            min_list = list(map(int, rgx.group(1).decode().split()))
+            min_latency = min(min_list)
+
+            rgx = re.search(br'# Avg Latencies: ([^\n]+)', mfile)
+            avg_list = list(map(int, rgx.group(1).decode().split()))
+            avg_latency = sum(avg_list) / len(avg_list)
+    except (ValueError, AttributeError):
+        logging.warning("failed to parse test results")
+        raise
+
+    return min_latency, avg_latency, max_latency
+
+def get_distro_info():
+    """Extract distro version and codename from os-release and return them as a tuple
+
+    Returns 'unknown' for either in case of file read exception or missing fields.
+
+    """
+    os_release_stmts = []
+    try:
+        with open('/etc/os-release') as os_release_file:
+            os_release_stmts = os_release_file.readlines()
+    except:
+        return ('unknown', 'unknown')
+    pairs = dict(map(lambda e: e.split('='), os_release_stmts))
+    version = pairs.get('VERSION_ID', 'unknown').strip()
+    name = pairs.get('DISTRO_CODENAME', 'unknown').strip()[1:-1]
+    return (version, name)
+
+def read_data(path):
+    """Read test data and metadata from a cyclictest log file"""
+    version, full_version = get_kernel_version(path)
+    controller = get_device(path)
+    test, time = get_test_params(path)
+    min_latency, avg_latency, max_latency = get_test_results(path)
+    distro_version, distro_name = get_distro_info()
+
+    data = {
+        "measurement": "latency",
+        "tags": {
+            "controller": controller,
+            "test": test,
+            "kernel_version": version,
+            "kernel_full_version": full_version,
+            "distro_version": distro_version,
+            "distro_name": distro_name
+        },
+        "fields": {
+            "min_latency": float(min_latency),
+            "avg_latency": float(avg_latency),
+            "max_latency": float(max_latency),
+        },
+        "time": time
+    }
+    return data
+
+
+def upload_results(data, server, server_port):
+    """Upload results to influxdb instance"""
+    try:
+        influxdb = InfluxDBClient(host=server, port=server_port)
+        influxdb.switch_database("rtos_kernel_performance")
+        if not influxdb.write_points(data):
+            logging.warning("failed to write data points to influxdb")
+        influxdb.close()
+    except (exceptions.InfluxDBClientError,
+            requests.exceptions.ConnectionError) as err:
+        logging.warning('influxdb error: %s', err)
+
+
+parser = argparse.ArgumentParser(
+    description="Parse and upload cyclictest results.")
+parser.add_argument("-i", "--input", required=True,
+                    help="cyclictest log input file")
+parser.add_argument("-s", "--server", required=True,
+                    help="influxdb server")
+parser.add_argument("-p", "--port", type=int, default=8086,
+                    help="influxdb server port")
+args = parser.parse_args()
+
+log_file = Path(args.input.strip())
+if not log_file.is_file():
+    logging.error('input file %s does not exist!', log_file)
+    sys.exit(1)
+
+try:
+    result = read_data(log_file)
+except (FileNotFoundError, AttributeError, ValueError):
+    logging.error('skipping malformed or incomplete test results at: %s',
+                  log_file)
+    sys.exit(1)
+
+results = []
+results.append(result)
+upload_results(results, args.server.strip(), args.port)

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests.bb
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests.bb
@@ -1,0 +1,66 @@
+SUMMARY = "Linux kernel-specific containerized performance tests"
+HOMEPAGE = "https://kernel.org"
+SECTION = "tests"
+LICENSE = "GPL-2.0-only & GPL-2.0-or-later"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-or-later;md5=fed54355545ffd980b814dab4a3b312c"
+
+inherit ptest
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}-files:"
+
+S = "${WORKDIR}"
+
+DEPENDS = "virtual/kernel"
+RDEPENDS:${PN}-ptest += "bash rt-tests fio iperf3 python3 python3-pip docker-ce"
+RDEPENDS:${PN}-ptest:append:x64 = " fw-printenv"
+RDEPENDS:${PN}-ptest:append:armv7a = " u-boot-fw-utils"
+
+ALLOW_EMPTY:${PN} = "1"
+
+SRC_URI += "\
+    file://run-ptest \
+    file://run-cyclictest \
+    file://upload_cyclictest_results.py \
+    file://common.cfg \
+    file://fio.cfg \
+    file://test_kernel_cyclictest_idle_containerized.sh \
+    file://test_kernel_cyclictest_hackbench_containerized.sh \
+    file://test_kernel_cyclictest_fio_containerized.sh \
+    file://test_kernel_cyclictest_iperf_containerized.sh \
+    file://cyclictest-container/Dockerfile \
+    file://cyclictest-container/call_run_ct.sh \
+    file://parallel-container/Dockerfile \
+    file://parallel-container/run_hackbench.sh \
+    file://parallel-container/run_fio.sh \
+    file://parallel-container/run_iperf.sh \
+"
+
+do_install_ptest:append() {
+    install -m 0755 ${S}/run-ptest ${D}${PTEST_PATH}
+    install -m 0755 ${S}/run-cyclictest ${D}${PTEST_PATH}
+    install -m 0755 ${S}/upload_cyclictest_results.py ${D}${PTEST_PATH}
+    install -m 0644 ${S}/common.cfg ${D}${PTEST_PATH}
+    install -m 0644 ${S}/fio.cfg ${D}${PTEST_PATH}
+    install -m 0755 ${S}/test_kernel_cyclictest_idle_containerized.sh ${D}${PTEST_PATH}
+    install -m 0755 ${S}/test_kernel_cyclictest_hackbench_containerized.sh ${D}${PTEST_PATH}
+    install -m 0755 ${S}/test_kernel_cyclictest_fio_containerized.sh ${D}${PTEST_PATH}
+    install -m 0755 ${S}/test_kernel_cyclictest_iperf_containerized.sh ${D}${PTEST_PATH}
+    mkdir -p ${D}${PTEST_PATH}/cyclictest-container
+    install -m 0755 ${S}/cyclictest-container/Dockerfile ${D}${PTEST_PATH}/cyclictest-container
+    install -m 0755 ${S}/cyclictest-container/call_run_ct.sh \
+        ${D}${PTEST_PATH}/cyclictest-container/call_run_ct.sh
+    mkdir -p ${D}${PTEST_PATH}/parallel-container
+    install -m 0755 ${S}/parallel-container/Dockerfile ${D}${PTEST_PATH}/parallel-container
+    install -m 0755 ${S}/parallel-container/run_hackbench.sh \
+        ${D}${PTEST_PATH}/parallel-container/run_hackbench.sh
+    install -m 0755 ${S}/parallel-container/run_fio.sh \
+        ${D}${PTEST_PATH}/parallel-container/run_fio.sh
+    install -m 0755 ${S}/parallel-container/run_iperf.sh \
+        ${D}${PTEST_PATH}/parallel-container/run_iperf.sh
+}
+
+pkg_postinst_ontarget:${PN}-ptest:append() {
+    python3 -m pip install influxdb
+}
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
## Reason

Customers want to use docker from nilrt, and we need to verify there is not a significant performance cost from doing so, so extend the existing kernel-performance-tests to run from containers to verify docker support is functional.

## Implementation

- Create two containers: one for running cyclictest and one to run in parallel with a load from hackbench, fio, or iperf.
- Duplicate the existing tests and modify each so the load command is called in the parallel container and the cyclictest is called in the main container

## Testing

Ran all the way through on a cRIO 9037 and uploaded results to Grafana.

NOTE: One small hiccup which is `fio` segfaults from a container. This will affect results as no load runs during the fio_containerized_test, but it doesn't stop the test or cause it to fail, so we can likely proceed for now and file a bug to fix the segfault.