### PR TITLE
packagegroup-ni-internal-deps: Add libglu

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
@@ -101,3 +101,10 @@ RDEPENDS:${PN} += "\
 RDEPENDS:${PN} += "\
 	libpcap \
 "
+
+# Required by LabVIEW Real-Time
+# Team: LabVIEW Real-Time
+# Contact: sharpk
+RDEPENDS:${PN} += "\
+	libglu \
+"


### PR DESCRIPTION
libglu is now a dep of LabVIEW Real-Time.

WI: [2549462](https://ni.visualstudio.com/DevCentral/_workitems/edit/2549462)

### Testing
- [X] Built the core feed
- [X] Verified the presence of libglu