### PR TITLE
Add kernel-containerized-performance-tests to packagegroup-ni-desirable

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-desirable.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-desirable.bb
@@ -55,6 +55,7 @@ RDEPENDS:${PN} += "\
 # Testing packages
 RDEPENDS:${PN} += "\
 	kernel-performance-tests \
+	kernel-containerized-performance-tests \
 	ni-base-system-image-tests \
 "
 RDEPENDS:${PN}:append:x64 = "\


### PR DESCRIPTION
## Reason

We created the kernel-containerized-performance-tests package to run on our ATS, but without being in a packagegroup, the ATS cannot install the package from feeds.

## Testing

Built `packagegroup-ni-desirable`