### PR TITLE
Add restarting the docker daemon to kernel-containerized-performance-tests

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_fio_containerized.sh
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_fio_containerized.sh
@@ -6,14 +6,20 @@ PTEST_LOCATION=/usr/lib/kernel-containerized-performance-tests/ptest
 if [ "$(docker images -q cyclictest-container:latest)" = "" ]; then
     echo "Building cyclictest-container..."
     DOCKER_BUILDKIT=1 \
-        docker build -t cyclictest-container --network=host ${PTEST_LOCATION}/cyclictest-container \
-        > /dev/null
+        docker build -t cyclictest-container --network=host ${PTEST_LOCATION}/cyclictest-container
+    if [ "$(docker images -q cyclictest-container:latest)" = "" ]; then
+        echo "Failed to build cyclictest-container"
+        exit 77
+    fi
 fi
 if [ "$(docker images -q parallel-container:latest)" = "" ]; then
     echo "Building parallel-container..."
     DOCKER_BUILDKIT=1 \
-        docker build -t parallel-container --network=host ${PTEST_LOCATION}/parallel-container \
-        > /dev/null
+        docker build -t parallel-container --network=host ${PTEST_LOCATION}/parallel-container
+    if [ "$(docker images -q parallel-container:latest)" = "" ]; then
+        echo "Failed to build parallel-container"
+        exit 77
+    fi
 fi
 
 # Start background disk I/O load

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_hackbench_containerized.sh
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_hackbench_containerized.sh
@@ -6,14 +6,20 @@ PTEST_LOCATION=/usr/lib/kernel-containerized-performance-tests/ptest
 if [ "$(docker images -q cyclictest-container:latest)" = "" ]; then
     echo "Building cyclictest-container..."
     DOCKER_BUILDKIT=1 \
-        docker build -t cyclictest-container --network=host ${PTEST_LOCATION}/cyclictest-container \
-        > /dev/null
+        docker build -t cyclictest-container --network=host ${PTEST_LOCATION}/cyclictest-container
+    if [ "$(docker images -q cyclictest-container:latest)" = "" ]; then
+        echo "Failed to build cyclictest-container"
+        exit 77
+    fi
 fi
 if [ "$(docker images -q parallel-container:latest)" = "" ]; then
     echo "Building parallel-container..."
     DOCKER_BUILDKIT=1 \
-        docker build -t parallel-container --network=host ${PTEST_LOCATION}/parallel-container \
-        > /dev/null
+        docker build -t parallel-container --network=host ${PTEST_LOCATION}/parallel-container
+    if [ "$(docker images -q parallel-container:latest)" = "" ]; then
+        echo "Failed to build parallel-container"
+        exit 77
+    fi
 fi
 
 # Start background scheduler load

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_idle_containerized.sh
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_idle_containerized.sh
@@ -7,8 +7,11 @@ LOG_DIR="/var/local/ptest-results/kernel-containerized-performance-tests"
 if [ "$(docker images -q cyclictest-container:latest)" = "" ]; then
     echo "Building cyclictest-container..."
     DOCKER_BUILDKIT=1 \
-        docker build -t cyclictest-container --network=host ${PTEST_LOCATION}/cyclictest-container \
-        > /dev/null
+        docker build -t cyclictest-container --network=host ${PTEST_LOCATION}/cyclictest-container
+    if [ "$(docker images -q cyclictest-container:latest)" = "" ]; then
+        echo "Failed to build cyclictest-container"
+        exit 77
+    fi
 fi
 
 # Run cyclictest

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_idle_containerized.sh
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_idle_containerized.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Hack: Docker-CE must be restarted before containers can build. This is the first ran test
+/etc/init.d/docker.init restart
+
 PTEST_LOCATION=/usr/lib/kernel-containerized-performance-tests/ptest
 LOG_DIR="/var/local/ptest-results/kernel-containerized-performance-tests"
 

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_iperf_containerized.sh
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_iperf_containerized.sh
@@ -22,14 +22,20 @@ fi
 if [ "$(docker images -q cyclictest-container:latest)" = "" ]; then
     echo "Building cyclictest-container..."
     DOCKER_BUILDKIT=1 \
-        docker build -t cyclictest-container --network=host ${PTEST_LOCATION}/cyclictest-container \
-        > /dev/null
+        docker build -t cyclictest-container --network=host ${PTEST_LOCATION}/cyclictest-container
+    if [ "$(docker images -q cyclictest-container:latest)" = "" ]; then
+        echo "Failed to build cyclictest-container"
+        exit 77
+    fi
 fi
 if [ "$(docker images -q parallel-container:latest)" = "" ]; then
     echo "Building parallel-container..."
     DOCKER_BUILDKIT=1 \
-        docker build -t parallel-container --network=host ${PTEST_LOCATION}/parallel-container \
-        > /dev/null
+        docker build -t parallel-container --network=host ${PTEST_LOCATION}/parallel-container
+    if [ "$(docker images -q parallel-container:latest)" = "" ]; then
+        echo "Failed to build parallel-container"
+        exit 77
+    fi
 fi
 
 # Start background network load


### PR DESCRIPTION
## Reason

Currently, we cannot run the kernel-containerized-performance-tests on our ATS due to it not building the containers after reboot.

This likely a bug with the docker daemon, but until it's fixed, this can be resolved by doing a docker daemon restart.

Also, if the containers fail to build, the tests should fail.

## Implementation

- Add `/etc/init.d/docker.init restart` to the first test
- Add if clause to exit if the docker container doesn't exist after building

## Testing

- Installed on ATS target
- Restart and immediately run `ptest-runner`
- Verify it builds the container and proceeds to the test
