### PR TITLE
Add test to validate that docker functionality is supported

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-ptest-smoke.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-ptest-smoke.bb
@@ -16,6 +16,7 @@ RDEPENDS:${PN}:append = "\
     busybox-ptest \
     bzip2-ptest \
     coreutils-ptest \
+    docker-functional-ptest \
     e2fsprogs-ptest \
     elfutils-ptest \
     ethtool-ptest \

--- a/recipes-ni/docker-functional-tests/docker-functional-tests.bb
+++ b/recipes-ni/docker-functional-tests/docker-functional-tests.bb
@@ -1,0 +1,35 @@
+SUMMARY = "Functional test of docker container capabilities on NILRT"
+HOMEPAGE = "https://github.com/ni/nilrt"
+SECTION = "tests"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+DEPENDS = ""
+
+SRC_URI = "\
+    file://run-ptest \
+    file://test_daemon.sh \
+    file://test_parallel.sh \
+    file://test_parallel.Dockerfile \
+    file://test_parallel_test_file.txt \
+"
+S = "${WORKDIR}"
+
+inherit ptest
+
+ALLOW_EMPTY:${PN} = "1"
+
+do_install_ptest:append() {
+    install -m 0755 ${S}/run-ptest ${D}${PTEST_PATH}
+    install -m 0755 ${S}/test_daemon.sh ${D}${PTEST_PATH}
+    install -m 0755 ${S}/test_parallel.sh ${D}${PTEST_PATH}
+    mkdir -p ${D}${PTEST_PATH}/test_parallel_container
+    install -m 0755 ${S}/test_parallel.Dockerfile \
+        ${D}${PTEST_PATH}/test_parallel_container/Dockerfile
+    install -m 0664 ${S}/test_parallel_test_file.txt \
+        ${D}${PTEST_PATH}/test_parallel_container/test_file.txt
+}
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+RDEPENDS:${PN}-ptest += "bash docker-ce"
+

--- a/recipes-ni/docker-functional-tests/files/run-ptest
+++ b/recipes-ni/docker-functional-tests/files/run-ptest
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+./test_daemon.sh
+./test_parallel.sh
+
+exit 0
+

--- a/recipes-ni/docker-functional-tests/files/test_daemon.sh
+++ b/recipes-ni/docker-functional-tests/files/test_daemon.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+echo "Running docker hello-world..."
+if ! docker run hello-world 2>&1; then
+    echo "ERROR: Couldn't execute \`docker run hello-world\`"
+    exit 1
+fi
+
+exit 0
+

--- a/recipes-ni/docker-functional-tests/files/test_parallel.Dockerfile
+++ b/recipes-ni/docker-functional-tests/files/test_parallel.Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:latest
+
+# Install rt-tests, sudo, etc
+RUN DEBIAN_FRONTEND=noninteractive apt update && apt install -y \
+    curl \
+    python3
+
+# Scripts to start loads from outside container
+ADD --chmod=664 test_file.txt ./test_file.txt
+

--- a/recipes-ni/docker-functional-tests/files/test_parallel.sh
+++ b/recipes-ni/docker-functional-tests/files/test_parallel.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+PTEST_LOCATION=/usr/lib/docker-functional-tests/ptest
+
+if [ "$(docker images -q test_parallel_container:latest)" = "" ]; then
+    echo "Building test_parallel_container..."
+    DOCKER_BUILDKIT=1 \
+        docker build -t test_parallel_container --network=host \
+            ${PTEST_LOCATION}/test_parallel_container > /dev/null 2>&1
+    if [ "$(docker images -q test_parallel_container:latest)" = "" ]; then
+        echo "SKIP: Failed to build test_parallel_container"
+        exit 77
+    fi
+fi
+
+echo "Starting background container..."
+BG_CONT=$(docker run -d --privileged --network=host -t test_parallel_container \
+    python3 -m http.server)
+RESULT=`echo ${BG_CONT} | sed 's/.$//'` # Remove trailing carriage return
+echo "Started background container ${BG_CONT}"
+
+echo "Communicating with background container..."
+RESULT=$(docker run --privileged --network=host -t test_parallel_container \
+    curl http://0.0.0.0:8000/test_file.txt)
+RESULT=`echo ${RESULT} | sed 's/.$//'` # Remove trailing carriage return
+
+echo "Stopping background container..."
+docker exec ${BG_CONT} bash -c "killall -INT python3 > /dev/null 2>&1"
+docker container stop ${BG_CONT}
+
+EXP=$(cat ${PTEST_LOCATION}/test_parallel_container/test_file.txt)
+if [ "${RESULT}" != "${EXP}" ]; then
+    echo "ERROR: Received \"${RESULT}\" from background container, but expected \"${EXP}\""
+    exit 1
+fi
+exit 0
+

--- a/recipes-ni/docker-functional-tests/files/test_parallel_test_file.txt
+++ b/recipes-ni/docker-functional-tests/files/test_parallel_test_file.txt
@@ -1,0 +1,1 @@
+sent from container


### PR DESCRIPTION
We want to support docker, so we need to ensure that things like the daemon, `--network host`, parallel containers, etc all work.

WI #2500898

This PR provides two tests:

- test_daemon which simply verifies that `docker run hello-world` runs without error
- test_parallel which sets up a background docker container with a file server and a second docker container which reads the file from that server

Tested by building the package and running ptest-runner on a 9053