### PR TITLE
Fix packagegroup-ni-ptest-smoke typo

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-ptest-smoke.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-ptest-smoke.bb
@@ -16,7 +16,7 @@ RDEPENDS:${PN}:append = "\
     busybox-ptest \
     bzip2-ptest \
     coreutils-ptest \
-    docker-functional-ptest \
+    docker-functional-tests-ptest \
     e2fsprogs-ptest \
     elfutils-ptest \
     ethtool-ptest \


### PR DESCRIPTION
## Reason

In a [previous PR](https://github.com/ni/meta-nilrt/pull/631), we added a new test. That test was incorrectly added to packagegroup-ni-ptest-smoke and is causing errors in the PR build now.

## Implementation

- Change `docker-functional-ptest` to `docker-funcitonal-tests-ptest`

## Testing

Built `packagegroup-ni-ptest-smoke`