### PR TITLE
Add restarting the docker daemon to docker-functional-tests

### DIFF
--- a/recipes-ni/docker-functional-tests/files/test_daemon.sh
+++ b/recipes-ni/docker-functional-tests/files/test_daemon.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Hack: Docker-CE must be restarted before containers can build. This is the first ran test
+/etc/init.d/docker.init restart
+
 echo "Running docker hello-world..."
 if ! docker run hello-world 2>&1; then
     echo "ERROR: Couldn't execute \`docker run hello-world\`"


### PR DESCRIPTION
## Reason

This is similar to #630 

There is an issue with docker not running correctly after reboot (it fails to pull new images), so the daemon must be restarted before tests can run at the moment.

WI [AB#2500898](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2500898)

## Implementation

- Restart daemon in first test as a temporary fix (can be removed after the issue is properly corrected)

## Testing

- Verified the issue exists upon reboot and that restarting the daemon solves it on a 9035
- Built `packagegroup-ni-ptest-smoke` 
- Installed the new package and verified it runs without manually restarting the daemon``