### PR TITLE
linux-nilrt-next: Bump version to latest 6.6 development branch

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-next_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-next_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NILRT linux kernel next development build"
 NI_RELEASE_VERSION = "master"
-LINUX_VERSION = "6.1"
+LINUX_VERSION = "6.6"
 LINUX_KERNEL_TYPE = "next"
 
 require linux-nilrt-alternate.inc


### PR DESCRIPTION
Now that ni/linux#138 and ni/linux#141 have completed, we can bump the kernel-next recipe to start building the 6.6 kernel.

[AB#2484319](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2484319)