### PR TITLE
Revert docker restart commits as they are no longer needed.

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_idle_containerized.sh
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_idle_containerized.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# Hack: Docker-CE must be restarted before containers can build. This is the first ran test
-/etc/init.d/docker.init restart
-
 PTEST_LOCATION=/usr/lib/kernel-containerized-performance-tests/ptest
 LOG_DIR="/var/local/ptest-results/kernel-containerized-performance-tests"
 

--- a/recipes-ni/docker-functional-tests/files/test_daemon.sh
+++ b/recipes-ni/docker-functional-tests/files/test_daemon.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-# Hack: Docker-CE must be restarted before containers can build. This is the first ran test
-/etc/init.d/docker.init restart
-
 echo "Running docker hello-world..."
 if ! docker run hello-world 2>&1; then
     echo "ERROR: Couldn't execute \`docker run hello-world\`"


### PR DESCRIPTION
Commits 725f76755b00107390747cb4322e95d35980b789 and 9aada3274ba4536fb64f263954c0863602dd4d0a are no longer necessary as we have a fix for docker issue in oe-core https://github.com/ni/openembedded-core/commit/c1bcd98d1d230971395dc966ddf032ebd7b6a79b.
So reverting the commits.

### Testing
None