### PR TITLE
docker-functional-tests: add "PASS" echo statement to the ends of tests

### DIFF
--- a/recipes-ni/docker-functional-tests/files/test_daemon.sh
+++ b/recipes-ni/docker-functional-tests/files/test_daemon.sh
@@ -6,5 +6,7 @@ if ! docker run hello-world 2>&1; then
     exit 1
 fi
 
+echo "PASS: Docker - test daemon"
+
 exit 0
 

--- a/recipes-ni/docker-functional-tests/files/test_parallel.sh
+++ b/recipes-ni/docker-functional-tests/files/test_parallel.sh
@@ -33,5 +33,7 @@ if [ "${RESULT}" != "${EXP}" ]; then
     echo "ERROR: Received \"${RESULT}\" from background container, but expected \"${EXP}\""
     exit 1
 fi
+
+echo "PASS: Docker - test parallel"
 exit 0
 


### PR DESCRIPTION
While exit codes and error messages are printed, passes are not. We need these to actually triage tests.

Add `echo "PASS: Docker - <test name>"` to each of the tests here.