### PR TITLE
Revert "linux-nilrt-next: Bump version to latest 6.6 development branch"

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-next_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-next_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NILRT linux kernel next development build"
 NI_RELEASE_VERSION = "master"
-LINUX_VERSION = "6.6"
+LINUX_VERSION = "6.1"
 LINUX_KERNEL_TYPE = "next"
 
 require linux-nilrt-alternate.inc


### PR DESCRIPTION
Some NI proprietary drivers have issues with the next kernel, and our testing attempts to use them in PR builds. Temporarily downgrading this will allow us to address the issues.

This reverts commit bb4488479883997e99f43fab71f2fb411bcd622f.

[AB#2581830](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2581830)