### PR TITLE
kernel-performance-tests: Add container load test

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/run-container-load
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/run-container-load
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+function setup_container_load()
+{
+   docker pull hello-world
+}
+
+function start_container_load()
+{
+   while true; do
+      docker run hello-world > /dev/null
+      sleep 1
+   done
+}

--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/run-ptest
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/run-ptest
@@ -4,4 +4,5 @@
 ./test_kernel_cyclictest_hackbench.sh
 ./test_kernel_cyclictest_fio.sh
 ./test_kernel_cyclictest_iperf.sh
+./test_kernel_cyclictest_container_load.sh
 exit 0

--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/test_kernel_cyclictest_container_load.sh
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/test_kernel_cyclictest_container_load.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+source ./run-cyclictest
+source ./run-container-load
+
+# start background container load
+setup_container_load
+start_container_load &
+
+# measure the system latency under container load
+run_cyclictest "container"
+
+# clean-up
+kill $(jobs -p) 2>/dev/null
+
+exit $CYCLICTEST_RESULT

--- a/recipes-kernel/kernel-tests/kernel-performance-tests.bb
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests.bb
@@ -11,7 +11,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}-files:"
 S = "${WORKDIR}"
 
 DEPENDS = "virtual/kernel"
-RDEPENDS:${PN}-ptest += "bash rt-tests fio iperf3 python3 python3-pip"
+RDEPENDS:${PN}-ptest += "bash rt-tests fio iperf3 python3 python3-pip docker"
 RDEPENDS:${PN}-ptest:append:x64 = " fw-printenv"
 RDEPENDS:${PN}-ptest:append:armv7a = " u-boot-fw-utils"
 
@@ -27,6 +27,8 @@ SRC_URI += "\
     file://test_kernel_cyclictest_hackbench.sh \
     file://test_kernel_cyclictest_fio.sh \
     file://test_kernel_cyclictest_iperf.sh \
+    file://run-container-load \
+    file://test_kernel_cyclictest_container_load.sh \
 "
 
 do_install_ptest:append() {
@@ -39,6 +41,8 @@ do_install_ptest:append() {
     install -m 0755 ${S}/test_kernel_cyclictest_hackbench.sh ${D}${PTEST_PATH}
     install -m 0755 ${S}/test_kernel_cyclictest_fio.sh ${D}${PTEST_PATH}
     install -m 0755 ${S}/test_kernel_cyclictest_iperf.sh ${D}${PTEST_PATH}
+    install -m 0755 ${S}/run-container-load ${D}${PTEST_PATH}
+    install -m 0755 ${S}/test_kernel_cyclictest_container_load.sh ${D}${PTEST_PATH}
 }
 
 pkg_postinst_ontarget:${PN}-ptest:append() {


### PR DESCRIPTION
Add a cyclictest ptest with container start/stop in background.

WI: [2500900](https://dev.azure.com/ni/DevCentral/_workitems/edit/2500900)

### Testing
- [x] `bitbake kernel-performance-tests`
- [x] Installed `kernel-performance-tests-ptest` on a cRIO-9043 and a VM
- [x] Ran `ptest-runner` with `TEST_DURATION` set to 8s. The new test passes. Docker load is cleaned up at the end even if test is aborted.