### PR TITLE
Kernel Containerized Performance Tests: Print run-cyclictest output

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/cyclictest-container/call_run_ct.sh
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/cyclictest-container/call_run_ct.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 cd /ptests
 source ./run-cyclictest
-TEST_LOG=${LOG_DIR}/run_cyclictest-`date +'%Y_%m_%d-%H_%M_%S'`-${1}.log
+TEST_LOG=${LOG_DIR}/run_cyclictest-${1}.log
 run_cyclictest "${1}" > ${TEST_LOG} 2>&1
 echo "${CYCLICTEST_RESULT}"
 

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_fio_containerized.sh
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_fio_containerized.sh
@@ -37,9 +37,11 @@ RESULT=$(docker run --privileged --network=host \
     bash call_run_ct.sh "fio_containerized" \
         | tr -d '\r' | tr -d '\n')
 
+# Make sure we print the PASS/FAIL message
+cat ${LOG_DIR}/run_cyclictest-fio_containerized.log
+
 # Clean up the background container
 docker exec ${LOAD_CONT} bash -c "killall -INT fio > /dev/null 2>&1"
 
-echo "Test Result: ${RESULT}"
 exit ${RESULT}
 

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_hackbench_containerized.sh
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_hackbench_containerized.sh
@@ -37,10 +37,12 @@ RESULT=$(docker run --privileged --network=host \
     bash call_run_ct.sh "hackbench_containerized" \
         | tr -d '\r' | tr -d '\n')
 
+# Make sure we print the PASS/FAIL message
+cat ${LOG_DIR}/run_cyclictest-hackbench_containerized.log
+
 # Clean up the background container
 docker exec ${LOAD_CONT} \
     bash -c "killall -INT hackbench > /dev/null 2>&1"
 
-echo "Test Result: ${RESULT}"
 exit ${RESULT}
 

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_idle_containerized.sh
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_idle_containerized.sh
@@ -24,6 +24,8 @@ RESULT=$(docker run --privileged --network=host \
     bash call_run_ct.sh "idle_containerized" \
         | tr -d '\r' | tr -d '\n')
 
-echo "Test result: ${RESULT}"
+# Make sure we print the PASS/FAIL message
+cat ${LOG_DIR}/run_cyclictest-idle_containerized.log
+
 exit ${RESULT}
 

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_iperf_containerized.sh
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_iperf_containerized.sh
@@ -54,10 +54,12 @@ RESULT=$(docker run --privileged --network=host \
     bash call_run_ct.sh "iperf_containerized" \
         | tr -d '\r' | tr -d '\n')
 
+# Make sure we print the PASS/FAIL message
+cat ${LOG_DIR}/run_cyclictest-iperf_containerized.log
+
 # Clean up the background container
 docker exec ${LOAD_CONT} \
     bash -c "killall -INT iperf3 > /dev/null 2>&1"
 
-echo "Test result: ${RESULT}"
 exit ${RESULT}
 


### PR DESCRIPTION
## Reason

The script `run-cyclictest` is run from within a container, and although the output is logged, it is never printed, meaning the tests do not print the PASS/FAIL messages required of ptests.

## Implementation

- After tests run, print the run-cyclictest log to stdout
- Remove date from log name (unneeded and makes it complicated to correctly cat the log)

## Testing

Ran through on ATS hardware and saw PASS messages appear