### PR TITLE
[kirkstone] linux-nilrt-nohz: Downgrade to 5.15 kernel

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-nohz_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-nohz_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NILRT linux kernel full dynamic ticks (NO_HZ_FULL) build"
 NI_RELEASE_VERSION = "master"
-LINUX_VERSION = "6.1"
+LINUX_VERSION = "5.15"
 LINUX_KERNEL_TYPE = "nohz"
 
 require linux-nilrt-alternate.inc


### PR DESCRIPTION
Same justification as #621, but now cherry-picked into the master branch to avoid performance regressions in the 24Q1 release.

# Testing
* [x] `bitbake -c configure linux-nilrt-nohz` succeeds.

# Meta
* Will cherry-pick to the `next` branch.