### PR TITLE
[kirkstone] ni-rtfeatures: handle poweron reset_source

### DIFF
--- a/recipes-ni/ni-rtfeatures/files/ni-rtfeatures.initd
+++ b/recipes-ni/ni-rtfeatures/files/ni-rtfeatures.initd
@@ -46,6 +46,9 @@ log_reset_source () {
 		ironclad)
 			log INFO "reset_source=${reason}  # Ironclad watchdog timer expired"
 			;;
+		poweron)
+			log INFO "reset_source=${reason}  # System powered-on; not reset."
+			;;
 		processor)
 			log INFO "reset_source=${reason}  # Reset from MAX or command line"
 			;;

--- a/recipes-ni/ni-rtfeatures/files/ni-rtfeatures.initd
+++ b/recipes-ni/ni-rtfeatures/files/ni-rtfeatures.initd
@@ -56,7 +56,7 @@ log_reset_source () {
 			log INFO "reset_source=${reason}  # RT watchdog timer expired"
 			;;
 		*)
-			log ERROR "Unkown reset_source string: \"$reason\""
+			log ERROR "Unknown reset_source string: \"$reason\""
 			;;
 	esac
 }

--- a/recipes-ni/ni-rtfeatures/ni-rtfeatures.bb
+++ b/recipes-ni/ni-rtfeatures/ni-rtfeatures.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 DEPENDS += "update-rc.d-native"
 
-PV = "2.0"
+PV = "2.1"
 
 
 SRC_URI += "\


### PR DESCRIPTION
```
When the reset_source register is `0x00` (no flags) - as in cases where
the system is totally powered off and then on - the ni-rtfeatures
driver writes "poweron" into the reset_source sysfs entry. The
ni-rtfeatures initscript does not handle this string, and warns that the
sysfs is malformed.

Handle this case in the initscript, and provide some useful logging
output.
```

[AB#2582066](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2582066)

# Testing
* [x] `ni-rtfeatures` recipe builds.
* Will ask the bug filer if they can validate the new log entry in their ATS, once it has been merged.

# Meta
* Will cherry-pick to master-next.