### PR TITLE
Allow choice of source for fw_printenv/fw_setenv

### DIFF
--- a/recipes-ni/fw-printenv/files/fw_printenv
+++ b/recipes-ni/fw-printenv/files/fw_printenv
@@ -9,10 +9,10 @@
 print_help(){
 cat <<EOF
 fw_printenv/fw_setenv, an implementation of the U-Boot environment variable facility in Grub/EFI
-usage:  fw_printenv [-n] [variable name]
-	fw_setenv [variable name] [variable value]
-	fw_setenv -s [ file ]
-	fw_setenv -s - < [ file ]
+usage:  fw_printenv [-t table name] [-n] [variable name]
+        fw_setenv [-t table name] [variable name] [variable value]
+        fw_setenv [-t table name] -s [ file ]
+        fw_setenv [-t table name] -s - < [ file ]
 
 File syntax example:
 	# Any line starting with # is treated as comment
@@ -23,6 +23,12 @@ File syntax example:
 In this case, var1 will be deleted, var2 and other_value
 will be set with the values passed. The value can contain any
 number of spaces.
+
+Table names:
+	smbios
+	efi
+	grub
+	all (the default)
 EOF
 }
 
@@ -209,7 +215,7 @@ print_invalid_opt(){
 }
 
 parse_opt(){
-	while getopts ":hn:s:-:" opt;
+	while getopts ":hn:t:s:-:" opt;
 	do
 		case "${opt}" in
 
@@ -225,6 +231,19 @@ parse_opt(){
 			h)	#print help and exit
 				print_help >&2
 				exit
+				;;
+			t)	if [ -n "$table" ]; then
+					echo "$0: -t argument cannot be repeated" >&2
+					exit 1
+				fi
+				case "${OPTARG}" in
+					smbios | efi | grub | all)
+						table="${OPTARG}"
+						;;
+					*)	echo "$0: -t argument must be one of \"smbios\", \"efi\", \"grub\", or \"all\"" >&2
+						exit 1
+						;;
+				esac
 				;;
 			s)	s_opt=1; s_file=$OPTARG ;;
 			n)	n_opt=1; varnames=$OPTARG ;;
@@ -255,6 +274,8 @@ parse_opt(){
 		echo "## Error: '-n' option requires exactly one argument" >&2
 		exit 1
 	fi
+
+	table="${table:-all}"
 }
 
 if [[ $0 =~ fw_setenv ]]; then
@@ -270,6 +291,7 @@ fi
 s_opt=0
 s_file=""
 n_opt=0
+table=""
 varnames=$@
 
 #parse opt for both printenv and setenv

--- a/recipes-ni/fw-printenv/files/fw_printenv
+++ b/recipes-ni/fw-printenv/files/fw_printenv
@@ -137,13 +137,50 @@ show_variable_efi(){
 #wraps together smbios, efi and grub variable query
 show_variable(){
 	if [ $# -eq 0 ]; then
-		#show all variables
-		show_variable_smbios && show_variable_efi && show_variable_grub
-		return $?
+		case "$table" in
+			smbios)	show_variable_smbios
+				return $?
+				;;
+			efi)	show_variable_efi
+				return $?
+				;;
+			grub)	show_variable_grub
+				return $?
+				;;
+			all)	show_variable_smbios && show_variable_efi && show_variable_grub
+				return $?
+				;;
+			*) 	echo "Bug: unhandled table type" >&2
+				exit 2
+				;;
+		esac
 	else
 		value=""
-		#check for single variable
-		if show_variable_smbios $1 || show_variable_efi $1 || show_variable_grub $1; then
+		case "$table" in
+			smbios)	show_variable_smbios "$1"
+				success=$?
+				;;
+			efi)	show_variable_efi "$1"
+				success=$?
+				;;
+			grub)	show_variable_grub "$1"
+				success=$?
+				;;
+			all)	# TODO this isn't "all," this is "first successful"
+				if show_variable_smbios $1 || show_variable_efi $1 || show_variable_grub $1; then
+					(( n_opt )) || printf '%s=' "$var_name"
+					printf '%s\n' "$value"
+					return 0
+				else
+					echo "## Error: \"$var_name\" not defined " >&2
+					exit 1
+				fi
+				;;
+			*)	echo "Bug: unhandled table type" >&2
+				exit  2
+				;;
+		esac
+		if [ 0 -eq $success ]; then
 			(( n_opt )) || printf '%s=' "$var_name"
 			printf '%s\n' "$value"
 			return 0

--- a/recipes-ni/fw-printenv/files/fw_printenv
+++ b/recipes-ni/fw-printenv/files/fw_printenv
@@ -322,7 +322,8 @@ parse_opt(){
 	done
 
 	#check if there are other options passed incorrectly
-	shift $(($OPTIND - 1))
+	shift_amount="$(($OPTIND - 1))"
+	shift $shift_amount
 	if [ "x$(echo $* | grep ' \-')" != "x" ]; then
 		echo "$0:  invalid syntax" >&2
 		echo "Try '$0 --help' for more information"
@@ -361,10 +362,12 @@ s_opt=0
 s_file=""
 n_opt=0
 table=""
-varnames=$@
+shift_amount=0
 
 #parse opt for both printenv and setenv
 parse_opt $@
+shift $shift_amount
+varnames=$@
 
 if (( ! is_setenv )) ; then
 	if [ $# -eq 0 ] ; then # if no arguments, list the variables

--- a/recipes-ni/fw-printenv/files/fw_printenv
+++ b/recipes-ni/fw-printenv/files/fw_printenv
@@ -194,35 +194,67 @@ show_variable(){
 add_rem_vars(){
 	value=""
 
-	#SMBIOS - are read only variables
-	if is_ni_bios || is_ni_device; then
-		if show_variable_smbios "$var_name"; then
-			echo "Can't overwrite" "\"$var_name\"" >&2
+	case "$table" in
+		smbios)	echo "SMBIOS variables are read-only" >&2
 			exit 1
-		fi
-	fi
+			;;
+		efi)	if [ -n "$new_value" ]; then
+				if [ "${efi_funcs[$var_name]}" ]; then
+					${efi_funcs[$var_name]} $new_value
+					return
+				else
+					echo "Not a valid EFI variable: $var_name" >&2
+					exit 1
+				fi
+			else
+				echo "EFI variables can't be deleted" >&2
+				exit 1
+			fi
+			;;
+		grub)	if readonly_grub_variable "$var_name"; then
+				echo "Can't overwrite" "\"$var_name\"" >&2
+				exit 1
+			fi
+			if [[ $new_value ]]; then
+				grub-editenv - set "$var_name=$new_value"
+			else
+				grub-editenv - unset "$var_name"
+			fi
+			;;
+		all)	#SMBIOS - are read only variables
+			if is_ni_bios || is_ni_device; then
+				if show_variable_smbios "$var_name"; then
+					echo "Can't overwrite" "\"$var_name\"" >&2
+					exit 1
+				fi
+			fi
 
-	#EFI
-	if [ "${efi_funcs[$var_name]}" ]; then
-		if [ -n "$new_value" ]; then
-			${efi_funcs[$var_name]} $new_value
-			return
-		else
-			echo "Can't delete" "\"$var_name\"" >&2
-			exit 1
-		fi
-	fi
+			#EFI
+			if [ "${efi_funcs[$var_name]}" ]; then
+				if [ -n "$new_value" ]; then
+					${efi_funcs[$var_name]} $new_value
+					return
+				else
+					echo "Can't delete" "\"$var_name\"" >&2
+					exit 1
+				fi
+			fi
 
-	#Grub
-	if readonly_grub_variable "$var_name"; then
-		echo "Can't overwrite" "\"$var_name\"" >&2
-		exit 1
-	fi
-	if [[ $new_value ]]; then
-		grub-editenv - set "$var_name=$new_value"
-	else
-		grub-editenv - unset "$var_name"
-	fi
+			#Grub
+			if readonly_grub_variable "$var_name"; then
+				echo "Can't overwrite" "\"$var_name\"" >&2
+				exit 1
+			fi
+			if [[ $new_value ]]; then
+				grub-editenv - set "$var_name=$new_value"
+			else
+				grub-editenv - unset "$var_name"
+			fi
+			;;
+		*)	echo "Bug: unhandled table type" >&2
+			exit 2
+			;;
+	esac
 }
 
 read_vars_from_file(){


### PR DESCRIPTION
As noted in [AB#2546902](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2546902), fw_printenv will print the "same" variable multiple times if it is found in multiple places (for instance, both SMBIOS and GRUB). Since we don't know which table should take priority in all cases, we can offer a choice to the user with a command-line argument.

## Testing
Used a VM with doubly-defined variables from SMBIOS and GRUB, as described in the bug. I haven't tested examining/manipulating EFI variables.

 - The default behavior of `fw_printenv` has not changed: doubly-defined variables are still printed twice without indicating their origin.
 - The default behavior of `fw_printenv variable` has not changed: doubly-defined variables have one of them chosen "arbitrarily" (really, it's just the first successful lookup, as before).
 - `fw_printenv -t table` prints all variables from the indicated table.
 - `fw_printenv -t table variable` prints the indicated variable from the indicated table.
 - The behavior of `fw_setenv` without the `-t` argument has not changed.
 - `fw_setenv -t table variable value` behaves appropriately.