### PR TITLE
fio.cfg: Enable options to reduce memory footprint

### DIFF
--- a/recipes-kernel/kernel-tests/files/fio.cfg
+++ b/recipes-kernel/kernel-tests/files/fio.cfg
@@ -7,6 +7,8 @@ openfiles=10
 direct=0
 verify=sha256
 do_verify=1
+experimental_verify=1
+random_generator=lfsr
 time_based
 clocksource=clock_gettime
 bs=5k


### PR DESCRIPTION
fio keeps consuming more memory the longer it is run and at somepoint, runs out of memory on some targets and gets killed.

This generates a huge coredump which on some targets contributes to filling up diskspace.

So set 'experimental_verify', 'random_generator' options as suggested in https://lore.kernel.org/all/50F12401.8090606@kernel.dk/T/ which causes not more than a few MB of memory to be used.

WI: [AB#2609746](https://dev.azure.com/ni/DevCentral/_workitems/edit/2609746)

### Testing
- [x] Ran `fio` with this .cfg for 3 hours and verified that memory footprint stays constant.
- [x] Ran containerized and non containerized ptests for 20s each with this .cfg without issues.