### PR TITLE
kernel-performance-tests: Remove stopped containers

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-performance-tests-files/run-container-load
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests-files/run-container-load
@@ -9,6 +9,6 @@ function start_container_load()
 {
    while true; do
       docker run hello-world > /dev/null
-      sleep 1
+      docker container prune -f > /dev/null
    done
 }


### PR DESCRIPTION
Container load test starts a docker container every few secconds which creates more and more files on disk until inodes are exhausted.

So run 'docker container prune -f' after each container run.

Also remove sleep between container runs as 'docker container prune -f' itself adds some delay.

WI: [AB#2609746](https://dev.azure.com/ni/DevCentral/_workitems/edit/2609746)

### Testing
- [x] Verified that running `docker container prune -f` on a system that had no inodes left after the test frees up inodes.
- [x] Ran container load test on a cRIO-9041 with these changes for 2 mins and verified from `docker ps -a` that stopped containers are removed.