### PR TITLE
kernel-tests: add replacement pattern for filesystem UUIDs

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-tests-files/kernel_dmesg_diff.py
+++ b/recipes-kernel/kernel-tests/kernel-tests-files/kernel_dmesg_diff.py
@@ -199,7 +199,8 @@ replacement_patterns = [
         [r'tsc: Refined TSC clocksource calibration: \d+.\d+ MHz', 'tsc: Refined TSC clocksource calibration: MHz'],
         [r'software IO TLB: mapped mem .*', 'software IO TLB: mapped mem'],
         [r'eth\d:', 'ethX:'],
-        [r'renamed from eth\d', 'renamed from ethX']
+        [r'renamed from eth\d', 'renamed from ethX'],
+        [r'mounted filesystem [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}', 'mounted filesystem xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx']
 ]
 
 def strip_known_differences(log):


### PR DESCRIPTION
I noticed that kernel_dmesg_diff.py was returning different hashes for each run against the 6.6 kernel. Many of those diffs would have identical hashes except that some filesystem UUIDs in the dmesg log are changing on each run. I updated the kernel_dmesg_diff.py test with an additional regex pattern so they can be grouped going forward.

[AB#2600436](https://dev.azure.com/ni/DevCentral/_workitems/edit/2600436)

### Testing
Ran kernel_dmesg_diff.py manually with this change and supplied the date of an affected dmesg log with --current_log_db_date. The output confirmed the changing UUIDs are replaced with a constant string.