### PR TITLE
pkggrp-ni-internal-deps: rm ni-grpc-device

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
@@ -24,9 +24,9 @@ RDEPENDS:${PN} += "\
 "
 
 # ni-sync
-RDEPENDS:${PN} += "\
-	ni-grpc-device \
-"
+#RDEPENDS:${PN} += "\
+#	ni-grpc-device \
+#"
 
 # Required components for Veristand.
 # Engineering contact: Marcelo Izaguirre


### PR DESCRIPTION
The ni-grpc-device recipe doesn't compile with grpc > 1.51.1. Rather than pulling the whole distro back to an older grpc version, temporarily disable ni-grpc-device until we can improve its compatibility.

The alternative to this patchset was to introduce a 14 commit revert into three recipes in meta-oe, which would massively complicate any future currency merges. I'll create a bug item to track the effort of getting ni-grpc-device in order and reverting this change.

[AB#2467374](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2467374)

# Testing
* [x] Revalidated that the core packagefeed succeeds without this failing recipe.