### PR TITLE
[next] Fix ni-hw-scripts-common and ni-rtfeatures allarch implementations

### DIFF
--- a/recipes-ni/ni-hw-scripts/ni-hw-scripts-common.bb
+++ b/recipes-ni/ni-hw-scripts/ni-hw-scripts-common.bb
@@ -16,6 +16,11 @@ SRC_URI += "\
 S = "${WORKDIR}"
 
 
+inherit allarch
+PACKAGE_ARCH = "all"
+PACKAGES:remove = "${PN}-staticdev ${PN}-dev ${PN}-dbg"
+
+
 do_install () {
 	install -d ${D}${sysconfdir}/init.d/
 
@@ -45,9 +50,6 @@ pkg_postrm:${PN} () {
 	update-rc.d $OPT nisetserialnumber remove
 }
 
-
-PACKAGE_ARCH = "all"
-PACKAGES:remove = "${PN}-staticdev ${PN}-dev ${PN}-dbg"
 
 FILES:${PN} += "\
 	${sysconfdir}/init.d/ni-rename-ifaces \

--- a/recipes-ni/ni-rtfeatures/ni-rtfeatures.bb
+++ b/recipes-ni/ni-rtfeatures/ni-rtfeatures.bb
@@ -20,6 +20,11 @@ SRC_URI += "\
 S = "${WORKDIR}"
 
 
+inherit allarch
+PACKAGE_ARCH = "all"
+PACKAGES:remove = "${PN}-staticdev ${PN}-dev ${PN}-dbg"
+
+
 do_install:append () {
 	install -d ${D}${sysconfdir}/init.d/
 	install -m 0755 ${S}/handle_cpld_ip_reset.initd  ${D}${sysconfdir}/init.d/handle_cpld_ip_reset
@@ -49,9 +54,6 @@ pkg_postrm:${PN} () {
 	update-rc.d $OPT ni-rtfeatures remove
 }
 
-
-PACKAGE_ARCH = "all"
-PACKAGES:remove = "${PN}-staticdev ${PN}-dev ${PN}-dbg"
 
 FILES:${PN} += "\
 	${sysconfdir}/init.d/* \


### PR DESCRIPTION
```
    ni-hw-scripts-common: fixup allarch variables
    
    When setting a package as "all" architecture, it is important to inherit
    'allarch.bbclass', in order to set many secondary variables for that
    case.
    
    ni-hw-scripts-common does not inherit 'allarch'. As a result, its spdx
    sstate hash information is namespaced as 'all/', instead of the expected
    'allarch/'. As a result, the SPDX operations in do_rootfs fail to find
    its SPDX snippet.
    
    Fixup the recipe by inheriting allarch.bbclass.
```

Ditto for ni-rtfeatures.

[AB#2467374](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2467374)

# Testing
* [x] Built the affected recipes and core packagegroup with this change. The create-spdx bbclass no longer complains that it cannot find the spdx json.