### PR TITLE
Revert "linux-nilrt-nohz: Downgrade to 5.15 kernel"

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-nohz_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-nohz_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NILRT linux kernel full dynamic ticks (NO_HZ_FULL) build"
 NI_RELEASE_VERSION = "master"
-LINUX_VERSION = "5.15"
+LINUX_VERSION = "6.1"
 LINUX_KERNEL_TYPE = "nohz"
 
 require linux-nilrt-alternate.inc


### PR DESCRIPTION
This reverts commit afb05b05939c4459eb10fdd51d0ba8148cea217d.

We have determined that, at this time, the current shipping products and client teams using the nohz kernel (NO_HZ_FULL) variant are not affected by the small regression in performance observed in the 6.1 nohz stress test[1].

Re-upgrade the nohz kernel to 6.1 in order to keep it in sync and up to date with the rest of the shipping kernel variants. Root cause analysis and testing will continue if/when needed.

[1] https://dev.azure.com/ni/DevCentral/_wiki/wikis/AppCentral.wiki/103057/NO_HZ-Kernel-Uses
[AB#2488177](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2488177)

### Testing

- [x] bitbake linux-nilrt-nohz