### PR TITLE
fs_permissions_diff: Run logrotate before running the test

### DIFF
--- a/recipes-ni/ni-base-system-image-tests/files/fs_permissions_diff.py
+++ b/recipes-ni/ni-base-system-image-tests/files/fs_permissions_diff.py
@@ -369,6 +369,11 @@ def diff_manifests(current_manifest, basis_manifest, recent_manifest, logger):
 
     return not any_differences
 
+def prepare_system_for_manifest():
+    # logrotate may not have run yet, so run it now to generate
+    # the logrotate.status
+    subprocess.run(["/usr/sbin/logrotate", "/etc/logrotate.conf"])
+
 def parse_args():
     parser = argparse.ArgumentParser(description='diff fs permissions with previous')
     parser.add_argument('--server', required=True, help='Mongo server hostname')
@@ -397,6 +402,7 @@ def main():
     if args.current_log_db_date:
         fs_manifest = get_previous_fs_manifest_as_current(db, args.current_log_db_date, logger)
     else:
+        prepare_system_for_manifest()
         fs_manifest = get_fs_manifest()
 
     if not args.current_log_db_date and not args.skip_upload:


### PR DESCRIPTION
logrotate runs via cron every 5 mins, which means that sometimes logrotate.status will be there and sometimes it won't during runs.  We do want to check that it's permissions are correct, so manually poke it the same way that cron will do it before running the test.

### Testing

None (aside from running the command on a target), but it's difficult to reproduce the condition of the DUT outside the ATS at the moment of testing.  Once this is complete the results will either start passing or continue failing and need a bit of further tweaking.
