### PR TITLE
kernel-containerized-performance-tests: Fix distro info

### DIFF
--- a/recipes-kernel/kernel-tests/files/run-docker-cyclictest
+++ b/recipes-kernel/kernel-tests/files/run-docker-cyclictest
@@ -10,6 +10,7 @@ case "$#" in
 		       -v /usr/share/fw_printenv:/usr/share/fw_printenv \
 		       -v /sbin/fw_printenv:/sbin/fw_printenv \
 		       -v /usr/share/nisysinfo:/usr/share/nisysinfo \
+		       -v /etc/os-release:/etc/os-release \
 		       -v /dev:/dev \
 		       -w ${TEST_DIR} \
 		       -t cyclictest-container \
@@ -25,6 +26,7 @@ case "$#" in
 		       -v /usr/share/fw_printenv:/usr/share/fw_printenv \
 		       -v /sbin/fw_printenv:/sbin/fw_printenv \
 		       -v /usr/share/nisysinfo:/usr/share/nisysinfo \
+		       -v /etc/os-release:/etc/os-release \
 		       -v /dev:/dev \
 		       -w ${TEST_DIR} \
 		       -t cyclictest-container \


### PR DESCRIPTION
kernel-containerized-performance-tests run inside a container, and distro_name, distro_version parsed from /etc/os-release are from the container itself.

Mount /etc/os-release from the host into container so host's distro_name, distro_version get parsed instead.

WI: [AB#2618107](https://dev.azure.com/ni/DevCentral/_workitems/edit/2618107)

### Testing
Ran the ptests on a `cRIO-9037` and verified that `distro_version`, `distro_name` are from host's `/etc/os-release`.