### PR TITLE
Replace egrep with grep -E in recovery tool files

### DIFF
--- a/recipes-core/base-files/base-files/safemode-ps1.sh
+++ b/recipes-core/base-files/base-files/safemode-ps1.sh
@@ -1,3 +1,3 @@
-if [ -f /etc/natinst/safemode ] || /sbin/runlevel | egrep -q ' 4$' ; then
+if [ -f /etc/natinst/safemode ] || /sbin/runlevel | grep -Eq ' 4$' ; then
 	PS1="(safemode) $PS1"
 fi

--- a/recipes-core/initrdscripts/files/ni_provisioning
+++ b/recipes-core/initrdscripts/files/ni_provisioning
@@ -3,7 +3,7 @@
 INVALID_NILRT_ID_MSG="Invalid value for PROVISION_PART_NILRT_ID. Use UUID=<value> or PARTUUID=<value> or auto."
 
 # verify required tools are installed
-for toolName in poweroff reboot mount umount sync ls rm ln mkdir cp echo printf dirname basename find grep egrep tar bzip2 bunzip2 lsblk cut udevadm date sleep head; do
+for toolName in poweroff reboot mount umount sync ls rm ln mkdir cp echo printf dirname basename find grep tar bzip2 bunzip2 lsblk cut udevadm date sleep head; do
 	if ! type "$toolName" >/dev/null; then
 		printf "\n***Error: Missing $toolName\n"
 		printf "PROVISIONING FAILED!"

--- a/recipes-core/initrdscripts/files/ni_provisioning.common
+++ b/recipes-core/initrdscripts/files/ni_provisioning.common
@@ -346,7 +346,7 @@ elif [ "$ARCH" = "x86_64" ]; then
 			echo "Configuring EFI for A/B image boot..."
 
 			# Delete existing NILRT entries with "-B" option
-			for ENTRY in $(efibootmgr | egrep -i '(LabVIEW RT)|(niboota)|(nibootb)' | egrep -o '[0-9A-Fa-f]{4}' || true);
+			for ENTRY in $(efibootmgr | grep -Ei '(LabVIEW RT)|(niboota)|(nibootb)' | grep -Eo '[0-9A-Fa-f]{4}' || true);
 			do
 				do_silent echo "Drop entry $ENTRY"
 				EFIMGR=$(efibootmgr -b "$ENTRY" -B 2>&1) || print_warning "efibootmgr -b $ENTRY -B failed with: $EFIMGR"
@@ -383,19 +383,19 @@ elif [ "$ARCH" = "x86_64" ]; then
 			#  first two boot entries and niboota is BootNext
 			echo -n "Check EFI boot configuration: "
 
-			boot_order=$(echo "$efi_boot_config" | egrep "^BootOrder: [0-9,]+" | cut -d" " -f2)
+			boot_order=$(echo "$efi_boot_config" | grep -E "^BootOrder: [0-9,]+" | cut -d" " -f2)
 			boot_A_numb=$(echo "$boot_order" | cut -d"," -f1)
 			boot_B_numb=$(echo "$boot_order" | cut -d"," -f2)
 
-			if ! echo "$efi_boot_config" | egrep -q "^Boot${boot_A_numb}.* niboota"$'\t'"+HD\(1,"; then
+			if ! echo "$efi_boot_config" | grep -Eq "^Boot${boot_A_numb}.* niboota"$'\t'"+HD\(1,"; then
 				die "niboota is not at Boot${boot_A_numb}, boot_order=$boot_order"
 			fi
 
-			if ! echo "$efi_boot_config" | egrep -q "^Boot${boot_B_numb}.* nibootb"$'\t'"+HD\(2,"; then
+			if ! echo "$efi_boot_config" | grep -Eq "^Boot${boot_B_numb}.* nibootb"$'\t'"+HD\(2,"; then
 				die "nibootb is not at Boot${boot_B_numb}, boot_order=$boot_order"
 			fi
 
-			boot_next=$(echo "$efi_boot_config" | egrep "^BootNext: [0-9]+ *$" | cut -d" " -f2)
+			boot_next=$(echo "$efi_boot_config" | grep -E "^BootNext: [0-9]+ *$" | cut -d" " -f2)
 			[ "$boot_next" == "$boot_A_numb" ] || die "BootNext=$boot_next, expecting niboota at $boot_A_numb"
 
 			echo "OK"
@@ -599,7 +599,7 @@ check_answer_file()
 	if [ -r "$filePath" ]; then
 		# Answer file may only contain lines beginning with '#' or 'PROVISION_*=' variables
 		if [ "`head -1 "$filePath"`" == "#NI_PROVISIONING_ANSWERS_V1" ]; then
-			if ! egrep -q -v '(^$|^#|^PROVISION_[A-Z0-9_]+=)' "$filePath"; then
+			if ! grep -E -q -v '(^$|^#|^PROVISION_[A-Z0-9_]+=)' "$filePath"; then
 				return 0
 			fi
 		fi

--- a/recipes-core/initrdscripts/files/ni_provisioning.safemode
+++ b/recipes-core/initrdscripts/files/ni_provisioning.safemode
@@ -211,7 +211,7 @@ install_grub()
 	GRUB_TARGET=$(uname -m)
 	cp /boot/EFI/BOOT/bootx64.efi $GRUB_TARGET_DIR
 	# Delete existing NILRT entries with "-B" option
-	for ENTRY in $(efibootmgr | egrep -i '(LabVIEW RT)|(niboota)|(nibootb)' | egrep -o '[0-9A-Fa-f]{4}' || true);
+	for ENTRY in $(efibootmgr | grep -Ei '(LabVIEW RT)|(niboota)|(nibootb)' | grep -Eo '[0-9A-Fa-f]{4}' || true);
 	do
 		print_info " Drop entry $ENTRY."
 		EFIMGR=$(efibootmgr -b "$ENTRY" -B 2>&1) || print_warning "efibootmgr -b $ENTRY -B failed with: $EFIMGR"

--- a/recipes-ni/ni-smbios-helper/files/smbios_helper
+++ b/recipes-ni/ni-smbios-helper/files/smbios_helper
@@ -70,7 +70,7 @@ get_serial_number()
     local sn="`$DMIDECODE -t 1 | grep "Serial Number:"`"
 
     # Filter out invalid sn strings like "Not Applicable" and "Not Specified"
-    if echo "$sn" | egrep -q "Serial Number: Not "; then
+    if echo "$sn" | grep -Eq "Serial Number: Not "; then
         sn=""
     fi
 


### PR DESCRIPTION
The version of egrep present in the recovery tool now outputs "egrep is obsolescent; using grep -E" on every call. Replacing egrep with grep -E in all locations present in the recovery tool.

[AB#2655026](https://dev.azure.com/ni/DevCentral/_workitems/edit/2655026)

### Testing
Built nilrt-recovery-media, put iso on a USB key, provisioned a target, exited to recovery shell, rebooted, and confirmed target seemed to provision correctly. Confirmed all "egrep is obsolescent" output is now gone.


