### PR TITLE
ni_provisioning: fix efibootmgr output parsing

### DIFF
--- a/recipes-core/initrdscripts/files/ni_provisioning.common
+++ b/recipes-core/initrdscripts/files/ni_provisioning.common
@@ -346,10 +346,11 @@ elif [ "$ARCH" = "x86_64" ]; then
 			echo "Configuring EFI for A/B image boot..."
 
 			# Delete existing NILRT entries with "-B" option
-			for ENTRY in $(efibootmgr | grep -Ei '(LabVIEW RT)|(niboota)|(nibootb)' | grep -Eo '[0-9A-Fa-f]{4}' || true);
+			for ENTRY in $(efibootmgr | grep -Ei '(LabVIEW RT)|(niboota)|(nibootb)' | grep -Eo 'Boot[0-9A-Fa-f]{4}' || true);
 			do
-				do_silent echo "Drop entry $ENTRY"
-				EFIMGR=$(efibootmgr -b "$ENTRY" -B 2>&1) || print_warning "efibootmgr -b $ENTRY -B failed with: $EFIMGR"
+				ENTRY_NUMBER=${ENTRY: 4:4}
+				do_silent echo "Drop entry $ENTRY_NUMBER"
+				EFIMGR=$(efibootmgr -b "$ENTRY_NUMBER" -B 2>&1) || print_warning "efibootmgr -b $ENTRY_NUMBER -B failed with: $EFIMGR"
 			done
 
 			# Add nibootX entries with "-c" option

--- a/recipes-core/initrdscripts/files/ni_provisioning.safemode
+++ b/recipes-core/initrdscripts/files/ni_provisioning.safemode
@@ -211,10 +211,11 @@ install_grub()
 	GRUB_TARGET=$(uname -m)
 	cp /boot/EFI/BOOT/bootx64.efi $GRUB_TARGET_DIR
 	# Delete existing NILRT entries with "-B" option
-	for ENTRY in $(efibootmgr | grep -Ei '(LabVIEW RT)|(niboota)|(nibootb)' | grep -Eo '[0-9A-Fa-f]{4}' || true);
+	for ENTRY in $(efibootmgr | grep -Ei '(LabVIEW RT)|(niboota)|(nibootb)' | grep -Eo 'Boot[0-9A-Fa-f]{4}' || true);
 	do
-		print_info " Drop entry $ENTRY."
-		EFIMGR=$(efibootmgr -b "$ENTRY" -B 2>&1) || print_warning "efibootmgr -b $ENTRY -B failed with: $EFIMGR"
+		ENTRY_NUMBER=${ENTRY: 4:4}
+		print_info " Drop entry $ENTRY_NUMBER."
+		EFIMGR=$(efibootmgr -b "$ENTRY_NUMBER" -B 2>&1) || print_warning "efibootmgr -b $ENTRY_NUMBER -B failed with: $EFIMGR"
 	done
 	efibootmgr $VERBOSE_ARGS -c -d ${TARGET_DISK} -p 1 -L 'LabVIEW RT' -l '\efi\boot\bootx64.efi'
 	print_done


### PR DESCRIPTION
The output of efibootmgr changed to include the PARTUUID of each boot entry. This broke the parsing code which previously scanned boot entries for a sequence of four digits.

[AB#2655037](https://dev.azure.com/ni/DevCentral/_workitems/edit/2655037)

### Testing
Built nilrt-recovery-media, put iso on a USB key, provisioned a target, exited to recovery shell, rebooted, and confirmed target seemed to provision correctly. Confirmed all extraneous "Drop entry" output is now gone.