### PR TITLE
cifs-utils: RDEPENDS on keyutils

### DIFF
--- a/recipes-support/cifs/cifs-utils_%.bbappend
+++ b/recipes-support/cifs/cifs-utils_%.bbappend
@@ -1,0 +1,4 @@
+# keyutils is required to be able to mount cifs shares when
+# CONFIG_CIFS_DFS_UPCALL is enabled. So adding it as dependency for
+# cifs-tools as cifs-tools is already a requirement to mount cifs shares.
+RDEPENDS:${PN} += "keyutils"


### PR DESCRIPTION
keyutils is required to be able to mount cifs shares when CONFIG_CIFS_DFS_UPCALL is enabled. So adding it as dependency for cifs-tools as cifs-tools is already a requirement to mount cifs shares.

WI: [AB#2627735](https://dev.azure.com/ni/DevCentral/_workitems/edit/2627735).

### Testing
- [x] `bitbake cifs-utils`
- [x] Installed `cifs-utils` on a VM and verified that with CONFIG_CIFS_DFS_UPCALL enabled, cifs shares containing DFS links work when correct `vers=<>` is specified in mount options.

Related: https://github.com/ni/linux/pull/149