### PR TITLE
[next] opkg-utils: revert break to opkg-feeds

### DIFF
--- a/recipes-devtools/opkg-utils/opkg-utils/0001-Revert-opkg-feed-Fix-adding-feeds-with-same-name-as-.patch
+++ b/recipes-devtools/opkg-utils/opkg-utils/0001-Revert-opkg-feed-Fix-adding-feeds-with-same-name-as-.patch
@@ -1,0 +1,34 @@
+From c93b3c56725efc80b51d628fe3446eeeac970227 Mon Sep 17 00:00:00 2001
+From: Alex Stewart <astewart.49c6@gmail.com>
+Date: Mon, 8 Apr 2024 16:16:08 -0400
+Subject: [PATCH] Revert "opkg-feed: Fix adding feeds with same name as
+ architecture"
+
+The new regexes added by the target commit invalidate the regex group
+indexes used to extract the feed source information. As a result,
+`opkg-feed list` operations fail to find feeds, in all cases.
+
+Revert this change until a fix can be developed.
+
+This reverts commit 67994e62dc598282830385da75ba9b1abbbda941.
+
+Signed-off-by: Alex Stewart <astewart.49c6@gmail.com>
+
+Upstream-Status: Inappropriate [upstream ticket]
+---
+ opkg-feed | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/opkg-feed b/opkg-feed
+index 36d4463..25ef879 100755
+--- a/opkg-feed
++++ b/opkg-feed
+@@ -171,7 +171,7 @@ createFeedLineRegex()
+ 	#	1 = full source type with any quotes
+ 	#	2 = source type without quotes if quoted
+ 	#	3 = source type if unquoted
+-	sourceTypePattern='("([^"](src|dist)(/gz)?)"|(src|dist)(/gz)?)\s+';
++	sourceTypePattern='("([^"]*)"|(\S+))\s+';
+ 
+ 	# Feed name capture groups (4, 5, 6)
+ 	#	4 = full feed name with any quotes

--- a/recipes-devtools/opkg-utils/opkg-utils_%.bbappend
+++ b/recipes-devtools/opkg-utils/opkg-utils_%.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-Revert-opkg-feed-Fix-adding-feeds-with-same-name-as-.patch"
+


### PR DESCRIPTION
A recent patch went into the opkg-utils_0.6.2:opkg-feeds script that fixed operations when feed names overlapped with architecture names. But the patch also broke the `list` operation - which is used by NI MAX to manage feeds.

Revert the offending opkg-utils fix until a proper fix can be developed. The fix is not needed on NILRT.

[AB#2699760](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2699760)

NOTE: I would like to put in a better fix for this. But before I do that, I need to redesign the sketchy tests that we put into the opkg-utils repo (and which should have been run to catch this regression). I won't have time to do that and get a fix through the mailing list before I'm off to Seattle. So this is a temporary fix to unblock MAX testing.

After this is in, I'll create an opkg bug to track the issue and a follow-on item to fix it in the long-term.

# Testing
* [x] Built `opkg-utils` locally and verified that the revert is in place and that it completely builds.

# Meta
The underlying issue here does not affect the kirkstone mainline, which is on an older version of opkg-utils.