### PR TITLE
layer.conf: Set layer compatibility to scarthgap

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_COLLECTIONS += "meta-nilrt"
 BBFILE_PATTERN_meta-nilrt = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-nilrt = "25"
 
-LAYERSERIES_COMPAT_meta-nilrt = "nanbield"
+LAYERSERIES_COMPAT_meta-nilrt = "scarthgap"


### PR DESCRIPTION
Changed layer compatibility to `scarthgap` as some layers now require `scarthgap`.

WI: [AB#2468923](https://dev.azure.com/ni/DevCentral/_workitems/edit/2468923)

### Testing
- [x] bitbake packagefeed-ni-core
- [x] bitbake packagegroup-ni-desirable
- [x] bitbake package-index && bitbake nilrt-base-system-image
- [x] Installed BSI on a VM and verified it boots