### PR TITLE
fs_permissions_diff: Fix run-time error caused by missing parameter

### DIFF
--- a/recipes-ni/ni-base-system-image-tests/files/fs_permissions_diff.py
+++ b/recipes-ni/ni-base-system-image-tests/files/fs_permissions_diff.py
@@ -397,7 +397,7 @@ def main():
     basis_fs_manifest, recent_fs_manifest = get_old_fs_manifests(db, logger, os_version, args.basis_log_db_date)
 
     if not args.current_log_db_date and not args.skip_upload:
-        db_date, db_id = upload_manifest(db, fs_manifest, logger)
+        db_date, db_id = upload_manifest(db, fs_manifest, os_version, logger)
 
     log_version_info(logger, 'current', os_version.codename, os_version.full, db_date, db_id)
 


### PR DESCRIPTION
A recent commit left out a parameter in a function call. This change fixes the issue.

[AB#2713354](https://dev.azure.com/ni/DevCentral/_workitems/edit/2713354)

### Testing

Modified this file just enough to avoid the actual upload from a hand-test run, but tested the remaining upload logic. Works correctly now.