### PR TITLE
fs_permissions_diff: Ensure recent manifest is not earlier than basis manifest

### DIFF
--- a/recipes-ni/ni-base-system-image-tests/files/fs_permissions_diff.py
+++ b/recipes-ni/ni-base-system-image-tests/files/fs_permissions_diff.py
@@ -184,7 +184,7 @@ def get_old_fs_manifests(db, logger, os_version, basis_override):
     if os_version.full == basis_version_full:
         recent_manifest, recent_version_full, unused = run_query('recent', query_date_build(basis_date))
     else:
-        # If not specified, the "recent" manifest is the most recent version less than the current manifest.
+        # The "recent" manifest is the most recent version less than the current manifest.
         # In general, it will be the previous build with the same MAJOR.MINOR.PATCH. Or if current is the first build of a new MAJOR.MINOR.PATCH,
         # then it will be the same as the basis version.
         recent_manifest, recent_version_full, unused = run_query('recent', query_version_build(os_version.build))


### PR DESCRIPTION
If the basis manifest is set using the command-line option, it is possible that the basis version will match the current version. In this case, the current method to determine the recent manifest can result in a recent manifest that is earlier than the basis manifest. This should never happen. In this case, make the recent manifest the same as the basis manifest.

[AB#2655853](https://dev.azure.com/ni/DevCentral/_workitems/edit/2655853)

### Testing

Ran fs_permissions_diff.py manually with and without this change, using the command-line options to force the basis and current versions to be the same. Confirmed the recent version is no longer earlier than the basis version with this change.