### PR TITLE
fs_permissions_diff: Make diff hash stable despite stripped versions

### DIFF
--- a/recipes-ni/ni-base-system-image-tests/files/fs_permissions_diff.py
+++ b/recipes-ni/ni-base-system-image-tests/files/fs_permissions_diff.py
@@ -219,6 +219,7 @@ def prepare_manifest_for_diff(manifest):
     result = {}
     for row in reader:
         stripped_path = strip_versions_from_path(row['path'])
+        del row['path']
         result[stripped_path] = row
     return result
 
@@ -267,9 +268,11 @@ class IntermediateDiff:
             difference['path'] = path
             yield difference
 
+def hash_and_prep(manifest):
+    manifest = prepare_manifest_for_diff(manifest)
+    return hashlib.md5(str(manifest).encode('utf-8')).hexdigest(), manifest
+
 def diff_manifests(current_manifest, basis_manifest, recent_manifest, logger):
-    hash_and_prep = lambda manifest: (hashlib.md5(manifest.encode('utf-8')).hexdigest(),
-                                      prepare_manifest_for_diff(manifest))
     current_hash, current_manifest = hash_and_prep(current_manifest)
     basis_hash, basis_manifest = hash_and_prep(basis_manifest)
     recent_hash, recent_manifest = hash_and_prep(recent_manifest)


### PR DESCRIPTION
This test ignores version number changes in file paths by stripping the version numbers out of the paths before diffing the file manifests. However, the code that calculates a combined diff hash based on the contents of the basis and current manifests is still using manifests that contain the unstripped paths. This causes the combined diff hash to change when there are changes in version numbers in file paths, even though those changes are not affecting the actual diff of the manifests.

This change makes the combined diff hash stable in this situation by removing the unstripped paths from the manifests before calculating the hash.

[AB#2702284](https://dev.azure.com/ni/DevCentral/_workitems/edit/2702284)

### Testing

Ran fs_permissions_diff.py manually with and without this change, using the command-line options to force the basis and current versions to be the same as several historical review queue test failures that had the same diff but resulted in varying combined diff hashes. Confirmed that the combined diff hashes are now the same in these cases with this change.