### PR TITLE
fs_permissions_diff: Pass dynamic command-line arguments

### DIFF
--- a/recipes-ni/ni-base-system-image-tests/files/test_fs_permissions_diff.sh
+++ b/recipes-ni/ni-base-system-image-tests/files/test_fs_permissions_diff.sh
@@ -5,7 +5,11 @@ source $(dirname "$0")/ptest-format.sh
 ptest_change_test $(basename "$0" ".sh") "" "Diff filesystem permissions with previous"
 
 source /home/admin/.mongodb.creds
-python3 fs_permissions_diff.py --server $MONGO_SERVER --user $MONGO_USER --password $MONGO_PASSWORD
+if [ -e /home/admin/.test.fs_permissions_diff.args ]; then
+   source /home/admin/.test.fs_permissions_diff.args
+fi
+
+python3 fs_permissions_diff.py --server $MONGO_SERVER --user $MONGO_USER --password $MONGO_PASSWORD "${FS_PERMISSIONS_DIFF_TEST_EXTRA_ARGS[@]}"
 
 if [ $? -eq 0 ]; then
    ptest_pass


### PR DESCRIPTION
In some situations, it is useful to pass additional command-line arguments along to the test that are determined dynamically each time a test is run. An example would be to pass a specific manifest to use as the basis of comparison. This can be used to move forward the basis of comparison each time manifest differences reported by a prior test failure have been confirmed as valid changes.

[AB#2655853](https://dev.azure.com/ni/DevCentral/_workitems/edit/2655853)

### Testing

Ran the test on a target via the ptest runner interface in the same way that it runs in the ATS. Ran with and without additional dynamic command-line arguments and confirmed expected behavior in both cases.