### PR TITLE
[next] salt: fix basic compatibility with python_3.12 (scarthgap)

### DIFF
--- a/recipes-core/packagegroups/packagefeed-ni-core.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-core.bb
@@ -16,6 +16,7 @@ RDEPENDS:${PN} = "\
 	packagegroup-ni-restoremode \
 	packagegroup-ni-runmode \
 	packagegroup-ni-safemode \
+	packagegroup-ni-skyline \
 	packagegroup-ni-tzdata \
 	packagegroup-ni-wifi \
 	packagegroup-core-x11 \

--- a/recipes-core/packagegroups/packagegroup-ni-skyline.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-skyline.bb
@@ -1,0 +1,37 @@
+# (C) Copyright 2024,
+#  National Instruments Corporation.
+#  All rights reserved.
+
+SUMMARY = "Open Source package dependencies for the NI Skyline software stack."
+LICENSE = "MIT"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
+
+RDEPENDS:${PN} = "\
+	salt-common \
+	salt-minion \
+"
+
+# Miscellaneous python deps for closed-source Skyline components
+RDEPENDS:${PN}:append = "\
+	python3-aiodns \
+	python3-aiohttp \
+	python3-avahi \
+	python3-configparser \
+	python3-difflib \
+	python3-misc \
+	python3-mmap \
+	python3-multiprocessing \
+	python3-pika \
+	python3-profile \
+	python3-psutil \
+	python3-pyiface \
+	python3-pyinotify \
+	python3-pyroute2 \
+	python3-resource \
+	python3-terminal \
+	python3-unixadmin \
+	python3-xmlrpc \
+"

--- a/recipes-devtools/python/python3-backports-ssl-match-hostname_3.7.0.1.bb
+++ b/recipes-devtools/python/python3-backports-ssl-match-hostname_3.7.0.1.bb
@@ -1,0 +1,23 @@
+SUMMARY = "The ssl.match_hostname() function from Python 3.5"
+DESCRIPTION = "\
+The Secure Sockets layer is only actually secure if you check the hostname in \
+the certificate returned by the server to which you are connecting, and verify \
+that it matches to hostname that you are trying to reach. But the matching \
+logic, defined in RFC2818, can be a bit tricky to implement on your own. So \
+the ssl package in the Standard Library of Python 3.2 and greater now includes \
+a match_hostname() function for performing this check instead of requiring \
+every application to implement the check separately. This backport brings \
+match_hostname() to users of earlier versions of Python"
+AUTHOR = "Toshio Kuratomi <toshio@fedoraproject.org>"
+HOMEPAGE = "https://pypi.org/project/backports.ssl_match_hostname/"
+LICENSE = "Python-2.0"
+LIC_FILES_CHKSUM = "file://PKG-INFO;md5=b2adbe8bfdeb625c9a01afd9aaa66619"
+
+SRC_URI[md5sum] = "32d2f593af01a046bec3d2f5181a420a"
+SRC_URI[sha256sum] = "bb82e60f9fbf4c080eabd957c39f0641f0fc247d9a16e31e26d594d8f42b9fd2"
+
+PYPI_PACKAGE = "backports.ssl_match_hostname"
+
+inherit pypi setuptools3
+
+RDEPENDS:${PN} += "${PYTHON_PN}-pkgutil"

--- a/recipes-support/salt/salt_3000.2.bb
+++ b/recipes-support/salt/salt_3000.2.bb
@@ -141,6 +141,7 @@ SUMMARY:${PN}-common = "shared libraries that salt requires for all packages"
 DESCRIPTION:${PN}-common ="${DESCRIPTION_COMMON} This particular package provides shared libraries that \
 salt-master, salt-minion, and salt-syndic require to function."
 RDEPENDS:${PN}-common = "\
+    python3-backports-ssl-match-hostname \
     python3-core \
     python3-dateutil \
     python3-fcntl \

--- a/recipes-support/salt/salt_3000.2.bb
+++ b/recipes-support/salt/salt_3000.2.bb
@@ -56,32 +56,6 @@ PACKAGES += "\
     ${PN}-bash-completion \
 "
 
-RDEPENDS:${PN}-minion += "\
-    python3-aiodns \
-    python3-aiohttp \
-    python3-avahi \
-    python3-mmap \
-    python3-pyinotify \
-    python3-pyroute2 \
-    python3-pika \
-    python3-psutil \
-"
-
-# NI Skyline dependencies only; not needed for base salt.
-RDEPENDS:${PN}-common += " \
-    python3-configparser \
-    python3-dateutil \
-    python3-difflib \
-    python3-misc \
-    python3-multiprocessing \
-    python3-profile \
-    python3-pyiface \
-    python3-resource \
-    python3-terminal \
-    python3-unixadmin \
-    python3-xmlrpc \
-"
-
 INITSCRIPT_PARAMS:${PN}-minion = "defaults 93 7"
 
 do_install:append() {

--- a/recipes-support/salt/salt_3000.2.bb
+++ b/recipes-support/salt/salt_3000.2.bb
@@ -142,6 +142,7 @@ DESCRIPTION:${PN}-common ="${DESCRIPTION_COMMON} This particular package provide
 salt-master, salt-minion, and salt-syndic require to function."
 RDEPENDS:${PN}-common = "\
     python3-backports-ssl-match-hostname \
+    python3-charset-normalizer \
     python3-core \
     python3-dateutil \
     python3-fcntl \


### PR DESCRIPTION
Salt 3000.2 is broken in nilrt/master/next due to incompatibilities between salt and python_3.12. This patchset:
1. Adds a new python recipe for `python3-backports-ssl-match-hostname`. A *forward-port* of the deprecated `ssl.match_hostname` module, that salt depends upon. This recipe won't be appropriate to upstream to OE-core.
2. Adds an `RDEPENDS` on the `python3-charset-normalizer` module, which salt requires. It was previously being implicitly included via another package.

[AB#2719441](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2719441)

# Testing
* [x] With these changes `salt-call --local grains.items` completes successfully (with unrelated warnings).
* [x] Rebuilt the full packagefeed and BSI with these changes and validated that salt now basically works from-installation.