### PR TITLE
Temporarily disable unbuildable packages in extra feed

### DIFF
--- a/files/group
+++ b/files/group
@@ -6,6 +6,7 @@ ni:x:500:
 openvpn:x:499:
 niwscerts:x:498:
 # free space
+arpwatch:x:402:
 ptest:x:401:
 ossec:x:400:
 mysql:x:399:

--- a/files/passwd
+++ b/files/passwd
@@ -6,6 +6,7 @@ webserv:x:501::::
 lvuser:x:500::::
 openvpn:x:499::::
 # free space
+arpwatch:x:402::::
 ptest:x:401::::
 ossec:x:400::::
 mysql:x:399::::

--- a/recipes-core/packagegroups/packagefeed-ni-extra.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-extra.bb
@@ -14,7 +14,6 @@ RDEPENDS:${PN}:append:x64 = "\
 		geany \
 		gimp \
 		gnuplot \
-		gnuradio \
 		gtk+3 \
 		iceauth \
 		fltk \
@@ -29,7 +28,6 @@ RDEPENDS:${PN}:append:x64 = "\
 		sessreg \
 		setxkbmap \
 		sysconfig-settings-ui \
-		toscoterm \
 		tk \
 		twm \
 		upower \
@@ -193,7 +191,6 @@ RDEPENDS:${PN} += "\
 	nss-myhostname \
 	pinentry \
 	ptest-runner \
-	sqlite \
 "
 
 # openembedded-core/meta/recipes-kernel
@@ -355,7 +352,6 @@ RDEPENDS:${PN}:append:x64 = "\
 
 # meta-openembedded/meta-oe/recipes-multimedia
 RDEPENDS:${PN} += "\
-	alsa-oss \
 	audiofile \
 	jack \
 	media-ctl \
@@ -497,19 +493,10 @@ RDEPENDS:${PN} += "\
 	tftp-hpa \
 	conntrack-tools \
 	ebtables \
-	netkit-ftp \
-	netkit-rpc \
-	netkit-rsh-client \
-	netkit-rsh-server \
-	netkit-rwho-server \
-	netkit-tftp-client \
-	netkit-tftp-server \
-	netkit-telnet \
 	net-snmp \
 	openflow \
 	openl2tp \
 	pptp-linux \
-	quagga \
 	radiusclient-ng \
 	rp-pppoe \
 	xl2tpd \


### PR DESCRIPTION
It seems that many recipes declared as RDEPENDS in the extra packagefeed have dropped from the layers. That doesn't fail the build, but it renders the whole feed metapackage as unbuildable and invalidates even those recipes which would otherwise be buildable.

This change is to unblock building of packagefeed-ni-extra group so that we can debug and fix the disabled packages and then reenable back.

[AB#2703160](https://dev.azure.com/ni/DevCentral/_workitems/edit/2703160/)

**Testing**
- [X] bitbake --continue packagefeed-ni-extra