### PR TITLE
cyclictest-container: install influxdb with apt

### DIFF
--- a/recipes-kernel/kernel-tests/files/cyclictest-container/Dockerfile
+++ b/recipes-kernel/kernel-tests/files/cyclictest-container/Dockerfile
@@ -6,7 +6,5 @@ RUN DEBIAN_FRONTEND=noninteractive apt update && apt install -y \
     python3 \
     python3-pip \
     dmidecode \
-    grub-common
-
-# Need to send to InfluxDB
-RUN pip install influxdb
+    grub-common \
+    python3-influxdb


### PR DESCRIPTION
Changed the installation of influxdb in the Dockerfile to install with apt install instead of pip install as the kernel-containerized-performance-tests seemed to be broken due to this.

[AB#2737868](https://dev.azure.com/ni/DevCentral/_workitems/edit/2737868/)

Reference to installation of influxdb package on Debian distro: [Link](https://pypi.org/project/influxdb/5.3.2/#:~:text=On%20Debian/Ubuntu,install%20python%2Dinfluxdb)

**Testing**
Tested by building the image manually
![image](https://github.com/ni/meta-nilrt/assets/111044286/3c3eaac6-cff1-499a-8694-b02a5b2c671f)
