### PR TITLE
nisystemreplication: Add support for custom images, improve error handling, UI

### DIFF
--- a/recipes-core/initrdscripts/files/ni_provisioning.common
+++ b/recipes-core/initrdscripts/files/ni_provisioning.common
@@ -53,7 +53,7 @@ ask_for_continue()
 	variable=${2:-"PROVISION_REPARTITION_TARGET"}
 
 	BUILD_IDENTIFIER=$(get_image_info BUILD_IDENTIFIER)
-	IMAGE_DISPLAY_NAME=$(get_image_info IMAGE_DISPLAY_NAME)
+	IMAGE_DISPLAY_NAME=${3:-$(get_image_info IMAGE_DISPLAY_NAME)}
 
 	printf "\nNI Linux Real-Time $type $BUILD_IDENTIFIER. \n\n"
 	printf "Continuing will partition the disk, format, and install $IMAGE_DISPLAY_NAME to the target.\n\n"

--- a/recipes-ni/ni-systemreplication/files/nisystemreplication
+++ b/recipes-ni/ni-systemreplication/files/nisystemreplication
@@ -7,6 +7,8 @@ declare -r MODE="${1:-}"
 
 NIRECOVERY_MOUNTPOINT=/mnt/NIRECOVERY
 
+# ---------------------- Get Image ----------------------
+
 get_default_image_name () {
 	local DeviceDesc=$(fw_printenv -n DeviceDesc 2>/dev/null)
 	if [ -z "$DeviceDesc" ]; then
@@ -54,6 +56,31 @@ image_get () {
 	echo "Done getting image"
 }
 
+# ---------------------- Set Image ----------------------
+
+# Presents a list of existing images and let's user select one
+select_image_from_list () {
+	[ ! -d $NIRECOVERY_MOUNTPOINT/Images ] && return
+
+	readarray -t images <<< "$(find $NIRECOVERY_MOUNTPOINT/Images -name systemimage.tgz | sort | sed "s,$NIRECOVERY_MOUNTPOINT/Images/,," | sed 's,/systemimage.tgz,,')"
+	[ -z $images ] && return
+	local no_of_images=${#images[@]}
+
+	echo "System images found on media:" >&2
+
+	PS3="Select an image to use for provisioning: "
+	select opt in "${images[@]}"; do
+		case $opt in
+			*)
+				if [[ "$REPLY" =~ ^[0-9]+$ ]] && [ $REPLY -gt 0 ] && [ $REPLY -le $no_of_images ]; then
+					echo $opt
+					break
+				fi
+				;;
+		esac
+	done
+}
+
 image_set () {
 	if [[ $(type -t early_setup) != function ]]; then
 		# If we're here, the script was invoked manually i.e., not from init.
@@ -62,10 +89,13 @@ image_set () {
 		early_setup
 	fi
 
+	local image_name=$(select_image_from_list)
+	[ -z "$image_name" ] && die "No system images found on the media"
+
 	source /ni_provisioning.safemode.common
 	install_safemode
 
-	nisystemimage setall -x tgz -f $NIRECOVERY_MOUNTPOINT/Images/systemimage.tgz -p reset -s reset
+	nisystemimage setall -x tgz -f $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.tgz -p reset -s reset
 
 	# Retain some grubenv settings
 	if grep --quiet "^consoleoutenable=" $BOOTFS_MOUNTPOINT/grub/grubenv; then

--- a/recipes-ni/ni-systemreplication/files/nisystemreplication
+++ b/recipes-ni/ni-systemreplication/files/nisystemreplication
@@ -8,7 +8,10 @@ declare -r MODE="${1:-}"
 NIRECOVERY_MOUNTPOINT=/mnt/NIRECOVERY
 
 image_get () {
-	mount -o remount,rw $NIRECOVERY_MOUNTPOINT
+	if ! mount -o remount,rw $NIRECOVERY_MOUNTPOINT; then
+		echo "Make sure the media is labeled NIRECOVERY and is writable" && false
+	fi
+
 	mkdir -p $NIRECOVERY_MOUNTPOINT/replication_images
 	nisystemimage getall -x tgz -f $NIRECOVERY_MOUNTPOINT/replication_images/systemimage.tgz
 	mount -o remount,ro $NIRECOVERY_MOUNTPOINT

--- a/recipes-ni/ni-systemreplication/files/nisystemreplication
+++ b/recipes-ni/ni-systemreplication/files/nisystemreplication
@@ -92,29 +92,35 @@ image_set () {
 	local image_name=$(select_image_from_list)
 	[ -z "$image_name" ] && die "No system images found on the media"
 
-	source /ni_provisioning.safemode.common
-	install_safemode
-
-	nisystemimage setall -x tgz -f $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.tgz -p reset -s reset
-
-	# Retain some grubenv settings
-	if grep --quiet "^consoleoutenable=" $BOOTFS_MOUNTPOINT/grub/grubenv; then
-		grubenv_consoleoutenable=$(grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv list |grep "^consoleoutenable=" | cut -f 2 -d '=')
+	if [[ "$PROVISION_REPARTITION_TARGET" != "y" ]]; then
+		ask_for_continue "ReplicateImage" "PROVISION_REPARTITION_TARGET" "$image_name"
 	fi
-	if grep --quiet "^bootdelay=" $BOOTFS_MOUNTPOINT/grub/grubenv; then
-		grubenv_bootdelay=$(grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv list |grep "^bootdelay=" | cut -f 2 -d '=')
+
+	if [[ $PROVISION_REPARTITION_TARGET == "y" ]]; then
+		source /ni_provisioning.safemode.common
+		install_safemode
+
+		nisystemimage setall -x tgz -f $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.tgz -p reset -s reset
+
+		# Retain some grubenv settings
+		if grep --quiet "^consoleoutenable=" $BOOTFS_MOUNTPOINT/grub/grubenv; then
+			grubenv_consoleoutenable=$(grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv list |grep "^consoleoutenable=" | cut -f 2 -d '=')
+		fi
+		if grep --quiet "^bootdelay=" $BOOTFS_MOUNTPOINT/grub/grubenv; then
+			grubenv_bootdelay=$(grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv list |grep "^bootdelay=" | cut -f 2 -d '=')
+		fi
+		rm -rf mkdir $BOOTFS_MOUNTPOINT/grub
+
+		install_grubenv
+		set_versions
+
+		echo $LOG_LEVEL > /proc/sys/kernel/printk
+		sanity_check
+
+		print_info "Re-enabling automount..."
+		enable_automount
+		print_done
 	fi
-	rm -rf mkdir $BOOTFS_MOUNTPOINT/grub
-
-	install_grubenv
-	set_versions
-
-	echo $LOG_LEVEL > /proc/sys/kernel/printk
-	sanity_check
-
-	print_info "Re-enabling automount..."
-	enable_automount
-	print_done
 
 	trap - ERR
 	exec 1>&3

--- a/recipes-ni/ni-systemreplication/files/nisystemreplication
+++ b/recipes-ni/ni-systemreplication/files/nisystemreplication
@@ -7,13 +7,49 @@ declare -r MODE="${1:-}"
 
 NIRECOVERY_MOUNTPOINT=/mnt/NIRECOVERY
 
+get_default_image_name () {
+	local DeviceDesc=$(fw_printenv -n DeviceDesc 2>/dev/null)
+	if [ -z "$DeviceDesc" ]; then
+		DeviceDesc="UnknownDevice"
+	fi
+
+	local Date=$(date +%F-%H-%M-%S)
+
+	echo $DeviceDesc-$Date
+}
+
+get_image_name () {
+	local default_image_name=$(get_default_image_name)
+	read -e -p "Enter image name (no spaces, no special chars except '-'): " -i "$default_image_name" image_name
+	echo $image_name
+}
+
+is_image_valid () {
+	local image_name=$1
+	if [ -z "$image_name" ]; then
+		echo "No image name specified. Please specify an image name" && return 1
+	fi
+	# If image already exists, confirm if it should be overwritten
+	if [ -f $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.tgz ]; then
+		read -e -p "An image already exits with this name. Overwrite? (y/N): " -i "N" overwrite 
+		[ $overwrite != "y" ] && return 1
+	fi
+	return 0
+}
+
 image_get () {
 	if ! mount -o remount,rw $NIRECOVERY_MOUNTPOINT; then
 		echo "Make sure the media is labeled NIRECOVERY and is writable" && false
 	fi
 
-	mkdir -p $NIRECOVERY_MOUNTPOINT/replication_images
-	nisystemimage getall -x tgz -f $NIRECOVERY_MOUNTPOINT/replication_images/systemimage.tgz
+	# If no image name is provided, retry
+	local image_name=$(get_image_name)
+	while ! is_image_valid $image_name; do
+		image_name=$(get_image_name)
+	done
+
+	mkdir -p $NIRECOVERY_MOUNTPOINT/Images/$image_name
+	nisystemimage getall -x tgz -f $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.tgz
 	mount -o remount,ro $NIRECOVERY_MOUNTPOINT
 	echo "Done getting image"
 }
@@ -29,7 +65,7 @@ image_set () {
 	source /ni_provisioning.safemode.common
 	install_safemode
 
-	nisystemimage setall -x tgz -f $NIRECOVERY_MOUNTPOINT/replication_images/systemimage.tgz -p reset -s reset
+	nisystemimage setall -x tgz -f $NIRECOVERY_MOUNTPOINT/Images/systemimage.tgz -p reset -s reset
 
 	# Retain some grubenv settings
 	if grep --quiet "^consoleoutenable=" $BOOTFS_MOUNTPOINT/grub/grubenv; then

--- a/recipes-ni/ni-systemreplication/files/nisystemreplication
+++ b/recipes-ni/ni-systemreplication/files/nisystemreplication
@@ -26,6 +26,40 @@ get_image_name () {
 	echo $image_name
 }
 
+get_filesystem_attribute () {
+	local label=$1
+	local column=$2
+
+	local tempdir=$(mktemp -d)
+
+	if ! mount -L $label $tempdir &>/dev/null; then
+		echo "Error mounting $label partition" >&2 && return
+	fi
+
+	available_space=$(df $tempdir | tail -1 | awk -v column="$column" '{print $column}')
+	umount $tempdir
+	rmdir $tempdir
+	echo $available_space
+}
+
+get_used_filesystem_size () {
+	get_filesystem_attribute $1 3
+}
+
+get_available_filesystem_size () {
+	get_filesystem_attribute $1 4
+}
+
+get_estimated_image_size () {
+	nigrub_size=$(get_used_filesystem_size "nigrub")
+	nibootfs_size=$(get_used_filesystem_size "nibootfs")
+	niconfig_size=$(get_used_filesystem_size "niconfig")
+	nirootfs_size=$(get_used_filesystem_size "nirootfs")
+
+	total_size=$(($nigrub_size + $nibootfs_size + $niconfig_size + $nirootfs_size))
+	echo $total_size
+}
+
 is_image_valid () {
 	local image_name=$1
 	if [ -z "$image_name" ]; then
@@ -41,8 +75,14 @@ is_image_valid () {
 
 image_get () {
 	if ! mount -o remount,rw $NIRECOVERY_MOUNTPOINT; then
-		echo "Make sure the media is labeled NIRECOVERY and is writable" && false
+		die "ERROR: Mount failure. No writable media labelled NIRECOVERY."
 	fi
+
+	local nirecovery_available_space=$(get_available_filesystem_size "NIRECOVERY")
+	local estimated_image_size=$(get_estimated_image_size)
+
+	[ $estimated_image_size -eq "0" ] && die "Error estimating image size"
+	[ $nirecovery_available_space -lt $estimated_image_size ] && die "Image might not fit on media. Estimated image size: $estimated_image_size. Available space on media: $nirecovery_available_space"
 
 	# If no image name is provided, retry
 	local image_name=$(get_image_name)
@@ -53,7 +93,7 @@ image_get () {
 	mkdir -p $NIRECOVERY_MOUNTPOINT/Images/$image_name
 	nisystemimage getall -x tgz -f $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.tgz
 	mount -o remount,ro $NIRECOVERY_MOUNTPOINT
-	echo "Done getting image"
+	echo "Image $image_name saved."
 }
 
 # ---------------------- Set Image ----------------------

--- a/recipes-ni/ni-systemreplication/files/nisystemreplication
+++ b/recipes-ni/ni-systemreplication/files/nisystemreplication
@@ -74,7 +74,7 @@ is_image_valid () {
 }
 
 image_get () {
-	if ! mount -o remount,rw $NIRECOVERY_MOUNTPOINT; then
+	if ! mount -o remount,rw,async $NIRECOVERY_MOUNTPOINT; then
 		die "ERROR: Mount failure. No writable media labelled NIRECOVERY."
 	fi
 
@@ -92,6 +92,8 @@ image_get () {
 
 	mkdir -p $NIRECOVERY_MOUNTPOINT/Images/$image_name
 	nisystemimage getall -x tgz -f $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.tgz
+
+	sync
 	mount -o remount,ro $NIRECOVERY_MOUNTPOINT
 	echo "Image $image_name saved."
 }


### PR DESCRIPTION
This patch set adds support for custom image names, improves error handling, Get Image speed, and UI.

WI: [AB#2371308](https://dev.azure.com/ni/DevCentral/_workitems/edit/2371308), [AB#2372288](https://dev.azure.com/ni/DevCentral/_workitems/edit/2372288), [AB#2372259](https://dev.azure.com/ni/DevCentral/_workitems/edit/2372259), [AB#2372291](https://dev.azure.com/ni/DevCentral/_workitems/edit/2372291)

Sample "Get Image" interaction:

![image](https://github.com/ni/meta-nilrt/assets/8194523/97e43862-0b7c-4ce0-91dd-a0d7c08343b7)

Sample "Set Image" interaction:

![image](https://github.com/ni/meta-nilrt/assets/8194523/617472a9-70f2-4b2e-966f-5fc0a912ac97)

### Testing
- [x] Tested "Get Image", "Set Image" with all "happy paths" and "error paths" on a VM.
