### PR TITLE
nisystemreplication: Add compatibility check, support for answers file, progress bar

### DIFF
--- a/recipes-core/initrdscripts/files/ni_provisioning
+++ b/recipes-core/initrdscripts/files/ni_provisioning
@@ -107,6 +107,11 @@ elif [[ $restore == "migrate" ]]; then
 	provision_target onboard
 elif [[ $restore == "get-image" ]]; then
 	echo "Get Image"
+
+	# source user's answer file, if present
+	source_answer_file
+	echo
+
 	source /sbin/nisystemreplication get
 	if [[ "${FORCE_PROVISIONING}" -eq 1 ]]; then
 		PROVISION_REBOOT_METHOD=${RESTART_OPTION}
@@ -114,6 +119,11 @@ elif [[ $restore == "get-image" ]]; then
 	ASK_BEFORE_REBOOT=1
 elif [[ $restore == "set-image" ]]; then
 	echo "Set Image"
+
+	# source user's answer file, if present
+	source_answer_file
+	echo
+
 	source /sbin/nisystemreplication set
 	if [[ "${FORCE_PROVISIONING}" -eq 1 ]]; then
 		PROVISION_REBOOT_METHOD=${RESTART_OPTION}

--- a/recipes-core/initrdscripts/files/ni_provisioning.answers.default
+++ b/recipes-core/initrdscripts/files/ni_provisioning.answers.default
@@ -45,3 +45,7 @@ PROVISION_PART_NILRT_LABEL="nilrt"
 # A hostname to configure after provisioning.
 # An empty string means hostname is generated on first boot.
 PROVISION_HOSTNAME=""
+
+# System Image name used for "Get Image" and "Set Image"
+# No spaces, no special characters except '-'
+PROVISION_SYSTEMIMAGE_NAME=""

--- a/recipes-ni/ni-systemimage/files/nisystemimage
+++ b/recipes-ni/ni-systemimage/files/nisystemimage
@@ -70,6 +70,10 @@ if [[ "${MODE}" == "get" || "${MODE}" == "set" ]]; then
 	BLACKLIST_PATHS+=(${BLACKLIST_PATHS_get_set[*]})
 fi
 
+# Passed as argument to pv. The default "-q" shows no progress.
+# Set this to empty string to display progress.
+DISPLAY_PROGRESS_ARG="-q"
+
 # All excludes to pass to `tar`. Includes BLACKLIST_PATHS and contents of all
 # files in BLACKLIST_LISTS. The contents of EXCLUDES are paths relative to
 # /mnt/userfs; the contents of BLACKLIST_PATHS and the contents of the files in
@@ -145,9 +149,9 @@ print_help () {
 cat <<EOF
 Usage:
 
-$BASENAME get -x <format> [-hnv] [-b <file>] [-B <path>] [-f <file>]
+$BASENAME get -x <format> [-dhnv] [-b <file>] [-B <path>] [-f <file>]
 
-$BASENAME set -x <format> [-hnv] [-b <file>] [-B <path>] [-f <file>]
+$BASENAME set -x <format> [-dhnv] [-b <file>] [-B <path>] [-f <file>]
 	-p reset|preserve|apply -s reset|preserve|apply
 
 EOF
@@ -369,7 +373,7 @@ image_get_tgz () {
 
 	cd $WORKING_USERFS
 	CMDLINE+=(*)
-	run_cmd "${CMDLINE[@]}" | pv 1>&"$FD_IMAGE"
+	run_cmd "${CMDLINE[@]}" | pv $DISPLAY_PROGRESS_ARG 1>&"$FD_IMAGE"
 	echo_verbose 2 "finished"
 }
 
@@ -551,7 +555,7 @@ image_set_tgz () {
 
 	cd $WORKING_USERFS
 	if [[ ! $NOEXEC ]]; then
-		pv 0<&"$FD_IMAGE" | "${CMDLINE[@]}"
+		pv $DISPLAY_PROGRESS_ARG 0<&"$FD_IMAGE" | "${CMDLINE[@]}"
 	else
 		if (( $VERBOSE > 0 )); then
 			echo_verbose 1 "skipping extraction; 'tar t' output:"
@@ -755,10 +759,11 @@ dump_settings () {
 }
 
 parse_settings () {
-	while getopts :b:B:f:hnp:s:vx: opt ; do
+	while getopts :b:B:df:hnp:s:vx: opt ; do
 		case $opt in
 			b) BLACKLIST_LISTS+=("$OPTARG") ;;
 			B) BLACKLIST_PATHS+=("$OPTARG") ;;
+			d) DISPLAY_PROGRESS_ARG="" ;;
 			f) IMAGE_FILE="$OPTARG" ;;
 			h) print_help; exit 0 ;;
 			n) NOEXEC=1 ;;

--- a/recipes-ni/ni-systemimage/files/nisystemimage
+++ b/recipes-ni/ni-systemimage/files/nisystemimage
@@ -369,7 +369,7 @@ image_get_tgz () {
 
 	cd $WORKING_USERFS
 	CMDLINE+=(*)
-	run_cmd "${CMDLINE[@]}" 1>&"$FD_IMAGE"
+	run_cmd "${CMDLINE[@]}" | pv 1>&"$FD_IMAGE"
 	echo_verbose 2 "finished"
 }
 
@@ -551,7 +551,7 @@ image_set_tgz () {
 
 	cd $WORKING_USERFS
 	if [[ ! $NOEXEC ]]; then
-		"${CMDLINE[@]}" 0<&"$FD_IMAGE"
+		pv 0<&"$FD_IMAGE" | "${CMDLINE[@]}"
 	else
 		if (( $VERBOSE > 0 )); then
 			echo_verbose 1 "skipping extraction; 'tar t' output:"

--- a/recipes-ni/ni-systemimage/ni-systemimage.bb
+++ b/recipes-ni/ni-systemimage/ni-systemimage.bb
@@ -33,5 +33,6 @@ RDEPENDS:${PN} += "\
 	gzip \
 	ni-netcfgutil \
 	niacctbase \
+	pv \
 	tar \
 "

--- a/recipes-ni/ni-systemreplication/files/nisystemreplication
+++ b/recipes-ni/ni-systemreplication/files/nisystemreplication
@@ -89,11 +89,14 @@ image_get () {
 	[ $estimated_image_size -eq "0" ] && die "Error estimating image size"
 	[ $nirecovery_available_space -lt $estimated_image_size ] && die "Image might not fit on media. Estimated image size: $estimated_image_size. Available space on media: $nirecovery_available_space"
 
-	# If no image name is provided, retry
-	local image_name=$(get_image_name)
-	while ! is_image_valid $image_name; do
+	local image_name=$PROVISION_SYSTEMIMAGE_NAME
+	if [ -z $image_name ]; then
 		image_name=$(get_image_name)
-	done
+		# If no image name is provided, retry
+		while ! is_image_valid $image_name; do
+			image_name=$(get_image_name)
+		done
+	fi
 
 	mkdir -p $NIRECOVERY_MOUNTPOINT/Images/$image_name
 	nisystemimage getall -x tgz -f $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.tgz
@@ -151,8 +154,11 @@ image_set () {
 		early_setup
 	fi
 
-	local image_name=$(select_image_from_list)
-	[ -z "$image_name" ] && die "No compatible system images found on the media"
+	local image_name=$PROVISION_SYSTEMIMAGE_NAME
+	if [ -z $image_name ]; then
+		image_name=$(select_image_from_list)
+		[ -z "$image_name" ] && die "No compatible system images found on the media"
+	fi
 
 	if [[ "$PROVISION_REPARTITION_TARGET" != "y" ]]; then
 		ask_for_continue "ReplicateImage" "PROVISION_REPARTITION_TARGET" "$image_name"

--- a/recipes-ni/ni-systemreplication/files/nisystemreplication
+++ b/recipes-ni/ni-systemreplication/files/nisystemreplication
@@ -99,6 +99,7 @@ image_get () {
 	fi
 
 	mkdir -p $NIRECOVERY_MOUNTPOINT/Images/$image_name
+	echo "Getting system image $image_name. This may take a while" >&2
 	nisystemimage getall -x tgz -f $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.tgz
 	echo "DeviceDesc=$(get_device_desc)" > $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.conf
 
@@ -168,6 +169,7 @@ image_set () {
 		source /ni_provisioning.safemode.common
 		install_safemode
 
+		echo "Applying system image $image_name. This may take a while" >&2
 		nisystemimage setall -x tgz -f $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.tgz -p reset -s reset
 
 		# Retain some grubenv settings

--- a/recipes-ni/ni-systemreplication/files/nisystemreplication
+++ b/recipes-ni/ni-systemreplication/files/nisystemreplication
@@ -100,7 +100,7 @@ image_get () {
 
 	mkdir -p $NIRECOVERY_MOUNTPOINT/Images/$image_name
 	echo "Getting system image $image_name. This may take a while" >&2
-	nisystemimage getall -x tgz -f $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.tgz
+	nisystemimage getall -d -x tgz -f $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.tgz
 	echo "DeviceDesc=$(get_device_desc)" > $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.conf
 
 	sync
@@ -170,7 +170,7 @@ image_set () {
 		install_safemode
 
 		echo "Applying system image $image_name. This may take a while" >&2
-		nisystemimage setall -x tgz -f $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.tgz -p reset -s reset
+		nisystemimage setall -d -x tgz -f $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.tgz -p reset -s reset
 
 		# Retain some grubenv settings
 		if grep --quiet "^consoleoutenable=" $BOOTFS_MOUNTPOINT/grub/grubenv; then

--- a/recipes-ni/ni-systemreplication/files/nisystemreplication
+++ b/recipes-ni/ni-systemreplication/files/nisystemreplication
@@ -9,12 +9,17 @@ NIRECOVERY_MOUNTPOINT=/mnt/NIRECOVERY
 
 # ---------------------- Get Image ----------------------
 
-get_default_image_name () {
+get_device_desc () {
 	local DeviceDesc=$(fw_printenv -n DeviceDesc 2>/dev/null)
 	if [ -z "$DeviceDesc" ]; then
 		DeviceDesc="UnknownDevice"
 	fi
 
+	echo $DeviceDesc
+}
+
+get_default_image_name () {
+	local DeviceDesc=$(get_device_desc)
 	local Date=$(date +%F-%H-%M-%S)
 
 	echo $DeviceDesc-$Date
@@ -92,6 +97,7 @@ image_get () {
 
 	mkdir -p $NIRECOVERY_MOUNTPOINT/Images/$image_name
 	nisystemimage getall -x tgz -f $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.tgz
+	echo "DeviceDesc=$(get_device_desc)" > $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.conf
 
 	sync
 	mount -o remount,ro $NIRECOVERY_MOUNTPOINT
@@ -100,15 +106,29 @@ image_get () {
 
 # ---------------------- Set Image ----------------------
 
-# Presents a list of existing images and let's user select one
+# Presents a list of existing compatible images and let's user select one
 select_image_from_list () {
 	[ ! -d $NIRECOVERY_MOUNTPOINT/Images ] && return
 
-	readarray -t images <<< "$(find $NIRECOVERY_MOUNTPOINT/Images -name systemimage.tgz | sort | sed "s,$NIRECOVERY_MOUNTPOINT/Images/,," | sed 's,/systemimage.tgz,,')"
+	images=()
+
+	for image in $(ls $NIRECOVERY_MOUNTPOINT/Images); do
+		if [ ! -f $NIRECOVERY_MOUNTPOINT/Images/$image/systemimage.tgz ] || [ ! -f $NIRECOVERY_MOUNTPOINT/Images/$image/systemimage.conf ]; then
+			echo "WARNING: Image \"$image\" is missing systemimage.tgz or systemimage.conf" >&2
+			continue
+		fi
+
+		local ImageDeviceDesc=$(awk -F= '{if ($1 == "DeviceDesc") print $2}' $NIRECOVERY_MOUNTPOINT/Images/$image/systemimage.conf)
+		if [ "$(get_device_desc)" = "$ImageDeviceDesc" ]; then
+			images+=($image)
+		fi
+	done
+
 	[ -z $images ] && return
 	local no_of_images=${#images[@]}
 
-	echo "System images found on media:" >&2
+	echo "" >&2
+	echo "Compatible system images found on media:" >&2
 
 	PS3="Select an image to use for provisioning: "
 	select opt in "${images[@]}"; do
@@ -132,7 +152,7 @@ image_set () {
 	fi
 
 	local image_name=$(select_image_from_list)
-	[ -z "$image_name" ] && die "No system images found on the media"
+	[ -z "$image_name" ] && die "No compatible system images found on the media"
 
 	if [[ "$PROVISION_REPARTITION_TARGET" != "y" ]]; then
 		ask_for_continue "ReplicateImage" "PROVISION_REPARTITION_TARGET" "$image_name"


### PR DESCRIPTION
This patch set adds
1. Compatibility checks so that only compatible images are listed for Set Image
2. Support for answers file so that there would be no user prompts
3. Show progress bar when getting and setting image from nisystemreplication

WI:[ AB#2372267](https://dev.azure.com/ni/DevCentral/_workitems/edit/2372267), [AB#2372293](https://dev.azure.com/ni/DevCentral/_workitems/edit/2372293)

### Testing
- [x] Verified that Get Image creates a systemimage.conf file
- [x] Verified that images taken on incompatible targets and images with missing .conf file or .tgz file are not listed in "Set Image"
- [x] Verified that with following answers file, Get Image and Set Image don't prompt for user interaction and apply configuration specified in the .conf file.
         
![image](https://github.com/ni/meta-nilrt/assets/8194523/5a130963-61a7-49c1-918f-70947b0be67e)

- [x] Verified that a progress bar is shown for get and set operations from nisystemreplication but not when nisystemimage is invoked without the new argument
Get Image:
![image](https://github.com/ni/meta-nilrt/assets/8194523/e26ec566-8f03-4ecb-90c6-c0f40c6b9dd3)
Set Image:
![image](https://github.com/ni/meta-nilrt/assets/8194523/627b05a3-fcb9-453d-8cbc-71182542b9bc)
 
- [x] Verify LV workflow to make sure progress bar doesn't break anything
         - LV workflow doesn't seem to be affected but even then, updated the code to not show progress bar by default in nisystemimage. nisystemreplication uses a cmdline argument to show the progress bar. This is to ensure we don't unintentionally break any existing workflows I haven't tested for.
- [x] Test on serial console to see how progress bar shows up
         - Apparently we configured the serial console to show a shell and not show any console output like user prompts; so progress bar is not displayed on serial console.