### PR TITLE
[nilrt/24.5/kirkstone] linux: staple kernel sources for 24.5 release

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-debug_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-debug_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "NILRT linux kernel debug build"
-NI_RELEASE_VERSION = "master"
+NI_RELEASE_VERSION = "24.5"
 LINUX_VERSION = "6.1"
 LINUX_VERSION:xilinx-zynq = "4.14"
 LINUX_KERNEL_TYPE = "debug"

--- a/recipes-kernel/linux/linux-nilrt-next_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-next_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "NILRT linux kernel next development build"
-NI_RELEASE_VERSION = "master"
+NI_RELEASE_VERSION = "24.5"
 LINUX_VERSION = "6.6"
 LINUX_KERNEL_TYPE = "next"
 

--- a/recipes-kernel/linux/linux-nilrt-nohz_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-nohz_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "NILRT linux kernel full dynamic ticks (NO_HZ_FULL) build"
-NI_RELEASE_VERSION = "master"
+NI_RELEASE_VERSION = "24.5"
 LINUX_VERSION = "6.1"
 LINUX_KERNEL_TYPE = "nohz"
 

--- a/recipes-kernel/linux/linux-nilrt_git.bb
+++ b/recipes-kernel/linux/linux-nilrt_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "Linux kernel based on nilrt branch"
-NI_RELEASE_VERSION = "master"
+NI_RELEASE_VERSION = "24.5"
 LINUX_VERSION = "6.1"
 LINUX_VERSION:xilinx-zynq = "4.14"
 


### PR DESCRIPTION
This patchset staples the regular, nohz, next, and debug kernels to their 24.5 release branches.

[AB#2667649](https://dev.azure.com/ni/DevCentral/_workitems/edit/2667649)

**Testing**

- [X] `bitbake -c fetch linux-nilrt linux-nilrt-next linux-nilrt-nohz linux-nilrt-debug` succeeds.