### PR TITLE
nisystemreplication: Replicate ext4 features

### DIFF
--- a/recipes-ni/ni-systemreplication/files/nisystemreplication
+++ b/recipes-ni/ni-systemreplication/files/nisystemreplication
@@ -36,6 +36,10 @@ get_ext4_features () {
 	echo $(debugfs -R features $bootfs_device 2>/dev/null | awk -F: '{if ($1 == "Filesystem features") print $2}' | xargs | sed 's/ /,/g')
 }
 
+ext4_has_unsupported_features () {
+	e2fsck -n LABEL=nibootfs 2>&1 | grep "unsupported feature"
+}
+
 get_filesystem_attribute () {
 	local label=$1
 	local column=$2
@@ -85,7 +89,11 @@ is_image_valid () {
 
 image_get () {
 	if ! mount -o remount,rw,async $NIRECOVERY_MOUNTPOINT; then
-		die "ERROR: Mount failure. No writable media labelled NIRECOVERY."
+		die "Mount failure. No writable media labelled NIRECOVERY."
+	fi
+
+	if ext4_has_unsupported_features; then
+		die "Unsupported filesystem features detected. Please use a newer version of recovery media."
 	fi
 
 	local nirecovery_available_space=$(get_available_filesystem_size "NIRECOVERY")

--- a/recipes-ni/ni-systemreplication/files/nisystemreplication
+++ b/recipes-ni/ni-systemreplication/files/nisystemreplication
@@ -31,6 +31,11 @@ get_image_name () {
 	echo $image_name
 }
 
+get_ext4_features () {
+	local bootfs_device=$(blkid -L nibootfs)
+	echo $(debugfs -R features $bootfs_device 2>/dev/null | awk -F: '{if ($1 == "Filesystem features") print $2}' | xargs | sed 's/ /,/g')
+}
+
 get_filesystem_attribute () {
 	local label=$1
 	local column=$2
@@ -100,8 +105,11 @@ image_get () {
 
 	mkdir -p $NIRECOVERY_MOUNTPOINT/Images/$image_name
 	echo "Getting system image $image_name. This may take a while" >&2
+	local ext4_features=$(get_ext4_features)
 	nisystemimage getall -d -x tgz -f $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.tgz
+
 	echo "DeviceDesc=$(get_device_desc)" > $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.conf
+	echo "Ext4Features=$ext4_features" >> $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.conf
 
 	sync
 	mount -o remount,ro $NIRECOVERY_MOUNTPOINT
@@ -166,6 +174,9 @@ image_set () {
 	fi
 
 	if [[ $PROVISION_REPARTITION_TARGET == "y" ]]; then
+		ext4_features=$(awk -F= '{if ($1 == "Ext4Features") print $2}' $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.conf)
+		# Start with "none" so that default features are not enabled if not listed in $ext4_features
+		MKFS_ARGS="${MKFS_ARGS} -O none,$ext4_features"
 		source /ni_provisioning.safemode.common
 		install_safemode
 


### PR DESCRIPTION
When "Set Image" operation is done from a recovery media containing newer OS version, mkfs.ext4 may create ext4 partitions with newer features enabled which may not be compatible with the grub version from the System Image being applied.

So save ext4 features used for creating nibootfs during "Get Image" operation and only enable them during "Set Image" operation.

Also, detect if filesystem contains unsupported features and error out in "Get Image"



WI: [AB#2765764](https://dev.azure.com/ni/DevCentral/_workitems/edit/2765764)

### Testing
- [x] "Get Image" operation now saves `Ext4Features` in `systemimage.conf`
- [x] `Ext4Features` specified in `systemimage.conf` are applied during "Set Image" operation and no other default features are enabled.
- [x] Doing a "Set Image" operation using "kirkstone" image with dist-next recovery media works on a VM. VM is bootable afterwards.
- [x] Doing "Get Image" operation on a dist-next provisioned VM from kirkstone recovery media gives out following error
![image](https://github.com/ni/meta-nilrt/assets/8194523/fb101172-7635-4318-b5d9-ae6731542f1c)

### Notes
- Will cherry-pick this into kirkstone.
- Detecting filesystem features in "Set Image" to print a more descriptive error is not easy so not doing that. We can do it in future if desired. Applying dist-next image from kirkstone recovery media shows following error for now

![image](https://github.com/ni/meta-nilrt/assets/8194523/f315be26-f0cc-42cb-a42f-b96605f0a8e1)