### PR TITLE
rtgroups: set priority for ktimers/*

### DIFF
--- a/recipes-rt/rt-tests/files/kthread_test_priority.sh
+++ b/recipes-rt/rt-tests/files/kthread_test_priority.sh
@@ -50,4 +50,8 @@ ptest_change_subtest 4 irq_work
 check_prio_for_task irq_work/ FIFO 12
 ptest_report
 
+ptest_change_subtest 5 ktimers
+check_prio_for_task ktimers/ FIFO 10
+ptest_report
+
 exit $rc_first

--- a/recipes-rt/rtctl/files/rtgroups
+++ b/recipes-rt/rtctl/files/rtgroups
@@ -41,5 +41,6 @@
 kthreadd:f:25:*:\[kthreadd\]$
 irqthread:f:15:*:\[irq\/.+\]$
 irq_work:f:12:*:\[irq_work\/.+\]$
+ktimers:f:10:*:\[ktimers\/.+\]$
 ksoftirqd:f:8:*:\[ksoftirqd\/.+\]$
 


### PR DESCRIPTION
Set the per-CPU 'ktimers' threads priority to FIFO 10. This places them above 'ksoftirqd' threads which run at FIFO 8 and matches the intent of the upstream stable-rt kernel commit c1d68f0da449 ("softirq: Use a dedicated thread for timer wake-ups.") which states:

  "Using a dedicated variable to store the pending softirq bits values
  ensure that the timer are not accidentally picked up by ksoftirqd and
  other threaded interrupts.
  It shouldn't be picked up by ksoftirqd since it runs at lower priority."

On our systems, up until this commit, 'ksoftirqd' was running at FIFO/8 whereas 'ktimers' were running at the default FIFO/1 which is not the intent of the upstream change.

Also, add the corresponding test that goes with it.

AB#2796625

### Testing

- [x] `bitbake rtctl`
- [x] `bitbake rt-tests`
- [x]  `bitbake package-index`
- [x] served from local feed and installed on a PXIe-8881
- [x] `opkg install rtctl` rebooted and verified the priority of ktimer threads is SCHED_FIFO 10
- [x] `opkg install rt-tests-ptest`
- [x] `ptest-runner`

```
# ptest-runner
START: ptest-runner
2024-08-05T22:22
BEGIN: /usr/lib/rt-tests/ptest
PASS: kernel_test_preempt_rt_presence
PASS: kernel_test_rt_throttling_disabled 1 - check kernel rt throttling
PASS: kthread_test_priority 1 - kthreadd
PASS: kthread_test_priority 2 - ksoftirqd
PASS: kthread_test_priority 3 - irq
PASS: kthread_test_priority 4 - irq_work
PASS: kthread_test_priority 5 - ktimers
PASS: irq_test_affinity 1 - check affinity
PASS: irq_test_affinity 2 - check affinity after restart
PASS: rcu_nocbs_test
DURATION: 3
END: /usr/lib/rt-tests/ptest
2024-08-05T22:22
STOP: ptest-runner
TOTAL: 1 FAIL: 0
```