### PR TITLE
kernel-test-nohz: tweak parameters to improve performance

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-test-nohz-files/nohz_test.c
+++ b/recipes-kernel/kernel-tests/kernel-test-nohz-files/nohz_test.c
@@ -420,7 +420,7 @@ static void validate_results(struct histogram_data *h)
 	p_99_999 = get_percentile(99.999, h);
 	p_99_9999 = get_percentile(99.9999, h);
 
-	if (h->max > max_latency)
+	if (h->max >= max_latency)
 		error_exit("Maximum latency exceeded", stats_summary, h->cnt, h->max, p_99_999, p_99_9999);
 	if (p_99_999 > percentile_99_999)
 		error_exit("99.999%% threshold exceeded", stats_summary, h->cnt, h->max, p_99_999, p_99_9999);

--- a/recipes-kernel/kernel-tests/kernel-test-nohz-files/nohz_test.c
+++ b/recipes-kernel/kernel-tests/kernel-test-nohz-files/nohz_test.c
@@ -20,7 +20,7 @@
 #include <signal.h>
 #include <linux/limits.h>
 
-#define TEST_PRIO	98
+#define TEST_PRIO	1
 
 #define NSEC_PER_USEC	1000ULL
 #define NSEC_PER_SEC	1000000000ULL

--- a/recipes-kernel/kernel-tests/kernel-test-nohz.bb
+++ b/recipes-kernel/kernel-tests/kernel-test-nohz.bb
@@ -40,7 +40,7 @@ pkg_postinst_ontarget:${PN}-ptest:append() {
     ISOLATED_CPU=$((CPUS - 1))
 
     if [ $ISOLATED_CPU -gt 0 ]; then
-        echo 'set otherbootargs="${otherbootargs} isolcpus=nohz,domain,managed_irq,'$ISOLATED_CPU' nohz_full='$ISOLATED_CPU' mitigations=off intel_pstate=disable intel_idle.max_cstate=0 processor.max_cstate=0 nosoftlockup mce=ignore_ce audit=0 tsc=nowatchdog"' > /boot/runmode/no-hz-full-params.cfg
+        echo 'set otherbootargs="${otherbootargs} isolcpus=nohz,domain,managed_irq,'$ISOLATED_CPU' nohz_full='$ISOLATED_CPU' mitigations=off intel_pstate=disable intel_idle.max_cstate=0 processor.max_cstate=0 nosoftlockup mce=ignore_ce audit=0 tsc=reliable"' > /boot/runmode/no-hz-full-params.cfg
         grep -qsxF 'source /runmode/no-hz-full-params.cfg' /boot/runmode/bootimage.cfg || echo 'source /runmode/no-hz-full-params.cfg' >> /boot/runmode/bootimage.cfg
     else
         echo "[kernel-test-nohz:error] This test requires a system with 2 or more CPUs"


### PR DESCRIPTION
Tweak parameters for the nohz kernel test to:

- Run test at FIFO/1 instead of FIFO/98. This improves test results because it allows the kernel threads pinned to the isolated CPU to run and get out of the way instead of keeping the scheduler tick on (i.e. because they are runnable but never get a chance to run).

- Use `tsc=reliable` kernel parameter instead of `tsc=nowatchdog`. This disables a repeating timer used to check the TSC validity on all CPUs, including isolated ones. This recurring timer adds to the latency observed on the isolated CPU(s).

WI: [AB#2796625](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2796625)

### Testing

- [x] `bitbake kernel-test-nohz` and served resulting packages from local feed
- [x] `opkg install kernel-test-nohz-ptest` on a PXIe-8881
- [x] `ptest-runner -t 345600`
- [x] validated the priority of nohz_test  with `chrt -p <pid>`
- [x] validated the kernel parameter change with `cat /proc/cmdline`

Initial test numbers show significant improvement in the max latency number; see associated bug for details. Final results to be validated by the ATS system.
