### PR TITLE
Update the software IO TLB filter rule to match new format

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-tests-files/kernel_dmesg_diff.py
+++ b/recipes-kernel/kernel-tests/kernel-tests-files/kernel_dmesg_diff.py
@@ -214,7 +214,7 @@ replacement_patterns = [
         [r'NODE_DATA\(0\) allocated \[mem .*\]', 'NODE_DATA(0) allocated [mem ]'],
         [r'ACPI: SSDT 0x.*', 'ACPI: SSDT 0x'],
         [r'tsc: Refined TSC clocksource calibration: \d+.\d+ MHz', 'tsc: Refined TSC clocksource calibration: MHz'],
-        [r'software IO TLB: mapped mem .*', 'software IO TLB: mapped mem'],
+        [r'software IO TLB: mapped .*', 'software IO TLB: mapped mem'],
         [r'eth\d:', 'ethX:'],
         [r'renamed from eth\d', 'renamed from ethX'],
         [r'mounted filesystem [0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}', 'mounted filesystem xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'],


### PR DESCRIPTION
This change should fix the AzDO bug here: https://dev.azure.com/ni/DevCentral/_workitems/edit/2817929

The format of the "software IO TLB " dmesg line change from "software IO TLB: mapped mem..." to "software IO TLB: mapped [mem...". This change updates the filter pattern to reflect this.