### PR TITLE
packagegroup-ni-base.bb: Add kernel to RDEPENDS

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -54,6 +54,7 @@ RDEPENDS:${PN} += "\
 	initscripts-nilrt \
 	iproute2 \
 	iptables \
+	kernel \
 	kernel-modules \
 	kmod \
 	libavahi-client \


### PR DESCRIPTION
Update packagegroup-ni-base recipe to list a RDEPENDS on kernel
