### PR TITLE
[next] Add a packagegroup for SNAC

### DIFF
--- a/recipes-core/packagegroups/packagefeed-ni-core.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-core.bb
@@ -6,6 +6,9 @@ inherit packagegroup
 RDEPENDS:${PN} = "\
 	packagegroup-base \
 	packagegroup-core-boot \
+	packagegroup-core-standalone-sdk-target \
+	packagegroup-core-x11 \
+	packagegroup-kernel-module-build \
 	packagegroup-ni-base \
 	packagegroup-ni-contributors \
 	packagegroup-ni-crio \
@@ -17,11 +20,9 @@ RDEPENDS:${PN} = "\
 	packagegroup-ni-runmode \
 	packagegroup-ni-safemode \
 	packagegroup-ni-skyline \
+	packagegroup-ni-snac \
 	packagegroup-ni-tzdata \
 	packagegroup-ni-wifi \
-	packagegroup-core-x11 \
-	packagegroup-core-standalone-sdk-target \
-	packagegroup-kernel-module-build \
 	dkms \
 	bolt \
 "

--- a/recipes-core/packagegroups/packagegroup-ni-snac.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-snac.bb
@@ -5,9 +5,7 @@ LICENSE = "MIT"
 inherit packagegroup
 
 
-RDEPENDS:${PN} = ""
-
-RDEPENDS:${PN}:append = "\
+RDEPENDS:${PN} = "\
 	cryptsetup \
 	ntp \
 	tmux \

--- a/recipes-core/packagegroups/packagegroup-ni-snac.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-snac.bb
@@ -1,0 +1,11 @@
+SUMMARY = "Open source package dependencies for the NILRT SNAC configuration."
+LICENSE = "MIT"
+
+
+inherit packagegroup
+
+
+RDEPENDS:${PN} = ""
+
+RDEPENDS:${PN}:append = "\
+"

--- a/recipes-core/packagegroups/packagegroup-ni-snac.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-snac.bb
@@ -8,4 +8,7 @@ inherit packagegroup
 RDEPENDS:${PN} = ""
 
 RDEPENDS:${PN}:append = "\
+	cryptsetup \
+	ntp \
+	tmux \
 "


### PR DESCRIPTION
Add a packagegroup to track package dependencies of the NILRT Secured,
Network-Attached Controller (SNAC) configuration.

Since the SNAC configuration is officially supported, add it to the core
package feed.

This packagegroup SHOULD NOT be installed to the NILRT runmode or
safemode images.


# Testing
* [x] Built `packagegroup-ni-snac` with this change. Meta package seems well formed.
* [x] Ran `bitbake -g packagefeed-ni-core` with this change and confirmed that the new packagegroup is in the pn-buildlist.

# Meta
* This is a NILRT 11 change only.