### PR TITLE
pkggrp-ni-internal-deps: change nissl contact

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
@@ -16,7 +16,7 @@ RDEPENDS:${PN} += "\
 "
 
 # nissl and nissleay
-# Contact: Haris Okanovic <haris.okanovic@ni.com>
+# Contact: Rich Tollerton <rich.tollerton@ni.com>
 RDEPENDS:${PN} += "\
 	apache-websocket \
 	apache2 \


### PR DESCRIPTION
Haris Okanovic no longer works at NI. Change NISSL dependency ownership to Rich Tollerton.

@rtollert 

# Testing
* None; nonfunctional changes.