### PR TITLE
Add libpwquality to packagefeed-ni-core

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-snac.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-snac.bb
@@ -9,4 +9,5 @@ RDEPENDS:${PN} = "\
 	cryptsetup \
 	ntp \
 	tmux \
+	libpwquality \
 "

--- a/recipes-extended/libpwquality/files/pwquality.conf
+++ b/recipes-extended/libpwquality/files/pwquality.conf
@@ -1,0 +1,78 @@
+# Configuration for systemwide password quality limits
+#
+# Number of characters in the new password that must not be present in the
+# old password.
+difok = 8
+#
+# Minimum acceptable size for the new password (plus one if
+# credits are not disabled which is the default). (See pam_cracklib manual.)
+# Cannot be set to lower value than 6.
+minlen = 15
+#
+# The maximum credit for having digits in the new password. If less than 0
+# it is the minimum number of digits in the new password.
+dcredit = -1
+#
+# The maximum credit for having uppercase characters in the new password.
+# If less than 0 it is the minimum number of uppercase characters in the new
+# password.
+ucredit = -1
+#
+# The maximum credit for having lowercase characters in the new password.
+# If less than 0 it is the minimum number of lowercase characters in the new
+# password.
+lcredit = -1
+#
+# The maximum credit for having other characters in the new password.
+# If less than 0 it is the minimum number of other characters in the new
+# password.
+ocredit = -1
+#
+# The minimum number of required classes of characters for the new
+# password (digits, uppercase, lowercase, others).
+minclass = 4
+#
+# The maximum number of allowed consecutive same characters in the new password.
+# The check is disabled if the value is 0.
+maxrepeat = 3
+#
+# The maximum number of allowed consecutive characters of the same class in the
+# new password.
+# The check is disabled if the value is 0.
+maxclassrepeat = 4
+#
+# Whether to check for the words from the passwd entry GECOS string of the user.
+# The check is enabled if the value is not 0.
+# gecoscheck = 0
+#
+# Whether to check for the words from the cracklib dictionary.
+# The check is enabled if the value is not 0.
+dictcheck = 1
+#
+# Whether to check if it contains the user name in some form.
+# The check is enabled if the value is not 0.
+# usercheck = 1
+#
+# Length of substrings from the username to check for in the password
+# The check is enabled if the value is greater than 0 and usercheck is enabled.
+# usersubstr = 0
+#
+# Whether the check is enforced by the PAM module and possibly other
+# applications.
+# The new password is rejected if it fails the check and the value is not 0.
+# enforcing = 1
+#
+# Path to the cracklib dictionaries. Default is to use the cracklib default.
+# dictpath =
+#
+# Prompt user at most N times before returning with error. The default is 1.
+retry = 3
+#
+# Enforces pwquality checks on the root user password.
+# Enabled if the option is present.
+# enforce_for_root
+#
+# Skip testing the password quality for users that are not present in the
+# /etc/passwd file.
+# Enabled if the option is present.
+# local_users_only

--- a/recipes-extended/libpwquality/libpwquality_1.%.bbappend
+++ b/recipes-extended/libpwquality/libpwquality_1.%.bbappend
@@ -1,0 +1,13 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI:append = "\
+    file://pwquality.conf \
+"
+
+do_install:append() {
+    install -d ${D}${sysconfdir}/security
+    install -m 644 ${WORKDIR}/pwquality.conf ${D}${sysconfdir}/security/pwquality.conf
+}
+
+FILES:${PN}     += "${sysconfdir}/security/pwquality.conf"
+CONFFILES:${PN} += "${sysconfdir}/security/pwquality.conf"


### PR DESCRIPTION
### Summary of Changes

* Add libpwquality to list of packages to be built
* Add pwquality.conf that has the values that are required for SNAC mode
  * These values are more restrictive than the default values
* Add bbappend file to install the config file to the correct location

### Justification

[AB#2817094](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2817094)


### Testing

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [X] Installed libpwquality and expected files were installed


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
