### PR TITLE
[next] .github: Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+### Summary of Changes
+
+TODO: Include a high-level description of the changes in this pull request.
+
+
+### Justification
+
+TODO: Justify why this contribution should be part of the project. Link to an AZDO work item with `AB#${AZDO ID}`.
+
+
+### Testing
+
+TODO: Detail what testing has been done to ensure this submission meets requirements.
+
+* [ ] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
+
+
+### Procedure
+
+* [ ] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).


### PR DESCRIPTION
Add a Github PR template to help contributors write high-quality PRs correctly the first time.

# Testing

I don't know how to test this. Opening a new PR against my dev branch doesn't prompt with the template. But this is basically just a copy of what we have been using in the [nilrt-snac repo](https://github.com/ni/nilrt-snac/blob/master/.github/PULL_REQUEST_TEMPLATE.md).