### PR TITLE
Add tmux config file to tmux IPK

### DIFF
--- a/recipes-extended/tmux/files/tmux.conf
+++ b/recipes-extended/tmux/files/tmux.conf
@@ -1,0 +1,3 @@
+set -g lock-command vlock
+bind X lock-session
+source-file -q /usr/share/tmux/conf.d/*

--- a/recipes-extended/tmux/tmux_3.%.bbappend
+++ b/recipes-extended/tmux/tmux_3.%.bbappend
@@ -1,0 +1,15 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "\
+    file://tmux.conf \
+"
+
+do_install:append() {
+    install -d ${D}${sysconfdir}
+    install -m 644 ${WORKDIR}/tmux.conf ${D}${sysconfdir}/tmux.conf
+    install -d ${D}/usr/share/tmux/conf.d
+}
+
+FILES:${PN}     += "${sysconfdir}/tmux.conf"
+CONFFILES:${PN} += "${sysconfdir}/tmux.conf"
+RDEPENDS:${PN}:append = " vlock"


### PR DESCRIPTION
# Changes
* [AB#2816950](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2816950)
* Create a directory for tmux configuration files in /usr/share/tmux/conf.d
* Add a /etc/tmux.conf file with default lock command
* Add a line to source all files in /usr/share/tmux/conf.d in /etc/tmux.conf
  * -q is to ignore errors if the directory is empty
* This allows snac mode to add a conf file to this location without modifying the main tmux.conf file

# Testing
* Built modified IPK successfully
* Installed on test machine and tmux started as expected with no errors