### PR TITLE
nisystemreplication: Split image files to fit FAT32

### DIFF
--- a/recipes-ni/ni-systemreplication/files/nisystemreplication
+++ b/recipes-ni/ni-systemreplication/files/nisystemreplication
@@ -80,7 +80,7 @@ is_image_valid () {
 		echo "No image name specified. Please specify an image name" && return 1
 	fi
 	# If image already exists, confirm if it should be overwritten
-	if [ -f $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.tgz ]; then
+	if [ -f $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.conf ]; then
 		read -e -p "An image already exits with this name. Overwrite? (y/N): " -i "N" overwrite 
 		[ $overwrite != "y" ] && return 1
 	fi
@@ -111,10 +111,13 @@ image_get () {
 		done
 	fi
 
+	# Cleanup any existing image files with same name first
+	rm -rf $NIRECOVERY_MOUNTPOINT/Images/$image_name
 	mkdir -p $NIRECOVERY_MOUNTPOINT/Images/$image_name
 	echo "Getting system image $image_name. This may take a while" >&2
 	local ext4_features=$(get_ext4_features)
-	nisystemimage getall -d -x tgz -f $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.tgz
+	# Split files at FAT32's max file size i.e., 2^32 - 1
+	nisystemimage getall -d -x tgz | split --bytes=$((2**32 - 1)) -d -a4 - $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.tgz
 
 	echo "DeviceDesc=$(get_device_desc)" > $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.conf
 	echo "Ext4Features=$ext4_features" >> $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.conf
@@ -133,8 +136,8 @@ select_image_from_list () {
 	images=()
 
 	for image in $(ls $NIRECOVERY_MOUNTPOINT/Images); do
-		if [ ! -f $NIRECOVERY_MOUNTPOINT/Images/$image/systemimage.tgz ] || [ ! -f $NIRECOVERY_MOUNTPOINT/Images/$image/systemimage.conf ]; then
-			echo "WARNING: Image \"$image\" is missing systemimage.tgz or systemimage.conf" >&2
+		if [ ! -f $NIRECOVERY_MOUNTPOINT/Images/$image/systemimage.tgz0000 ] || [ ! -f $NIRECOVERY_MOUNTPOINT/Images/$image/systemimage.conf ]; then
+			echo "WARNING: Image \"$image\" is missing systemimage.tgz* or systemimage.conf" >&2
 			continue
 		fi
 
@@ -189,7 +192,7 @@ image_set () {
 		install_safemode
 
 		echo "Applying system image $image_name. This may take a while" >&2
-		nisystemimage setall -d -x tgz -f $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.tgz -p reset -s reset
+		cat $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.tgz* | nisystemimage setall -d -x tgz -p reset -s reset
 
 		# Retain some grubenv settings
 		if grep --quiet "^consoleoutenable=" $BOOTFS_MOUNTPOINT/grub/grubenv; then


### PR DESCRIPTION
FAT32 max file size is limited to 2^32 - 1. So split the image files at this boundary.

### Justification

[AB#2834501](https://dev.azure.com/ni/DevCentral/_workitems/edit/2834501)

### Testing

* [x] Built core feed and recovery image with these changes
* [x] Used the recovery iso to "Get Image" and "Set Image" on a VM where `nirootfs` was 12GB. The image files were split at max file size boundary of FAT32 i.e., 4294967295 bytes.
* [x] Verified that setting the split size to a value larger than 4294967295 bytes causes `File too large` error during "Get Image".
* [x] Verified that largest files on `nirootfs` had the same md5 hash before and after imaging.
* [x] Verified that "Set Image" using the split 12G image works on VM with just 512MB memory. i.e., this this approach doesn't require large memory.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).

### Notes
- Needs cherry-pick into `nilrt/master/next`
