### PR TITLE
rtgroups: adjust ksoftirqd and rcu* priorities

### DIFF
--- a/recipes-core/busybox/files/ifplugd.action
+++ b/recipes-core/busybox/files/ifplugd.action
@@ -10,9 +10,6 @@
 
 export INTERFACE=$1
 
-# If there are drivers that need priorities changed, do it
-update_driver_priorities
-
 case "$2" in
    up)
       # On link-up, we're not guaranteed to be on the same network as

--- a/recipes-ni/ni-utils/files/functions.common
+++ b/recipes-ni/ni-utils/files/functions.common
@@ -695,19 +695,6 @@ update_all_interface_info () {
     done
 }
 
-update_driver_priorities () {
-    for d in /proc/irq/*; do
-        # Adjust wl12xx priority to something
-        # that allows reclamation of RCU objects
-        # through ksoftirqd under prolonged heavy
-        # wireless traffic conditions
-        if [ -d "$d"/wl12xx ]; then
-                echo 7 > "$d"/priority
-                break
-        fi
-    done
-}
-
 # Usage: enable_net_hotplug
 # Sets the flag so that enables hotplug.script to run
 enable_net_hotplug () {

--- a/recipes-rt/rt-tests/files/kthread_test_priority.sh
+++ b/recipes-rt/rt-tests/files/kthread_test_priority.sh
@@ -39,7 +39,7 @@ ptest_report
 rc_first=$ptest_rc
 
 ptest_change_subtest 2 ksoftirqd
-check_prio_for_task ksoftirqd/0 FIFO 8
+check_prio_for_task ksoftirqd/0 FIFO 1
 ptest_report
 
 ptest_change_subtest 3 irq
@@ -52,6 +52,22 @@ ptest_report
 
 ptest_change_subtest 5 ktimers
 check_prio_for_task ktimers/ FIFO 10
+ptest_report
+
+ptest_change_subtest 6 rcub
+check_prio_for_task rcub/ FIFO 2
+ptest_report
+
+ptest_change_subtest 7 rcuc
+check_prio_for_task rcuc/ FIFO 2
+ptest_report
+
+ptest_change_subtest 8 rcuog
+check_prio_for_task rcuog/ FIFO 2
+ptest_report
+
+ptest_change_subtest 9 rcu_preempt
+check_prio_for_task rcu_preempt FIFO 2
 ptest_report
 
 exit $rc_first

--- a/recipes-rt/rtctl/files/rtgroups
+++ b/recipes-rt/rtctl/files/rtgroups
@@ -42,5 +42,6 @@ kthreadd:f:25:*:\[kthreadd\]$
 irqthread:f:15:*:\[irq\/.+\]$
 irq_work:f:12:*:\[irq_work\/.+\]$
 ktimers:f:10:*:\[ktimers\/.+\]$
-ksoftirqd:f:8:*:\[ksoftirqd\/.+\]$
-
+rcu:f:2:*:\[rcu(b|c|og)\/[0-9]+\]$
+rcu_preempt:f:2:\[rcu_preempt\]$
+ksoftirqd:f:1:*:\[ksoftirqd\/.+\]$


### PR DESCRIPTION
### Summary of Changes

Adjust the priority for `ksoftirqd/x` and RCU threads which run at RT priority to match the upstream assumption that the priority of:

    irq_work > rcu* > ksoftirqd

Change the rt-tests ptest to reflect the changes.

### Justification

Our current NI Linux RT configuration which has the softirq tasks running at a higher RT priority than the RCU tasks causes a priority inversion and deadlock.

[AB#2795435](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2795435)

### Testing

* [x] `bitbake rtctl && bitbake rt-tests && bitbake package-index`, served packages from local feed
* [x] `opkg install rtctl`, rebooted target and manually validated the priority changes using `chrt`
* [x] validated that the deadlock is avoided with these settings in a 24h test
* [x] `opkg install rt-tests-ptest` and validated all tests pass with `ptest-runner`
* [x] manually tweaked the priority for `rcu_preempt` with `chrt -p -f 1 17` and verified the expected ptest subtests fail:

```
START: ptest-runner
2024-08-21T22:59
BEGIN: /usr/lib/rt-tests/ptest
PASS: kernel_test_preempt_rt_presence
PASS: kernel_test_rt_throttling_disabled 1 - check kernel rt throttling
PASS: kthread_test_priority 1 - kthreadd
PASS: kthread_test_priority 2 - ksoftirqd
PASS: kthread_test_priority 3 - irq
PASS: kthread_test_priority 4 - irq_work
PASS: kthread_test_priority 5 - ktimers
PASS: kthread_test_priority 6 - rcub
PASS: kthread_test_priority 7 - rcuc
PASS: kthread_test_priority 8 - rcuog
task rcu_preempt expected priority 2, but got priority 1
FAIL: kthread_test_priority 9 - rcu_preempt
unexpected tasks found running at FIFO/1 priority:
rcu_preempt
FAIL: kthread_test_priority 10 - fifo_1
PASS: irq_test_affinity 1 - check affinity
PASS: irq_test_affinity 2 - check affinity after restart
PASS: rcu_nocbs_test
DURATION: 4
END: /usr/lib/rt-tests/ptest
2024-08-21T22:59
STOP: ptest-runner
TOTAL: 1 FAIL: 0
```


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
