### PR TITLE
nisystemreplication: Fix unexpected differences

### DIFF
--- a/recipes-core/initrdscripts/files/ni_provisioning.safemode
+++ b/recipes-core/initrdscripts/files/ni_provisioning.safemode
@@ -3,6 +3,22 @@ set -e
 
 source /ni_provisioning.safemode.common
 
+check_all_used_binaries
+
+echo "Installing safemode to: $TARGET_DISK."
+echo 6 > /proc/sys/kernel/printk
+
+print_info "Disabling automount..."
+disable_automount
+print_done
+
+partitioning_disk
+wait_for_partitions $TARGET_DISK
+create_filesystems
+
+prune_efi_crash_vars
+install_grub
+
 install_safemode
 install_bootmode_file
 install_grubenv

--- a/recipes-core/initrdscripts/files/ni_provisioning.safemode.common
+++ b/recipes-core/initrdscripts/files/ni_provisioning.safemode.common
@@ -110,6 +110,7 @@ check_all_used_binaries()
 
 override_primaryport_grubenv()
 {
+	local grubenv_file=$1
 	# Add target-specific override of primary ethernet port if the lowest ifIndex is not to be used
 	local device_code=$(get_target_id)
 	# CVS-1458RT
@@ -117,7 +118,7 @@ override_primaryport_grubenv()
 		# Set eth0 (note: renamed to eth0 via udev) as the primary port. Do not let the primary
 		# port selection logic decide since it selects the 'eth' port with the lowest ifIndex
 		# value. (Renaming the port via udev does not alter ifIndex, so eth0 is not the lowest)
-		grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv set "ethaddr=`cat /sys/class/net/eth0/address`"
+		grub-editenv $grubenv_file set "ethaddr=`cat /sys/class/net/eth0/address`"
 	fi
 }
 
@@ -199,17 +200,8 @@ create_filesystems()
 	print_done
 }
 
-install_grub()
+set_efiboot_entry()
 {
-	GRUB_MOUNTPOINT=/var/volatile/grub
-	mkdir $GRUB_MOUNTPOINT -p
-	MOUNT_ERROR=`mount -L $PART1_LABEL $GRUB_MOUNTPOINT 2>&1` || die "$MOUNT_ERROR"
-
-	print_info "Configuring EFI grub2..."
-	GRUB_TARGET_DIR=$GRUB_MOUNTPOINT/efi/boot
-	mkdir -p $GRUB_TARGET_DIR
-	GRUB_TARGET=$(uname -m)
-	cp /boot/EFI/BOOT/bootx64.efi $GRUB_TARGET_DIR
 	# Delete existing NILRT entries with "-B" option
 	for ENTRY in $(efibootmgr | egrep -i '(LabVIEW RT)|(niboota)|(nibootb)' | egrep -o '[0-9A-Fa-f]{4}' || true);
 	do
@@ -218,6 +210,26 @@ install_grub()
 	done
 	efibootmgr $VERBOSE_ARGS -c -d ${TARGET_DISK} -p 1 -L 'LabVIEW RT' -l '\efi\boot\bootx64.efi'
 	print_done
+}
+
+mount_grub_partition()
+{
+	GRUB_MOUNTPOINT=/var/volatile/grub
+	mkdir $GRUB_MOUNTPOINT -p
+	MOUNT_ERROR=`mount -L $PART1_LABEL $GRUB_MOUNTPOINT 2>&1` || die "$MOUNT_ERROR"
+}
+
+install_grub()
+{
+	mount_grub_partition
+
+	print_info "Configuring EFI grub2..."
+	GRUB_TARGET_DIR=$GRUB_MOUNTPOINT/efi/boot
+	mkdir -p $GRUB_TARGET_DIR
+	GRUB_TARGET=$(uname -m)
+	cp /boot/EFI/BOOT/bootx64.efi $GRUB_TARGET_DIR
+
+	set_efiboot_entry
 
 	print_info "Installing grub.cfg..."
 
@@ -227,16 +239,21 @@ install_grub()
 	print_done
 }
 
+mount_bootfs_partition()
+{
+	BOOTFS_MOUNTPOINT=/var/volatile/bootfs
+	mkdir $BOOTFS_MOUNTPOINT -p
+	BOOTFS_ERROR=`mount -L $PART2_LABEL $BOOTFS_MOUNTPOINT 2>&1` || die "$BOOTFS_ERROR"
+}
+
 install_safemode()
 {
 	print_info "Installing safemode kernel and ramdisk..."
 
-	BOOTFS_MOUNTPOINT=/var/volatile/bootfs
-	mkdir $BOOTFS_MOUNTPOINT -p
-	BOOTFS_ERROR=`mount -L $PART2_LABEL $BOOTFS_MOUNTPOINT 2>&1` || die "$BOOTFS_ERROR"
+	mount_bootfs_partition
 	mkdir -p $BOOTFS_MOUNTPOINT/.safe
 
-	cp "$SOURCE_DIR"/*Image	   "$BOOTFS_MOUNTPOINT/.safe/"
+	cp "$SOURCE_DIR"/*Image		"$BOOTFS_MOUNTPOINT/.safe/"
 	cp "$SOURCE_DIR"/ramdisk.*	"$BOOTFS_MOUNTPOINT/.safe/"
 	cp "$SOURCE_DIR"/bootimage.*  "$BOOTFS_MOUNTPOINT/.safe/"
 
@@ -249,6 +266,13 @@ install_bootmode_file()
 	print_info "Installing bootmode file..."
 	echo "set BOOT_MODE=safemode" >$BOOTFS_MOUNTPOINT/bootmode
 	print_done
+}
+
+add_rootuuid_to_grubenv()
+{
+	# save rootfs UUID for grub to reference
+	ROOTUUID=`lsblk ${TARGET_DISK}${PART_SEPARATOR}4 -n -o PARTUUID`
+	echo set rootuuid=$ROOTUUID >> $GRUB_MOUNTPOINT/grubvar_readonly
 }
 
 install_grubenv()
@@ -266,7 +290,7 @@ install_grubenv()
 		cp $SOURCE_DIR/SMBIOS_NI_vars $BOOTFS_MOUNTPOINT/.safe
 		cp $SOURCE_DIR/EFI_NI_vars $BOOTFS_MOUNTPOINT/.safe
 		add_USB_gadget_args_to_grubenv
-		override_primaryport_grubenv
+		override_primaryport_grubenv $BOOTFS_MOUNTPOINT/grub/grubenv
 	else
 		cp $SOURCE_DIR/grubenv_non_ni_target $BOOTFS_MOUNTPOINT/grub/grubenv
 	fi
@@ -281,9 +305,7 @@ install_grubenv()
 		echo "$varname" >> "$BOOTFS_MOUNTPOINT/.safe/GRUB_NI_readonly_vars"
 	done
 
-	# save rootfs UUID for grub to reference
-	ROOTUUID=`lsblk ${TARGET_DISK}${PART_SEPARATOR}4 -n -o PARTUUID`
-	echo set rootuuid=$ROOTUUID >> $GRUB_MOUNTPOINT/grubvar_readonly
+	add_rootuuid_to_grubenv
 
 	# set proper permissions on and backup firmware variable files
 	chown 0:500 $BOOTFS_MOUNTPOINT/grub/grubenv
@@ -322,6 +344,26 @@ install_grubenv()
 	if [ -n "$grubenv_bootdelay" ]; then
 		grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv set "bootdelay=$grubenv_bootdelay"
 	fi
+}
+
+fix_grubenv_after_usbreplication()
+{
+		# Fix files in nigrub filesystem
+		rm $GRUB_MOUNTPOINT/grubvar_readonly
+		if is_ni_device ; then
+			add_USB_gadget_args_to_grubenv
+		fi
+		set_serial_port
+		add_rootuuid_to_grubenv
+
+		# Fix files in nibootfs filesystem
+		if is_ni_device ; then
+			override_primaryport_grubenv $BOOTFS_MOUNTPOINT/grub/grubenv
+			override_primaryport_grubenv $BOOTFS_MOUNTPOINT/grub/grubenv.bak
+		else
+			grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv set "serial#=ABCDEFG"
+		fi
+		grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv unset primaryethaddr
 }
 
 set_versions()
@@ -403,20 +445,4 @@ sanity_check()
 	print_done
 }
 
-check_all_used_binaries
-
-echo "Installing safemode to: $TARGET_DISK."
-echo 6 > /proc/sys/kernel/printk
-
 SOURCE_DIR=/payload
-
-print_info "Disabling automount..."
-disable_automount
-print_done
-
-partitioning_disk
-wait_for_partitions $TARGET_DISK
-create_filesystems
-
-prune_efi_crash_vars
-install_grub

--- a/recipes-ni/ni-systemreplication/files/nisystemreplication
+++ b/recipes-ni/ni-systemreplication/files/nisystemreplication
@@ -189,22 +189,30 @@ image_set () {
 		# Start with "none" so that default features are not enabled if not listed in $ext4_features
 		MKFS_ARGS="${MKFS_ARGS} -O none,$ext4_features"
 		source /ni_provisioning.safemode.common
-		install_safemode
+
+		check_all_used_binaries
+
+		echo "Installing to: $TARGET_DISK."
+		echo 6 > /proc/sys/kernel/printk
+
+		print_info "Disabling automount..."
+		disable_automount
+		print_done
+
+		partitioning_disk
+		wait_for_partitions $TARGET_DISK
+		create_filesystems
+
+		prune_efi_crash_vars
 
 		echo "Applying system image $image_name. This may take a while" >&2
 		cat $NIRECOVERY_MOUNTPOINT/Images/$image_name/systemimage.tgz* | nisystemimage setall -d -x tgz -p reset -s reset
 
-		# Retain some grubenv settings
-		if grep --quiet "^consoleoutenable=" $BOOTFS_MOUNTPOINT/grub/grubenv; then
-			grubenv_consoleoutenable=$(grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv list |grep "^consoleoutenable=" | cut -f 2 -d '=')
-		fi
-		if grep --quiet "^bootdelay=" $BOOTFS_MOUNTPOINT/grub/grubenv; then
-			grubenv_bootdelay=$(grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv list |grep "^bootdelay=" | cut -f 2 -d '=')
-		fi
-		rm -rf mkdir $BOOTFS_MOUNTPOINT/grub
+		set_efiboot_entry
 
-		install_grubenv
-		set_versions
+		mount_grub_partition
+		mount_bootfs_partition
+		fix_grubenv_after_usbreplication
 
 		echo $LOG_LEVEL > /proc/sys/kernel/printk
 		sanity_check


### PR DESCRIPTION
Existing "Set Image" workflow installed grub and safemode afresh from provisioning media while setting some variables to ensure settings from system image get carried over but this left undesired changes in some files.

This commit fixes this by copying nigrub and nibootfs from system image and later fixing the few files in them that are required to be different.

WI: [AB#2811709](https://dev.azure.com/ni/DevCentral/_workitems/edit/2811709)

### Testing

* [x] Built core feed, recovery image
* [x] Default Provisioning works as expected
* [x] Tested "Get Image" and "Set Image" on a VM, cRIO-9035 and PXIe-8840; other than the intended changes in grubenv* and grubvar_readonly, other files remain same.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).

### Note
Requires cherry-pick into `nilrt/master/next`.
