### PR TITLE
enable pam-plugin-faillock when it's installed with custom settings

### DIFF
--- a/recipes-extended/pam/libpam/security/faillock.conf
+++ b/recipes-extended/pam/libpam/security/faillock.conf
@@ -1,0 +1,62 @@
+# Configuration for locking the user after multiple failed
+# authentication attempts.
+#
+# The directory where the user files with the failure records are kept.
+# The default is /var/run/faillock.
+# dir = /var/run/faillock
+#
+# Will log the user name into the system log if the user is not found.
+# Enabled if option is present.
+audit
+#
+# Don't print informative messages.
+# Enabled if option is present.
+silent
+#
+# Don't log informative messages via syslog.
+# Enabled if option is present.
+# no_log_info
+#
+# Only track failed user authentications attempts for local users
+# in /etc/passwd and ignore centralized (AD, IdM, LDAP, etc.) users.
+# The `faillock` command will also no longer track user failed
+# authentication attempts. Enabling this option will prevent a
+# double-lockout scenario where a user is locked out locally and
+# in the centralized mechanism.
+# Enabled if option is present.
+# local_users_only
+#
+# Deny access if the number of consecutive authentication failures
+# for this user during the recent interval exceeds n tries.
+# The default is 3.
+deny = 3
+#
+# The length of the interval during which the consecutive
+# authentication failures must happen for the user account
+# lock out is <replaceable>n</replaceable> seconds.
+# The default is 900 (15 minutes).
+fail_interval = 900
+#
+# The access will be re-enabled after n seconds after the lock out.
+# The value 0 has the same meaning as value `never` - the access
+# will not be re-enabled without resetting the faillock
+# entries by the `faillock` command.
+# The default is 600 (10 minutes).
+unlock_time = 0
+#
+# Root account can become locked as well as regular accounts.
+# Enabled if option is present.
+# even_deny_root
+#
+# This option implies the `even_deny_root` option.
+# Allow access after n seconds to root account after the
+# account is locked. In case the option is not specified
+# the value is the same as of the `unlock_time` option.
+# root_unlock_time = 900
+#
+# If a group name is specified with this option, members
+# of the group will be handled by this module the same as
+# the root account (the options `even_deny_root>` and
+# `root_unlock_time` will apply to them.
+# By default, the option is not set.
+# admin_group = <admin_group_name>

--- a/recipes-extended/pam/libpam_1.%.bbappend
+++ b/recipes-extended/pam/libpam_1.%.bbappend
@@ -1,1 +1,23 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI += "\
+	file://security/faillock.conf \
+"
+
+do_install:append() {
+	install -m 644 ${WORKDIR}/security/faillock.conf ${D}${sysconfdir}/security/faillock.conf
+}
+
+pkg_postinst:pam-plugin-faillock:append() {
+	# enable faillock
+	sed -E -i 's/^(.+)success=1(.+)$/auth    requisite pam_faillock.so preauth\n\1success=2\2\nauth    [default=die] pam_faillock.so authfail/' "${sysconfdir}/pam.d/common-auth"
+	echo "auth    sufficient pam_faillock.so authsucc" >> "${sysconfdir}/pam.d/common-auth"
+}
+
+pkg_prerm:pam-plugin-faillock:append() {
+	# disable faillock
+	sed -E -i '/pam_faillock.so/d' "${sysconfdir}/pam.d/common-auth"
+	sed -E -i 's/^(.+)success=2(.+)$/\1success=1\2/' "${sysconfdir}/pam.d/common-auth"
+}
+
+RCONFLICTS:pam-plugin-faillock:append = " ni-auth"


### PR DESCRIPTION
### Summary of Changes

- update the pam-plugin-faillock package so that the plugin gets enabled when it's installed
- modify some faillock configuration settings
- prevent pam-plugin-faillock from being installed when `ni-auth` is installed


### Justification

This change simplifies Secured, Network-Attached Controller (SNAC) configuration, [AB#2816939](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2816939). faillock is required to be enabled on a SNAC. The faillock settings were chosen to comply with SNAC requirements. The conflict with `ni-auth` was added because from testing it appears that the faillock plugin is incompatible with the ni-auth plugin.


### Testing

I tested that opkg returns a clear error message when installing `pam-plugin-faillock` describing the conflict if `ni-auth` is installed. I confirmed that `libpam-runtime` contains the customized `/etc/security/faillock.conf`. After removing `ni-auth`, I installed `pam-plugin-faillock` and confirmed that the configuration files changed as I expected.

```text
>~# cat /etc/pam.d/common-auth
#
# /etc/pam.d/common-auth - authentication settings common to all services
#
# This file is included from other service-specific PAM config files,
# and should contain a list of the authentication modules that define
# the central authentication scheme for use on the system
# (e.g., /etc/shadow, LDAP, Kerberos, etc.).  The default is to use the
# traditional Unix authentication mechanisms.

# here are the per-package modules (the "Primary" block)
auth    requisite pam_faillock.so preauth
auth    [success=2 default=ignore]      pam_unix.so nullok_secure
auth    [default=die] pam_faillock.so authfail
# here's the fallback if no module succeeds
auth    requisite                       pam_deny.so
# prime the stack with a positive return value if there isn't one already;
# this avoids us returning an error just because nothing sets a success code
# since the modules above will each just jump around
auth    required                        pam_permit.so
# and here are more per-package modules (the "Additional" block)
auth    sufficient pam_faillock.so authsucc
```

I confirmed that `common-auth` was reverted after removing `pam-plugin-faillock`.

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).

@ni/rtos @amstewart