### PR TITLE
nftables, firewalld: add to runmode

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -40,6 +40,7 @@ RDEPENDS:${PN} = "\
 RDEPENDS:${PN} += "\
 	cpp \
 	cpp-symlinks \
+	firewalld \
 	libmpc \
 	libpython3 \
 	libyaml \

--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -44,6 +44,7 @@ RDEPENDS:${PN} += "\
 	libpython3 \
 	libyaml \
 	mpfr \
+	nftables \
 	python3-modules \
 	python3-aiodns \
 	python3-aiohttp \


### PR DESCRIPTION
### Summary of Changes

Add nftables (modern Linux packet filtering support) and firewalld (modern Linux high-level firewall administration tool) packages to runmode. At present, neither will be enabled, but they can be enabled by the user. The existing iptables initscript is unchanged. This is tracked by Azure DevOps workitem [AB#2823118](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2823118).

### Testing

Built nilrt-base-system-image and confirmed it runs on a VM. nft runs; iptables still runs. firewall-cmd is not yet tested.

This change will grow the uncompressed BSI by approximately **9.5MB** (!). The largest new files break down along the following lines:

| Directory | Size (KiB) |
|-|-|
| /usr/lib/python-3.10/ | 2458 |
| /usr/lib/girepository-1.0/ | 724 |
| /usr/lib/gobject-introspection/ | 669 |
| /usr/lib/\*.so.\* | 1264 |
| /lib/modules/ | 870 |
| /usr/*bin/ | 897 |
| /usr/share/licenses/ | 341 | 
| /usr/share/firewalld/ | 712 |

Several things about this seem problematic.
- The entirety of the increased disk usage in /usr/lib/girepository-1.0/, /usr/lib/gobject-introspection/, and /usr/share/licenses/, and a substantial fraction of /usr/lib/python-3.10/ — perhaps 3 MiB in all — is solely due to firewalld's dependency on python3-pygobject, which in turn pulls in gobject-introspection, libcairo2 (!), libcairo-gobject2 (!!), python3-pycairo, etc.
- The entirety of the disk usage in /usr/share/firewalld/ is due to a new file firewall-config.glade, which appears to solely exist for the sake of GTK3-based firewalld configuration UI; this appears to be installed as `firewall-config`; we don't need it, but if we need GTK3 anyway, I guess it can't hurt.
- /usr/bin/firewall-applet is a python script which requires PyQt5 which is not installed.

I fear the gobject-related bits will be hard to remove; they've been in firewalld since 2012. That said, the only thing I can find so far that clearly requires it is DBus (?). I think I'm missing something.

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
