### PR TITLE
[next] nftables, firewalld: add to runmode

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -23,6 +23,7 @@ RDEPENDS:${PN} = "\
 	librtpi \
 	linux-firmware-radeon \
 	lldpd \
+	nftables \
 	ni-configpersistentlogs \
 	ni-locale-alias \
 	ni-modules-autoload \

--- a/recipes-core/packagegroups/packagegroup-ni-snac.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-snac.bb
@@ -7,6 +7,7 @@ inherit packagegroup
 
 RDEPENDS:${PN} = "\
 	cryptsetup \
+	firewalld \
 	ntp \
 	tmux \
 	libpwquality \


### PR DESCRIPTION
### Summary of Changes

Add nftables (modern Linux packet filtering support) to runmode; disabled by default.

Add firewalld (modern Linux high-level firewall administration tool) packages to SNAC. (nftables is in runmode, not SNAC, for symmetry with the kernel configuration, which will include the NFT modules in runmode too.) 

The existing iptables initscript is unchanged. This is tracked by Azure DevOps workitem [AB#2823118](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2823118).

Note: this is a continuation of #725, rebased to `nilrt/master/next`.

### Testing

Built nilrt-base-system-image and confirmed it runs on a VM. nft runs; iptables still runs. firewall-cmd is not yet tested.

This change will grow the uncompressed BSI by approximately 9.5MB; see #725 for details.

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
