### PR TITLE
sudo: give the sudo group permission to run the sudo command

### DIFF
--- a/recipes-extended/sudo/sudo_1.%.bbappend
+++ b/recipes-extended/sudo/sudo_1.%.bbappend
@@ -1,0 +1,3 @@
+do_install:append() {
+	sed -i 's/^# \(%sudo	ALL=(ALL:ALL) ALL\)$/\1/' ${D}${sysconfdir}/sudoers
+}


### PR DESCRIPTION
### Summary of Changes

give the sudo group permission to run the sudo command


### Justification

This change simplifies Secured, Network-Attached Controller (SNAC) configuration. [AB#2833082](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2833082). SNAC System Administrators will be added to the sudo group, and these System Administrators need to be able to use the sudo command.

The implementation mimics what is done for the wheel group [here][1].

[1]: https://github.com/ni/openembedded-core/blob/55f1437e2e7f11724ace489677ae214611244faf/meta/recipes-extended/sudo/sudo_1.9.15p2.bb#L36

### Testing

I confirmed that `sudo-lib` contains the modified `/etc/sudoers`.

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).

@ni/rtos @amstewart
