### PR TITLE
[next] recipes-ni: add nilrt-snac recipe

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-snac.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-snac.bb
@@ -8,7 +8,8 @@ inherit packagegroup
 RDEPENDS:${PN} = "\
 	cryptsetup \
 	firewalld \
+	libpwquality \
+	nilrt-snac \
 	ntp \
 	tmux \
-	libpwquality \
 "

--- a/recipes-ni/nilrt-snac/nilrt-snac_git.bb
+++ b/recipes-ni/nilrt-snac/nilrt-snac_git.bb
@@ -1,0 +1,32 @@
+SUMMARY = "NILRT SNAC Configuration Tool"
+DESCRIPTION = "\
+A utility for admins to put a NILRT system into the SNAC configuration.\
+"
+HOMEPAGE = "https://github.com/ni/nilrt-snac"
+SECTION = "base"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=380df876633ca23587b9851600778cc0"
+
+
+SRC_URI = "\
+	git://github.com/ni/nilrt-snac;branch=master;protocol=https \
+"
+
+
+SRCREV = "${AUTOREV}"
+PV = "0.1.1+git${SRCPV}"
+
+S = "${WORKDIR}/git"
+
+
+do_install() {
+	oe_runmake install \
+		DESTDIR=${D}
+}
+
+
+RDEPENDS:${PN} = "\
+	bash \
+	opkg \
+	python3-core \
+"


### PR DESCRIPTION
### Summary of Changes

1. Add a `nilrt-snac` recipe that ships the [nilrt-snac](https://github.com/ni/nilrt-snac) project.
2. Add the `nilrt-snac` package to the SNAC packagegroup.


### Justification

[AB#2744170](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2744170)

This patchset allows SNAC users to install the nilrt-snac configuration tool from the canonical package feeds.


### Testing

```
root@NI-cRIO-903x-VM-15b7aebf:~# opkg info nilrt-snac
Package: nilrt-snac
Version: 0.1.1+git0+5488d5a779-r999
Depends: bash, opkg, python3-core
Recommends: nilrt-snac-lic
Status: install ok installed
Section: base
Architecture: core2-64
Maintainer: NI Linux Real-Time Maintainers <nilrt@ni.com>
MD5Sum: 7e633b3964d18b804d0639077d10d2fd
Size: 10382
Filename: nilrt-snac_0.1.1+git0+5488d5a779-r999_core2-64.ipk
Source: nilrt-snac_git.bb
Description: NILRT SNAC Configuration Tool
Installed-Size: 34257
Installed-Time: 1725642021
OE: nilrt-snac
HomePage: https://github.com/ni/nilrt-snac
License: MIT
```

* [x] The nilrt-snac recipe builds locally.
```
[0] usr0:nilrt-snac$ tree 0.1.1+git/image/
0.1.1+git/image/
├── etc
│   ├── init.d
│   │   └── ni-wireguard-labview
│   └── wireguard
│       └── wglv0.conf
└── usr
    ├── lib
    │   └── nilrt-snac
    │       └── nilrt_snac
    │           ├── _common.py
    │           ├── _configs
    │           │   ├── _base_config.py
    │           │   ├── _config_file.py
    │           │   ├── _console_config.py
    │           │   ├── _cryptsetup_config.py
    │           │   ├── _faillock_config.py
    │           │   ├── __init__.py
    │           │   ├── _niauth_config.py
    │           │   ├── _ntp_config.py
    │           │   ├── _opkg_config.py
    │           │   ├── _pwquality_config.py
    │           │   ├── _usbguard_config.py
    │           │   ├── _wifi_config.py
    │           │   ├── _wireguard_config.py
    │           │   └── _x11_config.py
    │           ├── __init__.py
    │           ├── __main__.py
    │           ├── OpkgHelper.py
    │           └── _pre_reqs.py
    ├── sbin
    │   └── nilrt-snac
    └── share
        ├── doc
        │   └── nilrt-snac
        │       ├── LICENSE
        │       └── README.md
        └── nilrt-snac
            └── nilrt-snac-conflicts.ipk

14 directories, 25 files
```
* [x] Installed the `nilrt-snac` package to a 24.8 dist-next VM.
  * Confirmed that `nilrt-snac` is in PATH.
  * Confirmed that `nilrt-snac configure` works and places the target into SNAC mode.
  * Confirmed that `nilrt-verify` works and verifies the configuration after installation.
```
root@NI-cRIO-903x-VM-15b7aebf:~# nilrt-snac verify
Checking EUID
Checking iptables
Chain INPUT (policy ACCEPT)
target     prot opt source               destination         

Chain FORWARD (policy ACCEPT)
target     prot opt source               destination         

Chain OUTPUT (policy ACCEPT)
target     prot opt source               destination         
Validating SNAC mode.
Verifying NTP configuration...
Verifying opkg configuration...
Verifying wireguard configuration...
Verifying cryptsetup configuration...
Verifying NIAuth...
Verifying WiFi configuration...
Verifying PAM faillock...
Verifying X11 stack removal...
Verifying console access configuration...
Verifying Password quality...
```

* [x] Built the SNAC package group locally.
* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

This is a `nilrt/master/next`-only patchset.

* [x] **BLOCKED**: This PR is blocked until the [nilrt-snac#15](https://github.com/ni/nilrt-snac/pull/15) PR is pulled.
* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
