### PR TITLE
Onboard: Add onboard virtual keyboard

### DIFF
--- a/recipes-support/onboard/files/0001-add-xfce-to-autostart-onlyshowin.patch
+++ b/recipes-support/onboard/files/0001-add-xfce-to-autostart-onlyshowin.patch
@@ -1,0 +1,10 @@
+diff --git a/data/onboard-autostart.desktop.in b/data/onboard-autostart.desktop.in
+index 8fb55ac..cf022a0 100644
+--- a/data/onboard-autostart.desktop.in
++++ b/data/onboard-autostart.desktop.in
+@@ -9,4 +9,4 @@ NoDisplay=true
+ X-Ubuntu-Gettext-Domain=onboard
+ AutostartCondition=GSettings org.gnome.desktop.a11y.applications screen-keyboard-enabled
+ X-GNOME-AutoRestart=true
+-OnlyShowIn=GNOME;Unity;MATE;
++OnlyShowIn=GNOME;Unity;MATE;XFCE;

--- a/recipes-support/onboard/files/0001-pypredict-lm-Define-error-API-if-platform-does-not-h.patch
+++ b/recipes-support/onboard/files/0001-pypredict-lm-Define-error-API-if-platform-does-not-h.patch
@@ -1,0 +1,70 @@
+From 1c95f64aa342147387ce4b1b7269a5c8b34bd898 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 13 Jul 2017 09:01:04 -0700
+Subject: [PATCH] pypredict/lm: Define error API if platform does not have it
+
+error() API is not implemented across all libcs on linux
+e.g. musl does not provide it.
+
+Upstream-Status: Inactive-Upstream [lastcommit: 2017-10-09]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+---
+ Onboard/pypredict/lm/lm.cpp         |  1 -
+ Onboard/pypredict/lm/lm.h           | 13 +++++++++++++
+ Onboard/pypredict/lm/lm_dynamic.cpp |  2 --
+ 3 files changed, 13 insertions(+), 3 deletions(-)
+
+diff --git a/Onboard/pypredict/lm/lm.cpp b/Onboard/pypredict/lm/lm.cpp
+index 2e64296..37ae241 100644
+--- a/Onboard/pypredict/lm/lm.cpp
++++ b/Onboard/pypredict/lm/lm.cpp
+@@ -19,7 +19,6 @@
+ 
+ #include <stdlib.h>
+ #include <stdio.h>
+-#include <error.h>
+ #include <algorithm>
+ #include <cmath>
+ #include <string>
+diff --git a/Onboard/pypredict/lm/lm.h b/Onboard/pypredict/lm/lm.h
+index ed4164a..b8b63ee 100644
+--- a/Onboard/pypredict/lm/lm.h
++++ b/Onboard/pypredict/lm/lm.h
+@@ -32,6 +32,19 @@
+ #include <algorithm>
+ #include <string>
+ 
++#if defined(HAVE_ERROR_H)
++#include <error.h>
++#else
++#include <err.h>
++#define _onboard_error(S, E, F, ...) do { \
++       if (E) \
++               err(S, F ": %s", ##__VA_ARGS__, strerror(E)); \
++       else \
++               err(S, F, ##__VA_ARGS__); \
++} while(0)
++
++#define error _onboard_error
++#endif
+ 
+ // break into debugger
+ // step twice to come back out of the raise() call into known code
+diff --git a/Onboard/pypredict/lm/lm_dynamic.cpp b/Onboard/pypredict/lm/lm_dynamic.cpp
+index 7c62824..e7c7f40 100644
+--- a/Onboard/pypredict/lm/lm_dynamic.cpp
++++ b/Onboard/pypredict/lm/lm_dynamic.cpp
+@@ -17,8 +17,6 @@
+  * along with this program. If not, see <http://www.gnu.org/licenses/>.
+  */
+ 
+-#include <error.h>
+-
+ #include "lm_dynamic.h"
+ 
+ using namespace std;
+-- 
+2.13.2
+

--- a/recipes-support/onboard/files/0002-onboard-onhover-seg-fault-fix.patch
+++ b/recipes-support/onboard/files/0002-onboard-onhover-seg-fault-fix.patch
@@ -1,0 +1,52 @@
+From: 1be95325d320122efd5dedf7437839cfcca01f7a
+From: https://github.com/void-linux/void-packages/commit/1be95325d320122efd5dedf7437839cfcca01f7a
+Date: Mon, 23 Sep 2024
+Subject: [PATCH] onboard: fix segfault when hovering over the keyboard
+
+Currently, if the mouse pointer is hovered over the Onboard keyboard, the application crashes with a segmentation fault.
+This is because the new_device_event function is not acquiring the GIL before creating a new object. This patch fixes
+the issue by acquiring the GIL before creating a new object. It also acquires the GIL before queueing the event.
+This patch is taken from the fix provided in the following link:
+https://github.com/void-linux/void-packages/commit/1be95325d320122efd5dedf7437839cfcca01f7a
+
+Signed-off by: Pratheeksha S N <pratheeksha.s.n@ni.com>
+
+Upstream-Status: Inactive-Upstream [lastcommit: 2017-10-09]
+
+--- a/Onboard/osk/osk_devices.c
++++ b/Onboard/osk/osk_devices.c
+@@ -97,13 +97,15 @@ osk_device_event_dealloc (OskDeviceEvent
+ static OskDeviceEvent*
+ new_device_event (void)
+ {
+-    OskDeviceEvent *ev = PyObject_New(OskDeviceEvent, &osk_device_event_type);
++    OskDeviceEvent *ev;
++    PyGILState_STATE gstate = PyGILState_Ensure();
++    ev = PyObject_New(OskDeviceEvent, &osk_device_event_type);
+     if (ev)
+     {
+         osk_device_event_type.tp_init((PyObject*) ev, NULL, NULL);
+-        return ev;
+     }
+-    return NULL;
++    PyGILState_Release(gstate);
++    return ev;
+ }
+ 
+ static PyObject *
+@@ -334,6 +336,7 @@ osk_devices_dealloc (OskDevices *dev)
+ static void
+ queue_event (OskDevices* dev, OskDeviceEvent* event, Bool discard_pending)
+ {
++    PyGILState_STATE state = PyGILState_Ensure ();
+     GQueue* queue = dev->event_queue;
+     if (queue)
+     {
+@@ -364,6 +367,7 @@ queue_event (OskDevices* dev, OskDeviceE
+         Py_INCREF(event);
+         g_queue_push_head(queue, event);
+     }
++    PyGILState_Release (state);
+ }
+ 
+ static gboolean idle_process_event_queue (OskDevices* dev)

--- a/recipes-support/onboard/files/01-gnome-accessibility
+++ b/recipes-support/onboard/files/01-gnome-accessibility
@@ -1,0 +1,3 @@
+# We need accessibility on in order to use Onboard's auto-show.
+[org/gnome/desktop/interface]
+toolkit-accessibility=true

--- a/recipes-support/onboard/files/NI.colors
+++ b/recipes-support/onboard/files/NI.colors
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<!--
+    Copyright (c) 2022 National Instruments
+
+    SPDX-License-Identifier: GPL-3.0
+-->
+<color_scheme name="NI" format="2.1">
+    <window type="key-popup">
+        <color element="border" rgb="#044123" opacity="0.0"/>
+    </window>
+
+    <layer> <color element="background" rgb="#044123" opacity="1.0"/> </layer>
+    <layer> <color element="background" rgb="#044123" opacity="0.9"/> </layer>
+    <layer> <color element="background" rgb="#044123" opacity="0.9"/> </layer>
+
+    <key_group>
+        <color element="fill"   rgb="#f4f4f4"/>
+        <color element="stroke" rgb="#000000" opacity="0.0" />
+        <color element="label"  rgb="#044123"/>
+        icon0
+        
+        <key_group>
+            <color element="fill" rgb="#ffffff"/>
+            icon1, icon2
+        </key_group>
+        
+        <!-- dark keys -->
+        <key_group>
+            <color element="fill" rgb="#cddcc8"/>
+            <color element="label" rgb="#044123"/>
+            icon3,
+            RCTL, LCTL, RALT, LALT, LWIN, CAPS, 
+            LFSH, RTSH, NMLK,
+            MENU, RWIN, BKSP, TAB, RTRN, 
+            KPDL, KPEN, KPSU, KPDV, KPAD, KPMU,
+            LEFT, RGHT, UP, DOWN, INS, DELE, HOME, END, PGUP, PGDN,
+            F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12,
+            Prnt, Pause, ESC, Scroll,
+            secondaryclick, middleclick, doubleclick, dragclick, hoverclick,
+            hide, showclick, move, layer,
+            quit
+
+            <!-- word suggestions -->
+            <key_group>
+                <color element="fill" rgb="#cddcc8"/>
+                wordlist, prediction, pause-learning.wordlist, language.wordlist, hide.wordlist
+            </key_group>
+        </key_group>
+        
+        <!-- snippets -->
+        <key_group>
+            <color element="fill" rgb="#f4f4f4"/>
+            m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15
+        </key_group>
+        
+        <!-- red preferences -->
+        <key_group>
+            <color element="fill" rgb="#eb8768"/>
+            settings
+        </key_group>
+    </key_group>
+</color_scheme>

--- a/recipes-support/onboard/files/NI.theme
+++ b/recipes-support/onboard/files/NI.theme
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!--
+    Copyright (c) 2022 National Instruments
+
+    SPDX-License-Identifier: GPL-3.0
+-->
+<theme name="NI" format="1.3">
+    <color_scheme>NI</color_scheme>
+    <key_style>flat</key_style>
+    <roundrect_radius>20</roundrect_radius>
+    <key_fill_gradient>30</key_fill_gradient>
+    <key_stroke_gradient>70</key_stroke_gradient>
+    <key_gradient_direction>-3</key_gradient_direction>
+    <key_label_font></key_label_font>
+    <key_label_overrides></key_label_overrides>
+</theme>

--- a/recipes-support/onboard/files/onboard-defaults.conf
+++ b/recipes-support/onboard/files/onboard-defaults.conf
@@ -1,0 +1,13 @@
+[main]
+layout=Compact
+theme=NI
+key-label-font=DejaVu Sans
+
+[window]
+force-to-top=True
+
+[auto-show]
+# Enable autoshow when there's no keyboard detected.
+enabled=True
+keyboard-device-detection-enabled=True
+keyboard-device-detection-exceptions=['::noserial']

--- a/recipes-support/onboard/onboard_1.4.1.bb
+++ b/recipes-support/onboard/onboard_1.4.1.bb
@@ -1,0 +1,62 @@
+SUMMARY = "An onscreen keyboard"
+LICENSE = "GPL-3.0-only"
+LIC_FILES_CHKSUM = "file://COPYING.GPL3;md5=8521fa4dd51909b407c5150498d34f4e"
+
+DEPENDS += "gtk+3 hunspell libcanberra libxkbfile dconf python3-distutils-extra-native intltool-native"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI = "https://launchpad.net/onboard/1.4/${PV}/+download/${BPN}-${PV}.tar.gz \
+           file://0001-pypredict-lm-Define-error-API-if-platform-does-not-h.patch \
+           file://0002-onboard-onhover-seg-fault-fix.patch \
+           file://0001-add-xfce-to-autostart-onlyshowin.patch \
+           file://01-gnome-accessibility \
+           file://NI.colors \
+           file://NI.theme \
+           file://onboard-defaults.conf \
+           "
+SRC_URI[sha256sum] = "01cae1ac5b1ef1ab985bd2d2d79ded6fc99ee04b1535cc1bb191e43a231a3865"
+
+CXXFLAGS += "-Werror=declaration-after-statement"
+
+inherit features_check setuptools3 pkgconfig gtk-icon-cache gsettings mime-xdg
+
+REQUIRED_DISTRO_FEATURES = "x11"
+
+FILES:${PN} += " \
+    ${datadir}/dbus-1 \
+    ${datadir}/icons \
+    ${datadir}/gnome-shell \
+    ${datadir}/help \
+"
+
+RDEPENDS:${PN} += " \
+    ncurses \
+    python3-dbus \
+    python3-pycairo \
+    python3-pygobject \
+"
+
+do_install:append() {
+	install -Dm 0644 ${D}${PYTHON_SITEPACKAGES_DIR}${sysconfdir}/xdg/autostart/onboard-autostart.desktop ${D}${sysconfdir}/xdg/autostart/onboard-autostart.desktop
+
+	install -Dm 0644 ${WORKDIR}/01-gnome-accessibility ${D}${sysconfdir}/dconf/db/local.d/01-gnome-accessibility
+	install -Dm 0644 ${WORKDIR}/onboard-defaults.conf ${D}${sysconfdir}/onboard/onboard-defaults.conf
+
+	install -Dm 0644 ${WORKDIR}/NI.colors ${D}${datadir}/onboard/themes/NI.colors
+	install -Dm 0644 ${WORKDIR}/NI.theme ${D}${datadir}/onboard/themes/NI.theme
+}
+
+pkg_postinst:${PN} () {
+	dconf update
+}
+
+CONFFILES:${PN}:append := " \
+	${sysconfdir}/onboard/onboard-defaults.conf \
+	${sysconfdir}/dconf/db/local.d/01-gnome-accessibility \
+"
+
+RDEPENDS:${PN}:append = " dconf"
+# Onboard uses unicode glyphs in its key_defs.xml file, which means
+# we need a font that has those glyphs present.
+RDEPENDS:${PN}:append = " ttf-dejavu-sans"


### PR DESCRIPTION
### Summary of Changes

The PR adds the virtual keyboard "Onboard" to scarthgap.


### Justification
[#AB2491688](https://dev.azure.com/ni/DevCentral/_workitems/edit/2491688/) requires the keyboard to be present on scarthgap as well.

The virtual keyboard "Onboard" (present on kirkstone) had been removed from scarthgap due to build errors on python 3.12. This PR adds back the same to scarthgap with corrections required for python3.12.

![image](https://github.com/user-attachments/assets/55c51392-8dda-4536-9ad1-2060586077e5)

### Implementation
Changes that differ from kirkstone:
1. The recipe adds CXXLAGS `-Werror=declaration-after-statement` to remove build errors that get generated when the recipe builds the source of Onboard.
2. The recipe (and a couple of patch files) used to be present in the meta-openembedded layer, but has now been moved to the meta-nilrt layer since upstream no longer maintains this recipe. We have also decided not to push it upstream since we might be the only ones still using it.
3. Removed the MD5 sum since it is no longer being used.

The keyboard can now be launched and used just like in kirkstone. It also auto-starts on boot, and launches as soon as a text box comes into focus.

### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)

Tested by installing the built IPK on a VM.
* [x] Keyboard launch
* [x] Type on keyboard by clicking on the keys
* [x] Click on other windows (like the file explorer) to test that the keyboard goes to the background
* [x] Click on any window or textbox where something can be typed to test that the keyboard is back in focus and can type


Signed-off by: Pratheeksha S N <pratheeksha.s.n@ni.com>

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
