### PR TITLE
[next] nilrt-snac: make test output ptest-compliant

### DIFF
--- a/recipes-ni/nilrt-snac/files/run-ptest
+++ b/recipes-ni/nilrt-snac/files/run-ptest
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 
+import os
+
 import pytest
+
+
+# nirtcfg is installed to a non-standard path
+os.environ["PATH"] = "/usr/local/natinst/bin:" + os.environ.get("PATH", "")
 
 pytest.main([
 	"--automake",

--- a/recipes-ni/nilrt-snac/files/run-ptest
+++ b/recipes-ni/nilrt-snac/files/run-ptest
@@ -3,6 +3,6 @@
 import pytest
 
 pytest.main([
-	"-v",
+	"--automake",
 	"/usr/lib/nilrt-snac/tests/integration",
 ])

--- a/recipes-ni/nilrt-snac/files/run-ptest
+++ b/recipes-ni/nilrt-snac/files/run-ptest
@@ -9,6 +9,6 @@ import pytest
 os.environ["PATH"] = "/usr/local/natinst/bin:" + os.environ.get("PATH", "")
 
 pytest.main([
-	"--automake",
-	"/usr/lib/nilrt-snac/tests/integration",
+    "--automake",
+    "/usr/lib/nilrt-snac/tests/integration",
 ])

--- a/recipes-ni/nilrt-snac/nilrt-snac_git.bb
+++ b/recipes-ni/nilrt-snac/nilrt-snac_git.bb
@@ -43,4 +43,5 @@ RDEPENDS:${PN}-ptest += "\
 	bash \
 	python3-core \
 	python3-pytest \
+	python3-unittest-automake-output \
 "


### PR DESCRIPTION
The NI ptest-parser (and ptests in general) use the AutoMake style of test output. The nilrt-snac integration tests uses pytest formatting, which is generally non-compliant and obscures individual testcase output from being parsed by the RTOS ptesting pipeline.

Use the python3-unittest-automake-output plugin for pytest, to output the test results in format ptest can parse.

[AB#2776057](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2776057)

### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] Tested the new package on a real crio-904x series. New test output looks like this:
```
admin@NI-cRIO-9049-01CEEE05:/usr/lib/nilrt-snac/ptest# ptest-runner nilrt-snac
START: ptest-runner
2024-09-20T15:09
BEGIN: /usr/lib/nilrt-snac/ptest
PASS: test_cli.py:test_help
PASS: test_cli.py:test_noargs
PASS: test_cli.py:test_verify
PASS: test_cli.py:test_version
PASS: test_installation.py:test_conflicts_ipk
PASS: test_installation.py:test_iptables
PASS: test_installation.py:test_opkg_binary
PASS: test_installation.py:test_supported_distro
PASS: test_installation.py:test_wireguard_conf
============================================================================
Testsuite summary
# TOTAL: 9
# PASS: 9
# SKIP: 0
# XFAIL: 0
# FAIL: 0
# XPASS: 0
# ERROR: 0
DURATION: 4
END: /usr/lib/nilrt-snac/ptest
2024-09-20T15:09
STOP: ptest-runner
TOTAL: 1 FAIL: 0
```


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
