### PR TITLE
salt: Switch to 24.8 branch for release

### DIFF
--- a/recipes-support/salt/salt_3000.2.bb
+++ b/recipes-support/salt/salt_3000.2.bb
@@ -18,7 +18,7 @@ PACKAGECONFIG[tcp] = ",,python3-pycryptodome"
 PACKAGECONFIG[zeromq] = ",,python3-pycryptodome python3-pyzmq"
 
 SRC_URI = "\
-    git://github.com/ni/salt.git;protocol=https;branch=ni/master/3000.2 \
+    git://github.com/ni/salt.git;protocol=https;branch=ni/skyline-24.8/3000.2 \
     file://minion \
     file://salt-minion \
     file://salt-common.bash_completion \


### PR DESCRIPTION
### Summary of Changes

Switched salt recipe source to use `ni/skyline-24.8/3000.2` branch for 24.8 release.

### Justification

WI: [AB#2755032](https://dev.azure.com/ni/DevCentral/_workitems/edit/2755032)

### Testing

None. Existing and new branch heads point to same commit hash so there should be no code changes.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
