### PR TITLE
opkg-keyrings: change version to distro version

### DIFF
--- a/recipes-devtools/opkg/opkg-keyrings_%.bbappend
+++ b/recipes-devtools/opkg/opkg-keyrings_%.bbappend
@@ -1,5 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
+PV = "${DISTRO_VERSION}"
+
 SRC_URI += " \
 	file://nilrt-feed-2019.gpg \
 	file://nilrt-feed-2023.gpg \


### PR DESCRIPTION
### Summary of Changes

The PR changes the version of the opkg-keyrings IPK so that it is shipped with the distro version.


### Justification

[#AB2346871](https://dev.azure.com/ni/DevCentral/_workitems/edit/2346871)

NILRT deployments which are very old might conceivably outlive the lifetimes of their default opkg signing keys. Eg. a NILRT 20.0 deployment with only the 2019 signing key may be deployed in 2029. NI doesn't provide an appealing user interface to manipulate the opkg keystore. But we should give customers a pathway to upgrade their signing keys which is more easy than hacking newer OE feeds onto their device.

As part of this, the opkg-keyrings IPK will now be versioned with the distro version. This way, the newest release can later be copied into the dist/feed, with which customers can upgrade to the latest signing keys.

### Testing

Tested that the built IPK was versioned with the distro version, i.e., `opkg-keyrings_10.4-r0.0_core2-64.ipk`
![Screenshot from 2024-09-24 18-15-15](https://github.com/user-attachments/assets/4ebc56c3-da68-443f-8238-b320b70aec0e)


* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
