### PR TITLE
packagefeed-ni-extra: enable gnuradio and sqlite3

### DIFF
--- a/recipes-core/packagegroups/packagefeed-ni-extra.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-extra.bb
@@ -14,6 +14,7 @@ RDEPENDS:${PN}:append:x64 = "\
 		geany \
 		gimp \
 		gnuplot \
+		gnuradio \
 		gtk+3 \
 		iceauth \
 		fltk \
@@ -191,6 +192,7 @@ RDEPENDS:${PN} += "\
 	nss-myhostname \
 	pinentry \
 	ptest-runner \
+	sqlite3 \
 "
 
 # openembedded-core/meta/recipes-kernel
@@ -207,7 +209,7 @@ RDEPENDS:${PN} += "\
 	systemtap \
 "
 
-# openembedded-gore/meta/recipes-multimedia
+# openembedded-core/meta/recipes-multimedia
 RDEPENDS:${PN} += "\
 	alsa-tools \
 	alsa-utils \


### PR DESCRIPTION
### Summary of Changes

gnuradio: was able to directly enable and build the recipe.
sqlite3: name of the recipe had to be renamed from sqlite to sqlite3 to make it build.

Other changes:
Fixed a small visible typo for openembedded-core.


### Justification
As a part of this [bug](https://dev.azure.com/ni/DevCentral/_workitems/edit/2703160), we had temporarily disabled some of the recipes from extra's feed to make extra package feed buildable. This PR is to fix and re-enable all such recipes.
[AB#2738353](https://dev.azure.com/ni/DevCentral/_workitems/edit/2738353/)

### Testing
* [X] I have built the extra package feed with this PR in place. (`bitbake packagefeed-ni-extra`)
* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
