### PR TITLE
meta-nilrt: remove quagga entry from files group

### DIFF
--- a/files/group
+++ b/files/group
@@ -19,7 +19,6 @@ ftp:x:393:
 nobody:x:392:
 ntp:x:391:
 shutdown:x:390:
-quagga:x:389:
 pulse:x:388:
 rpcuser:x:387:
 rpc:x:386:

--- a/files/passwd
+++ b/files/passwd
@@ -19,7 +19,6 @@ ppp:x:393::::
 ntp:x:392::::
 pulse:x:391::::
 distcc:x:390::::
-quagga:x:389::::
 rpcuser:x:388::::
 rpc:x:387::::
 builder:x:386::::


### PR DESCRIPTION

### Summary of Changes
remove quagga entry from files group

### Justification

remove quagga entry from files group as the recipe is no longer maintained or available in the upstream. In fact, the recipe is not being used anywhere in meta layers. Hence, removing its residuals would make sense.
[AB#2738353](https://dev.azure.com/ni/DevCentral/_workitems/edit/2738353)


### Testing
N/A

### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
