### PR TITLE
fw_printenv: Don't escape the - character

### DIFF
--- a/recipes-ni/ni-utils/files/x64/fw_printenv
+++ b/recipes-ni/ni-utils/files/x64/fw_printenv
@@ -235,7 +235,7 @@ parse_opt(){
 
 	#check if there are other options passed incorrectly
 	shift $(($OPTIND - 1))
-	if [ "x$(echo $* | grep ' \-')" != "x" ]; then
+	if [ "x$(echo $* | grep ' -')" != "x" ]; then
 		echo "$0:  invalid syntax" >&2
 		echo "Try '$0 --help' for more information"
 		exit 1


### PR DESCRIPTION
### Summary of Changes

Removed the escape character before `-`.


### Justification

 This fixes this grep warning we were seeing on boot: `grep: warning: stray \ before -`. This issue was likely caused by a grep upgrade that made `-` no longer need to be escaped. The related bug is here: https://dev.azure.com/ni/DevCentral/_workitems/edit/2854653


### Testing

I tested this locally on a system by manually editing fw_printenv on a system and confirming that fixed the grep warnings in the boot log. I still need to build the core package feed and possibly the base image for testing but will be out the rest of the week. I'll test this as soon as I'm back.

* [ ] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
