### PR TITLE
packagefeed-ni-extra: remove sqlite3

### DIFF
--- a/recipes-core/packagegroups/packagefeed-ni-extra.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-extra.bb
@@ -192,7 +192,6 @@ RDEPENDS:${PN} += "\
 	nss-myhostname \
 	pinentry \
 	ptest-runner \
-	sqlite3 \
 "
 
 # openembedded-core/meta/recipes-kernel


### PR DESCRIPTION
### Summary of Changes

packagefeed-ni-extra: remove sqlite3


### Justification
sqlite3 is already enabled in the [main feeds](http://nickdanger.amer.corp.natinst.com/feeds/next/2025Q1/x64/main/core2-64/#:~:text=sqlite3%2Ddbg_3.45.1%2Dr0.1_core2%2D64.ipk%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2008%2DOct%2D2024%2006%3A52%20%20%20%20%20%20%20%20%20%20%20%20%202730914%0Asqlite3%2Dlic_3.45.1%2Dr0.1_core2%2D64.ipk%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2008%2DOct%2D2024%2006%3A52%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%201098%0Asqlite3%2Dsrc_3.45.1%2Dr0.1_core2%2D64.ipk%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2008%2DOct%2D2024%2006%3A52%20%20%20%20%20%20%20%20%20%20%20%20%202705362%0Asqlite3_3.45.1%2Dr0.1_core2%2D64.ipk) through packagegroup-sdr-base and it does not make sense enabling it in the extras feed as well.
[AB#2738353](https://dev.azure.com/ni/DevCentral/_workitems/edit/2738353)
### Testing

N/A


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
