### PR TITLE
fw_printenv: Don't escape the - character

### DIFF
--- a/recipes-ni/fw-printenv/files/fw_printenv
+++ b/recipes-ni/fw-printenv/files/fw_printenv
@@ -211,7 +211,7 @@ parse_opt(){
 
 	#check if there are other options passed incorrectly
 	shift $(($OPTIND - 1))
-	if [ "x$(echo $* | grep ' \-')" != "x" ]; then
+	if [ "x$(echo $* | grep ' -')" != "x" ]; then
 		echo "$0:  invalid syntax" >&2
 		echo "Try '$0 --help' for more information"
 		exit 1


### PR DESCRIPTION
### Summary of Changes

Removed the escape character before `-`.


### Justification

 This fixes this grep warning we were seeing on boot: `grep: warning: stray \ before -`. This issue was likely caused by a grep upgrade that made `-` no longer need to be escaped. The related bug is here: https://dev.azure.com/ni/DevCentral/_workitems/edit/2854653


### Testing

I built the core package feed and base image, formatted a machine with the built image, and confirmed that there were no grep warnings in the boot log.

I also tested the grep command on a NILRT 11.0 system to make sure the `-` character really doesn't need to be escaped to still function correctly. The result was that the output of the grep command was the same regardless of the escape character but threw a warning when it was present.
![grep test](https://github.com/user-attachments/assets/b159c274-d931-4eb5-b038-f3b5d138e8c6)


* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
