### PR TITLE
linux-nilrt: Set CVE_VERSION to correct value

### DIFF
--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -45,6 +45,7 @@ SRC_URI = "\
 # specified by a recipe.
 SRCREV ?= "${AUTOREV}"
 PV = "${LINUX_VERSION}+git${SRCPV}"
+CVE_VERSION = "${KERNEL_VERSION}+git${SRCPV}"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 LIC_FILES_CHKSUM:xilinx-zynq = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"


### PR DESCRIPTION
### Summary of Changes

When CVE_VERSION is not explicitly set, it [defaults to PV](https://github.com/ni/openembedded-core/blob/nilrt/master/kirkstone/meta/classes/cve-check.bbclass#L26) which does not contain minor version number. This results in incorrect CVE status determination.

So set CVE_VERSION to full version.

CVE_VERSION was previously like "6.1+gitAUTOINC+8030b315ef"`.
Now it is "6.1.111-rt42+gitAUTOINC+8030b315ef".

### Justification

WI: [AB#2848014](https://dev.azure.com/ni/DevCentral/_workitems/edit/2848014)

### Testing

- [x] With `INHERIT += "cve-check"` set in `conf/local.conf`, `bitbake linux-nilrt` succeeds.
- [x] Lot of CVEs that were previous misclassified as "Unpatched" are now classified as "Patched". e.g., CVE-2023-38426.

### Procedure

- [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).

### Note
- Requires cherry-pick to `nilrt/master/next`.