### PR TITLE
nilrt.inc: Change PACKAGE_FEED_* to default assignment

### DIFF
--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -138,9 +138,9 @@ NILRT_MAIN_FEED_VERSION            ?= "${NILRT_FEED_NAME}"
 NILRT_MACHINE_FEED_URI_nimain      ?= "${NILRT_FEEDS_URI}/${NILRT_MAIN_FEED_VERSION}/ni-main"
 
 # OE Packages with TUNEARCHes
-PACKAGE_FEED_URIS       = "${NILRT_MACHINE_FEED_URI}"
-PACKAGE_FEED_BASE_PATHS = "extra main"
-PACKAGE_FEED_ARCHS      = "all ${MACHINE} ${TUNE_PKGARCH}"
+PACKAGE_FEED_URIS       ?= "${NILRT_MACHINE_FEED_URI}"
+PACKAGE_FEED_BASE_PATHS ?= "extra main"
+PACKAGE_FEED_ARCHS      ?= "all ${MACHINE} ${TUNE_PKGARCH}"
 
 # NI Packages, which are flat feeds
 # Add additional (non-constructed) opkg sources with the pattern:


### PR DESCRIPTION
Locally-hosted package repositories are a longstanding NI Linux RT development pattern. While these can be trivially configured in /etc/opkg/ after installation, being able to customize the feed URLs in the base system image itself unlocks some unique automation possibilities.

While nilrt/scripts/tests/test_nilrt-ptest.py presently implements a feed server (and rewriting the post-install opkg configuration accordingly), its implementation is tightly coupled to the needs of ptest execution. Instead, the nominal way to accomplish this should be in site.conf: set PACKAGE_FEED_URIS to point at the local server, and clear out PACKAGE_FEED_BASE_PATHS, because the "extra/" and "main/" subdirectory distinction does not exist at the level of developer bitbake runs, nor arguably should it.

That's not presently possible because PACAKGE_FEED_URIS and PACKAGE_FEED_BASE_PATHS are assigned in the usual way (`=`) in nilrt.inc, overriding anything set in nilrt.inc. If we change nilrt.inc to only set default values, i.e. `?=`, then customizing them in site.conf works. Note that almost all other variables in nilrt.inc are already default-assigned.

PACKAGE_FEED_ARCHS does not need to be customizing for this use case, but is also changed to default assignment for reasons of consistency.

### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
