### PR TITLE
issue*: delete NIAuth references

### DIFF
--- a/recipes-core/base-files/base-files/issue
+++ b/recipes-core/base-files/base-files/issue
@@ -7,5 +7,3 @@
 
 NI Linux Real-Time (safe mode on \n)
 
-Log in with your NI-Auth credentials.
-

--- a/recipes-core/base-files/base-files/issue.net
+++ b/recipes-core/base-files/base-files/issue.net
@@ -1,4 +1,2 @@
 NI Linux Real-Time (safe mode)
 
-Log in with your NI-Auth credentials.
-


### PR DESCRIPTION
Telling users to "Log in with your NI-Auth credentials" doesn't really mean anything to them. NIAuth is only barely documented to begin with (which says a lot about how user-visible it was mean to be in the first place). Even if/when niauth is disabled and passwd takes over, there's no real value to be gained by disclosing this. Delete.

### Testing

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)

### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
