### PR TITLE
niacctbase: remove unused sudo access for lvuser

### DIFF
--- a/recipes-ni/niacctbase/niacctbase/sudoers
+++ b/recipes-ni/niacctbase/niacctbase/sudoers
@@ -1,6 +1,3 @@
 
 # Allow the admin user (UID 0) to invoke sudo without a password
 admin ALL=(ALL) NOPASSWD: ALL
-
-# Allow lvuser to modify the opkg state without a password
-lvuser ALL=(#0:#0) NOPASSWD: /usr/bin/opkg info *


### PR DESCRIPTION
### Summary of Changes

remove sudo access for lvuser


### Justification

lvuser no longer requires sudo access, [AB#2861805](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2861805).


### Testing

I ran nisyscfg's `Get Installed Components.vi` on a LabVIEW RT target.

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).

@ni/rtos @amstewart