### PR TITLE
packagegroup-ni-ptest-smoke: Removing ptests from packagegroup

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-ptest-smoke.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-ptest-smoke.bb
@@ -27,7 +27,6 @@ RDEPENDS:${PN}:append = "\
 	kernel-tests-ptest \
 	liberror-perl-ptest \
 	libxml2-ptest \
-	mdadm-ptest \
 	nettle-ptest \
 	ni-hw-scripts-ptest \
 	ni-test-boot-time-ptest \
@@ -36,15 +35,10 @@ RDEPENDS:${PN}:append = "\
 	pango-ptest \
 	parted-ptest \
 	perl-ptest \
-	pstore-save-ptest \
 	python3-appdirs-ptest \
 	python3-atomicwrites-ptest \
 	python3-bcrypt-ptest \
-	python3-cryptography-ptest \
-	python3-markupsafe-ptest \
 	python3-more-itertools-ptest \
-	python3-msgpack-ptest \
-	python3-multidict-ptest \
 	python3-pluggy-ptest \
 	python3-pyasn1-ptest \
 	python3-pyroute2-ptest \


### PR DESCRIPTION
### Summary of Changes

Removed ptests that were found to be unused - ptests that were executed, but did not run any tests


### Justification

[AB#2755352](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2755352)
The testptest.py will be updated to assert if a ptest does not return any test results


### Testing
* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have built the core package feed with this PR in place. (`bitbake packagegroup-ni-ptest-smoke`)
* [x] Executed ptests via debug run - all tests succeeded

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
