### PR TITLE
ni-firewalld-servicedefs: add

### DIFF
--- a/recipes-ni/ni-firewalld-servicedefs/files/services/dnp3.xml
+++ b/recipes-ni/ni-firewalld-servicedefs/files/services/dnp3.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>DNP3</short>
+  <description>DNP3 is an older smart grid protocol.</description>
+  <port protocol="tcp" port="20000"/>
+  <port protocol="udp" port="20000"/>
+</service>

--- a/recipes-ni/ni-firewalld-servicedefs/files/services/dstp.xml
+++ b/recipes-ni/ni-firewalld-servicedefs/files/services/dstp.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>DSTP</short>
+  <description>The DataSocket Transport Protocol (DSTP) is a legacy protocol for transferring measurement data to/from DataSocket Servers.</description>
+  <port protocol="tcp" port="3015"/>
+</service>

--- a/recipes-ni/ni-firewalld-servicedefs/files/services/ethernet-ip-explicit.xml
+++ b/recipes-ni/ni-firewalld-servicedefs/files/services/ethernet-ip-explicit.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Ethernet/IP Explicit Messaging</short>
+  <description>Ethernet/IP is an industrial communications protocol which adapts the object-oriented Control and Information Protocol (CIP) to TCP/UDP.</description>
+  <port protocol="udp" port="2222"/>
+  <port protocol="tcp" port="44818"/>
+</service>

--- a/recipes-ni/ni-firewalld-servicedefs/files/services/ethernet-ip-implicit.xml
+++ b/recipes-ni/ni-firewalld-servicedefs/files/services/ethernet-ip-implicit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Ethernet/IP Implicit Messaging</short>
+  <description>Ethernet/IP is an industrial communications protocol which adapts the object-oriented Control and Information Protocol (CIP) to TCP/UDP.</description>
+  <port protocol="udp" port="2222"/>
+</service>

--- a/recipes-ni/ni-firewalld-servicedefs/files/services/ethernet-ip.xml
+++ b/recipes-ni/ni-firewalld-servicedefs/files/services/ethernet-ip.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Ethernet/IP</short>
+  <description>Ethernet/IP is an industrial communications protocol which adapts the object-oriented Control and Information Protocol (CIP) to TCP/UDP.</description>
+  <include service="ethernet-ip-implicit"/>
+  <include service="ethernet-ip-explicit"/>
+</service>

--- a/recipes-ni/ni-firewalld-servicedefs/files/services/iec-60870-5-104.xml
+++ b/recipes-ni/ni-firewalld-servicedefs/files/services/iec-60870-5-104.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>IEC 60870-5-104</short>
+  <description></description>
+  <port protocol="tcp" port="2404"/>
+</service>

--- a/recipes-ni/ni-firewalld-servicedefs/files/services/iec-61850.xml
+++ b/recipes-ni/ni-firewalld-servicedefs/files/services/iec-61850.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>IEC 61850</short>
+  <description></description>
+  <port protocol="tcp" port="102"/>
+</service>

--- a/recipes-ni/ni-firewalld-servicedefs/files/services/modbus.xml
+++ b/recipes-ni/ni-firewalld-servicedefs/files/services/modbus.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Modbus protocol</short>
+  <description></description>
+  <port protocol="tcp" port="502"/>
+</service>

--- a/recipes-ni/ni-firewalld-servicedefs/files/services/ni-dnet.xml
+++ b/recipes-ni/ni-firewalld-servicedefs/files/services/ni-dnet.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>NI-DNET</short>
+  <description></description>
+  <port protocol="tcp" port="1492"/>
+</service>

--- a/recipes-ni/ni-firewalld-servicedefs/files/services/ni-imaq.xml
+++ b/recipes-ni/ni-firewalld-servicedefs/files/services/ni-imaq.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>NI IMAQ</short>
+  <description></description>
+  <port protocol="tcp" port="7750"/>
+</service>

--- a/recipes-ni/ni-firewalld-servicedefs/files/services/ni-labview-realtime.xml
+++ b/recipes-ni/ni-firewalld-servicedefs/files/services/ni-labview-realtime.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>LabVIEW Real-Time</short>
+  <description>LabVIEW Real-Time permits interactive deployment, execution, and debugging of LabVIEW VIs on remote machines running real-time operating systems.</description>
+  <port protocol="tcp" port="3079"/>
+</service>

--- a/recipes-ni/ni-firewalld-servicedefs/files/services/ni-labview-viserver.xml
+++ b/recipes-ni/ni-firewalld-servicedefs/files/services/ni-labview-viserver.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>LabVIEW VI Server</short>
+  <description>The LabVIEW VI Server protocol permits deployment and manipulation of LabVIEW VIs and other resources on a remote LabVIEW application instance.</description>
+  <port protocol="tcp" port="3363"/>
+</service>

--- a/recipes-ni/ni-firewalld-servicedefs/files/services/ni-logos-xt.xml
+++ b/recipes-ni/ni-firewalld-servicedefs/files/services/ni-logos-xt.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>NI Logos XT</short>
+  <description>NI Logos XT is a publish-subscribe protocol used for data transfer between applications written in LabVIEW, CVI, and other elements of the NI software platform.</description>
+  <port protocol="tcp" port="2343"/>
+  <port protocol="tcp" port="59110-59209"/>
+  <port protocol="udp" port="6000-6010"/>
+</service>

--- a/recipes-ni/ni-firewalld-servicedefs/files/services/ni-mxs.xml
+++ b/recipes-ni/ni-firewalld-servicedefs/files/services/ni-mxs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>NI MXS</short>
+  <description>The NI Configuration Manager ("MXS") stores configuration information on behalf of components of the NI software platform.</description>
+  <port protocol="tcp" port="51700"/>
+</service>

--- a/recipes-ni/ni-firewalld-servicedefs/files/services/ni-rfsa-classic-sfp.xml
+++ b/recipes-ni/ni-firewalld-servicedefs/files/services/ni-rfsa-classic-sfp.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>NI-RFSA Classic Soft Front Panel</short>
+  <description></description>
+  <port protocol="tcp" port="3303"/>
+</service>

--- a/recipes-ni/ni-firewalld-servicedefs/files/services/ni-rfsa-sfp.xml
+++ b/recipes-ni/ni-firewalld-servicedefs/files/services/ni-rfsa-sfp.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>NI-RFSA Soft Front Panel</short>
+  <description></description>
+  <port protocol="tcp" port="3304"/>
+</service>

--- a/recipes-ni/ni-firewalld-servicedefs/files/services/ni-rfsg-sfp.xml
+++ b/recipes-ni/ni-firewalld-servicedefs/files/services/ni-rfsg-sfp.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>NI-RFSG Soft Front Panel</short>
+  <description></description>
+  <port protocol="tcp" port="3305"/>
+</service>

--- a/recipes-ni/ni-firewalld-servicedefs/files/services/ni-scope-sfp.xml
+++ b/recipes-ni/ni-firewalld-servicedefs/files/services/ni-scope-sfp.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>NI-SCOPE Soft Front Panel</short>
+  <description></description>
+  <port protocol="tcp" port="3300-3301"/>
+</service>

--- a/recipes-ni/ni-firewalld-servicedefs/files/services/ni-service-locator.xml
+++ b/recipes-ni/ni-firewalld-servicedefs/files/services/ni-service-locator.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>NI Service Locator</short>
+  <description>The NI Service Locator is a legacy port mapping facility for NI software.</description>
+  <port protocol="tcp" port="3580"/>
+</service>

--- a/recipes-ni/ni-firewalld-servicedefs/files/services/ni-sync-remote.xml
+++ b/recipes-ni/ni-firewalld-servicedefs/files/services/ni-sync-remote.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>NI-Sync Remote</short>
+  <description></description>
+  <port protocol="tcp" port="31762"/>
+</service>

--- a/recipes-ni/ni-firewalld-servicedefs/files/services/ni-visa-server.xml
+++ b/recipes-ni/ni-firewalld-servicedefs/files/services/ni-visa-server.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>NI-VISA Server</short>
+  <description></description>
+  <port protocol="tcp" port="3537"/>
+</service>

--- a/recipes-ni/ni-firewalld-servicedefs/files/services/ni-xnet-bus-monitor.xml
+++ b/recipes-ni/ni-firewalld-servicedefs/files/services/ni-xnet-bus-monitor.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>NI XNET Bus Monitor</short>
+  <description></description>
+  <port protocol="tcp" port="13456"/>
+</service>

--- a/recipes-ni/ni-firewalld-servicedefs/files/services/opcua.xml
+++ b/recipes-ni/ni-firewalld-servicedefs/files/services/opcua.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>OPC UA</short>
+  <description></description>
+  <port protocol="tcp" port="49580"/>
+</service>

--- a/recipes-ni/ni-firewalld-servicedefs/ni-firewalld-servicedefs.bb
+++ b/recipes-ni/ni-firewalld-servicedefs/ni-firewalld-servicedefs.bb
@@ -1,0 +1,44 @@
+SUMMARY = "Firewalld XML service definitions for NI software"
+DESCRIPTION = "Installs firewalld service definitions for protocols implemented by NI software."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+PV = "1.0"
+
+SRC_URI = "\
+	file://services/dnp3.xml \
+	file://services/dstp.xml \
+	file://services/ethernet-ip-explicit.xml \
+	file://services/ethernet-ip-implicit.xml \
+	file://services/ethernet-ip.xml \
+	file://services/iec-60870-5-104.xml \
+	file://services/iec-61850.xml \
+	file://services/modbus.xml \
+	file://services/ni-dnet.xml \
+	file://services/ni-imaq.xml \
+	file://services/ni-labview-realtime.xml \
+	file://services/ni-labview-viserver.xml \
+	file://services/ni-logos-xt.xml \
+	file://services/ni-rfsa-classic-sfp.xml \
+	file://services/ni-rfsa-sfp.xml \
+	file://services/ni-rfsg-sfp.xml \
+	file://services/ni-scope-sfp.xml \
+	file://services/ni-service-locator.xml \
+	file://services/ni-sync-remote.xml \
+	file://services/ni-visa-server.xml \
+	file://services/ni-xnet-bus-monitor.xml \
+	file://services/opcua.xml \
+"
+
+FILES:${PN} += "/"
+
+do_install () {
+	for f in ${SRC_URI}; do
+		case $f in
+		"file://services/"*) echo "$f"; install -D -t ${D}${libdir}/firewalld/services/ \
+			-m 0644 "${WORKDIR}/${f##file://}" ;;
+		esac
+	done
+}
+
+RDEPENDS:${PN} += "firewalld"


### PR DESCRIPTION
This package contains firewalld service definitions for NI software and the protocols NI software interacts with. Presently this package only contains service definitions, although other firewalld entities (helpers, policies, zones, etc.) might exist in the future. These service definitions are quite provisional at the moment and are subject to change.

NI has not yet decided on where these service definitions should exist long-term. While firewalld appears to have decided to include many third-party service definitions in firewalld itself, we presently reserve the right to refactor these definitions, e.g. into their associated application IPKs. The ni-firewalld-config package should be treated as essentially transient until further notice.

Fixes [AB#2902893](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2902893).


### Testing

Package install works. `firewall-cmd --zone=public --add-service=ni-labview-realtime` works.

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)

### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).

---
**asewart: This needs a cherry-pick into `nilrt/master/next` on merge.**