### PR TITLE
[kirkstone] pkggrp-ni-snac: add wireguard-tools

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-snac.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-snac.bb
@@ -12,4 +12,5 @@ RDEPENDS:${PN} = "\
 	nilrt-snac \
 	ntp \
 	tmux \
+	wireguard-tools \
 "


### PR DESCRIPTION
SNAC configuration requires wireguard-tools to configure the labview wireguard interface and to allow users to configure their own.

Add wireguard-tools to the core IPK feeds.

[AB#2769306](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2769306)


### Testing

* [x] Built `packagegroup-ni-snac` with this patchset and confirmed that the wireguard-tools IPKs are generated.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).

* Should be cherry-picked to `nilrt/master/next`.
