### PR TITLE
pkggrp-ni-base: remove opkg-keyrings

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -83,7 +83,6 @@ RDEPENDS:${PN} += "\
 	openssh-sshd \
 	openvpn \
 	opkg \
-	opkg-keyrings \
 	os-release \
 	pigz \
 	pstore-save \


### PR DESCRIPTION
### Summary of Changes

Removed opkg-keyrings from packagegroup-ni-base.


### Justification

opkg-keyrings recipe would be building separately as a new subcomponent in the ni-central build and would get published into dist feeds instead of oe-core feeds. This is needed so that the NILRT users can upgrade their keystore and need not depend on the default version deployed with the BSI.
[AB#2346871](https://dev.azure.com/ni/DevCentral/_workitems/edit/2346871/)


### Testing
None

### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
