### PR TITLE
Fix pstore-save-ptest and readd to smoke tests

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-ptest-smoke.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-ptest-smoke.bb
@@ -35,6 +35,7 @@ RDEPENDS:${PN}:append = "\
 	pango-ptest \
 	parted-ptest \
 	perl-ptest \
+	pstore-save-ptest \
 	python3-appdirs-ptest \
 	python3-atomicwrites-ptest \
 	python3-bcrypt-ptest \

--- a/recipes-ni/ni-grpc-device/files/ptest/run-ptest
+++ b/recipes-ni/ni-grpc-device/files/ptest/run-ptest
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-# close stdin
-exec 0<&-
-
 # redirect stderr to stdout
 exec 2>&1
 

--- a/recipes-ni/pstore-save/files/run-ptest
+++ b/recipes-ni/pstore-save/files/run-ptest
@@ -2,9 +2,6 @@
 
 set -euo pipefail
 
-# close stdin
-exec 0<&-
-
 # redirect stderr to stdout
 exec 2>&1
 


### PR DESCRIPTION
### Summary of Changes

- Fixed ptests (pstore-save-ptest, ni-grpc-device-ptest) that close stdin as they crash with older version of ptest-runner.
- Added back pstore-save-ptest to smoke tests.

### Justification

WI: [AB#2908690](https://dev.azure.com/ni/DevCentral/_workitems/edit/2908690)

### Testing

- [x] `bitbake packagegroup-ni-ptest-smoke` and `bitbake ni-grpc-device`
- [x] Verified `pstore-save` and `ni-grpc-device ptests` pass with these changes


### Procedure

- [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).

### Note
The two "Don't close stdin" commits don't really need to be cherry-picked in `nilrt/master/next`, only packagegroup-ni-ptest-smoke commit needs to be cherry picked. But better to cherry-pick everything to keep both branches consistent.