### PR TITLE
[next] Make the embedded UI toggle removable.

### DIFF
--- a/recipes-core/images/includes/nilrt-xfce.inc
+++ b/recipes-core/images/includes/nilrt-xfce.inc
@@ -1,7 +1,7 @@
 # Mix-in of common deps to include XFCE in CG
 
 IMAGE_INSTALL += "\
-	packagegroup-ni-xfce \
+	packagegroup-ni-graphical \
 	"
 
 IMAGE_FEATURES += "x11"

--- a/recipes-core/packagegroups/packagefeed-ni-extra.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-extra.bb
@@ -3,47 +3,43 @@ LICENSE = "MIT"
 
 inherit packagegroup
 
-# These packages are only built for the nilrt-xfce fork of the older NILRT distro
-# as opposed to nilrt-nxg which always enables x11 support. Also only for x64
-# because NILRT ARM does not have a GUI.
-RDEPENDS:${PN}:append:x64 = "\
-	${@bb.utils.contains('DISTRO_FEATURES', 'x11', '\
-		packagegroup-self-hosted \
-		packagegroup-xfce-extended \
-		consolekit \
-		geany \
-		gimp \
-		gnuplot \
-		gnuradio \
-		gtk+3 \
-		iceauth \
-		fltk \
-		libvncserver \
-		libwmf \
-		lxdm \
-		mesa-demos \
-		modemmanager \
-		networkmanager \
-		numlockx \
-		openbox \
-		sessreg \
-		setxkbmap \
-		tk \
-		twm \
-		upower \
-		vte \
-		x11vnc \
-		xbitmaps \
-		xclock \
-		xcursorgen \
-		xdotool \
-		xfontsel \
-		xlsfonts \
-		xmag \
-		xrdb \
-		xterm \
-		xwd \
-	', '', d)} \
+# Graphical extra packages
+RDEPENDS:${PN}:append = "\
+	packagegroup-self-hosted \
+	packagegroup-xfce-extended \
+	consolekit \
+	fltk \
+	geany \
+	gimp \
+	gnuplot \
+	gnuradio \
+	gtk+3 \
+	iceauth \
+	libvncserver \
+	libwmf \
+	lxdm \
+	mesa-demos \
+	modemmanager \
+	networkmanager \
+	numlockx \
+	openbox \
+	sessreg \
+	setxkbmap \
+	tk \
+	twm \
+	upower \
+	vte \
+	x11vnc \
+	xbitmaps \
+	xclock \
+	xcursorgen \
+	xdotool \
+	xfontsel \
+	xlsfonts \
+	xmag \
+	xrdb \
+	xterm \
+	xwd \
 "
 
 RDEPENDS:${PN} = "\

--- a/recipes-core/packagegroups/packagefeed-ni-extra.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-extra.bb
@@ -28,7 +28,6 @@ RDEPENDS:${PN}:append:x64 = "\
 		openbox \
 		sessreg \
 		setxkbmap \
-		sysconfig-settings-ui \
 		tk \
 		twm \
 		upower \

--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -90,7 +90,6 @@ RDEPENDS:${PN} += "\
 	run-postinsts \
 	sudo \
 	sysconfig-settings \
-	sysconfig-settings-ui \
 	syslog-ng \
 	sysvinit \
 	tar \

--- a/recipes-core/packagegroups/packagegroup-ni-graphical.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-graphical.bb
@@ -6,5 +6,6 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 inherit packagegroup
 
 RDEPENDS:${PN} = "\
-    packagegroup-ni-xfce \
+	packagegroup-ni-xfce \
+	sysconfig-settings-ui \
 "

--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -1,7 +1,3 @@
-# (C) Copyright 2013,
-#  National Instruments Corporation.
-#  All rights reserved.
-
 SUMMARY = "Runmode specific packages for NI Linux Realtime distribution"
 LICENSE = "MIT"
 

--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -10,6 +10,8 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 inherit packagegroup
 
 RDEPENDS:${PN} = "\
+	cpp \
+	cpp-symlinks \
 	dosfstools \
 	e2fsprogs \
 	e2fsprogs-e2fsck \
@@ -20,9 +22,13 @@ RDEPENDS:${PN} = "\
 	glibc-gconv-cp936 \
 	glibc-gconv-iso8859-1 \
 	iproute2-tc \
+	libmpc \
+	libpython3 \
 	librtpi \
+	libyaml \
 	linux-firmware-radeon \
 	lldpd \
+	mpfr \
 	nftables \
 	ni-configpersistentlogs \
 	ni-locale-alias \
@@ -30,22 +36,6 @@ RDEPENDS:${PN} = "\
 	niwatchdogpet \
 	opkg-utils-shell-tools \
 	parted \
-	rtctl \
-	systemimageupdateinfo \
-	util-linux-sfdisk \
-	vlan \
-	zip \
-"
-
-# Packages required by SystemLink
-RDEPENDS:${PN} += "\
-	cpp \
-	cpp-symlinks \
-	libmpc \
-	libpython3 \
-	libyaml \
-	mpfr \
-	python3-modules \
 	python3-aiodns \
 	python3-aiohttp \
 	python3-asn1crypto \
@@ -82,6 +72,7 @@ RDEPENDS:${PN} += "\
 	python3-mime \
 	python3-misc \
 	python3-mmap \
+	python3-modules \
 	python3-msgpack \
 	python3-multidict \
 	python3-multiprocessing \
@@ -123,9 +114,14 @@ RDEPENDS:${PN} += "\
 	python3-xml \
 	python3-xmlrpc \
 	python3-yarl \
+	rtctl \
 	salt-common \
 	salt-minion \
 	sysconfig-settings \
+	systemimageupdateinfo \
+	util-linux-sfdisk \
+	vlan \
+	zip \
 "
 
 # Required components for Veristand.

--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -126,7 +126,6 @@ RDEPENDS:${PN} += "\
 	salt-common \
 	salt-minion \
 	sysconfig-settings \
-	sysconfig-settings-ui \
 "
 
 # Required components for Veristand.

--- a/recipes-ni/sysconfig-settings/sysconfig-settings.bb
+++ b/recipes-ni/sysconfig-settings/sysconfig-settings.bb
@@ -4,119 +4,56 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 SECTION = "base"
 
+
+# RECIPE VARIABLES #
+DEPENDS += "shadow-native pseudo-native niacctbase base-files-nilrt"
+
+
+# SOURCE VARIABLES #
+SRC_URI = "\
+	file://systemsettings/consoleout.ini \
+	file://systemsettings/fpga_target.ini \
+	file://systemsettings/rt_target.ini \
+	file://systemsettings/target_common.ini \
+	file://uixml/nilinuxrt.fpga_disable.binding.xml \
+	file://uixml/nilinuxrt.fpga_disable.const.de.xml \
+	file://uixml/nilinuxrt.fpga_disable.const.fr.xml \
+	file://uixml/nilinuxrt.fpga_disable.const.ja.xml \
+	file://uixml/nilinuxrt.fpga_disable.const.ko.xml \
+	file://uixml/nilinuxrt.fpga_disable.const.xml \
+	file://uixml/nilinuxrt.fpga_disable.const.zh-CN.xml \
+	file://uixml/nilinuxrt.fpga_disable.def.xml \
+	file://uixml/nilinuxrt.rtapp_disable.binding.xml \
+	file://uixml/nilinuxrt.rtapp_disable.const.de.xml \
+	file://uixml/nilinuxrt.rtapp_disable.const.fr.xml \
+	file://uixml/nilinuxrt.rtapp_disable.const.ja.xml \
+	file://uixml/nilinuxrt.rtapp_disable.const.ko.xml \
+	file://uixml/nilinuxrt.rtapp_disable.const.xml \
+	file://uixml/nilinuxrt.rtapp_disable.const.zh-CN.xml \
+	file://uixml/nilinuxrt.rtapp_disable.def.xml \
+	file://uixml/nilinuxrt.rtprotocol_enable.binding.xml \
+	file://uixml/nilinuxrt.rtprotocol_enable.const.de.xml \
+	file://uixml/nilinuxrt.rtprotocol_enable.const.fr.xml \
+	file://uixml/nilinuxrt.rtprotocol_enable.const.ja.xml \
+	file://uixml/nilinuxrt.rtprotocol_enable.const.ko.xml \
+	file://uixml/nilinuxrt.rtprotocol_enable.const.xml \
+	file://uixml/nilinuxrt.rtprotocol_enable.const.zh-CN.xml \
+	file://uixml/nilinuxrt.rtprotocol_enable.def.xml \
+"
+
+S = "${WORKDIR}"
+
 uixmldir = "${datadir}/nisysapi/uixml"
 settingsdatadir = "${datadir}/${BPN}/systemsettings"
 systemsettingsdir = "${localstatedir}/local/natinst/systemsettings"
 
+
+# CLASS VARIABLES #
 inherit update-rc.d
 
-# sysconfig-settings package
-SRC_URI = "file://systemsettings/consoleout.ini \
-           file://systemsettings/fpga_target.ini \
-           file://systemsettings/rt_target.ini \
-           file://systemsettings/target_common.ini \
-           file://uixml/nilinuxrt.rtprotocol_enable.binding.xml \
-           file://uixml/nilinuxrt.rtprotocol_enable.const.xml \
-           file://uixml/nilinuxrt.rtprotocol_enable.const.de.xml \
-           file://uixml/nilinuxrt.rtprotocol_enable.const.fr.xml \
-           file://uixml/nilinuxrt.rtprotocol_enable.const.ja.xml \
-           file://uixml/nilinuxrt.rtprotocol_enable.const.ko.xml \
-           file://uixml/nilinuxrt.rtprotocol_enable.const.zh-CN.xml \
-           file://uixml/nilinuxrt.rtprotocol_enable.def.xml \
-           file://uixml/nilinuxrt.rtapp_disable.binding.xml \
-           file://uixml/nilinuxrt.rtapp_disable.const.xml \
-           file://uixml/nilinuxrt.rtapp_disable.const.de.xml \
-           file://uixml/nilinuxrt.rtapp_disable.const.fr.xml \
-           file://uixml/nilinuxrt.rtapp_disable.const.ja.xml \
-           file://uixml/nilinuxrt.rtapp_disable.const.ko.xml \
-           file://uixml/nilinuxrt.rtapp_disable.const.zh-CN.xml \
-           file://uixml/nilinuxrt.rtapp_disable.def.xml \
-           file://uixml/nilinuxrt.fpga_disable.binding.xml \
-           file://uixml/nilinuxrt.fpga_disable.const.xml \
-           file://uixml/nilinuxrt.fpga_disable.const.de.xml \
-           file://uixml/nilinuxrt.fpga_disable.const.fr.xml \
-           file://uixml/nilinuxrt.fpga_disable.const.ja.xml \
-           file://uixml/nilinuxrt.fpga_disable.const.ko.xml \
-           file://uixml/nilinuxrt.fpga_disable.const.zh-CN.xml \
-           file://uixml/nilinuxrt.fpga_disable.def.xml \
-"
 
-FILES:${PN} = "${settingsdatadir}/consoleout.ini \
-               ${settingsdatadir}/fpga_target.ini \
-               ${settingsdatadir}/rt_target.ini \
-               ${settingsdatadir}/target_common.ini \
-               ${uixmldir}/nilinuxrt.rtprotocol_enable.* \
-               ${uixmldir}/nilinuxrt.rtapp_disable.* \
-               ${uixmldir}/nilinuxrt.fpga_disable.* \
-               ${systemsettingsdir} \
-"
-
-DEPENDS += "shadow-native pseudo-native niacctbase base-files-nilrt"
-RDEPENDS:${PN} += "niacctbase bash fw-printenv"
-
-# sysconfig-settings-ssh package
-PACKAGES += "${PN}-ssh"
-
-SUMMARY:${PN}-ssh = "System configuration files for ssh"
-DESCRIPTION:${PN}-ssh = "SSH configuration files for the National Instruments System Configuration subsystem."
-
-SRC_URI:append = "file://uixml/nilinuxrt.sshd_enable.binding.xml \
-                  file://uixml/nilinuxrt.sshd_enable.const.de.xml \
-                  file://uixml/nilinuxrt.sshd_enable.const.fr.xml \
-                  file://uixml/nilinuxrt.sshd_enable.const.ja.xml \
-                  file://uixml/nilinuxrt.sshd_enable.const.ko.xml \
-                  file://uixml/nilinuxrt.sshd_enable.const.xml \
-                  file://uixml/nilinuxrt.sshd_enable.const.zh-CN.xml \
-                  file://uixml/nilinuxrt.sshd_enable.def.xml \
-"
-
-FILES:${PN}-ssh = "${uixmldir}/nilinuxrt.sshd_enable.*"
-
-# sysconfig-settings-ui package
-PACKAGES += "${PN}-ui"
-
-SUMMARY:${PN}-ui = "System configuration files to enable UI"
-DESCRIPTION:${PN}-ui = "Configuration files to enable UI for the National Instruments System Configuration subsystem."
-
-SRC_URI:append = "file://nisetembeddeduixml \
-                  file://systemsettings/ui_enable.ini \
-                  file://uixml/nilinuxrt.System.binding.xml \
-                  file://uixml/nilinuxrt.System.const.xml \
-                  file://uixml/nilinuxrt.System.const.de.xml \
-                  file://uixml/nilinuxrt.System.const.fr.xml \
-                  file://uixml/nilinuxrt.System.const.ja.xml \
-                  file://uixml/nilinuxrt.System.const.ko.xml \
-                  file://uixml/nilinuxrt.System.const.zh-CN.xml \
-                  file://uixml/nilinuxrt.System.def.xml \
-                  file://uixml/nilinuxrt.ui_enable.binding.xml \
-                  file://uixml/nilinuxrt.ui_enable.const.xml \
-                  file://uixml/nilinuxrt.ui_enable.const.de.xml \
-                  file://uixml/nilinuxrt.ui_enable.const.fr.xml \
-                  file://uixml/nilinuxrt.ui_enable.const.ja.xml \
-                  file://uixml/nilinuxrt.ui_enable.const.ko.xml \
-                  file://uixml/nilinuxrt.ui_enable.const.zh-CN.xml \
-                  file://uixml/nilinuxrt.ui_enable.def.xml \
-"
-
-FILES:${PN}-ui = "${sysconfdir}/init.d/nisetembeddeduixml \
-                  ${settingsdatadir}/ui_enable.ini \
-                  ${uixmldir}/nilinuxrt.System.* \
-                  ${uixmldir}/nilinuxrt.ui_enable.* \
-"
-
-RDEPENDS:${PN}-ui += "sysconfig-settings niacctbase"
-
-INITSCRIPT_PACKAGES += "${PN}-ui"
-INITSCRIPT_NAME:${PN}-ui = "nisetembeddeduixml"
-INITSCRIPT_PARAMS:${PN}-ui = "start 20 5 ."
-
-pkg_prerm_ontarget:${PN}-ui () {
-	rm -f ${systemsettingsdir}/ui_enable.ini
-}
-
+# TASK OVERRIDES #
 do_install[depends] += "niacctbase:do_populate_sysroot"
-
-S = "${WORKDIR}"
 
 do_install () {
 	# UIXML config (soft dip switches, etc.)
@@ -155,7 +92,88 @@ pkg_postinst_ontarget:${PN} () {
 
 pkg_prerm_ontarget:${PN} () {
 	rm -f ${systemsettingsdir}/target_common.ini \
-	      ${systemsettingsdir}/rt_target.ini \
-	      ${systemsettingsdir}/fpga_target.ini \
-	      ${systemsettingsdir}/consoleout.ini
+		${systemsettingsdir}/rt_target.ini \
+		${systemsettingsdir}/fpga_target.ini \
+		${systemsettingsdir}/consoleout.ini
+}
+
+
+# PACKAGE VARAIBLES #
+FILES:${PN} = "\
+	${settingsdatadir}/consoleout.ini \
+	${settingsdatadir}/fpga_target.ini \
+	${settingsdatadir}/rt_target.ini \
+	${settingsdatadir}/target_common.ini \
+	${systemsettingsdir} \
+	${uixmldir}/nilinuxrt.fpga_disable.* \
+	${uixmldir}/nilinuxrt.rtapp_disable.* \
+	${uixmldir}/nilinuxrt.rtprotocol_enable.* \
+"
+
+RDEPENDS:${PN} += "niacctbase bash fw-printenv"
+
+
+# SUBPACKAGES #
+###############
+
+# sysconfig-settings-ssh package
+PACKAGES += "${PN}-ssh"
+SUMMARY:${PN}-ssh = "System configuration files for ssh"
+DESCRIPTION:${PN}-ssh = "SSH configuration files for the National Instruments System Configuration subsystem."
+
+SRC_URI:append = "\
+	file://uixml/nilinuxrt.sshd_enable.binding.xml \
+	file://uixml/nilinuxrt.sshd_enable.const.de.xml \
+	file://uixml/nilinuxrt.sshd_enable.const.fr.xml \
+	file://uixml/nilinuxrt.sshd_enable.const.ja.xml \
+	file://uixml/nilinuxrt.sshd_enable.const.ko.xml \
+	file://uixml/nilinuxrt.sshd_enable.const.xml \
+	file://uixml/nilinuxrt.sshd_enable.const.zh-CN.xml \
+	file://uixml/nilinuxrt.sshd_enable.def.xml \
+"
+
+FILES:${PN}-ssh = "${uixmldir}/nilinuxrt.sshd_enable.*"
+
+
+# sysconfig-settings-ui package
+PACKAGES += "${PN}-ui"
+SUMMARY:${PN}-ui = "System configuration files to enable UI"
+DESCRIPTION:${PN}-ui = "Configuration files to enable UI for the National Instruments System Configuration subsystem."
+
+SRC_URI:append = "\
+	file://nisetembeddeduixml \
+	file://systemsettings/ui_enable.ini \
+	file://uixml/nilinuxrt.System.binding.xml \
+	file://uixml/nilinuxrt.System.const.de.xml \
+	file://uixml/nilinuxrt.System.const.fr.xml \
+	file://uixml/nilinuxrt.System.const.ja.xml \
+	file://uixml/nilinuxrt.System.const.ko.xml \
+	file://uixml/nilinuxrt.System.const.xml \
+	file://uixml/nilinuxrt.System.const.zh-CN.xml \
+	file://uixml/nilinuxrt.System.def.xml \
+	file://uixml/nilinuxrt.ui_enable.binding.xml \
+	file://uixml/nilinuxrt.ui_enable.const.de.xml \
+	file://uixml/nilinuxrt.ui_enable.const.fr.xml \
+	file://uixml/nilinuxrt.ui_enable.const.ja.xml \
+	file://uixml/nilinuxrt.ui_enable.const.ko.xml \
+	file://uixml/nilinuxrt.ui_enable.const.xml \
+	file://uixml/nilinuxrt.ui_enable.const.zh-CN.xml \
+	file://uixml/nilinuxrt.ui_enable.def.xml \
+"
+
+FILES:${PN}-ui = "\
+	${sysconfdir}/init.d/nisetembeddeduixml \
+	${settingsdatadir}/ui_enable.ini \
+	${uixmldir}/nilinuxrt.System.* \
+	${uixmldir}/nilinuxrt.ui_enable.* \
+"
+
+RDEPENDS:${PN}-ui += "sysconfig-settings niacctbase"
+
+INITSCRIPT_PACKAGES += "${PN}-ui"
+INITSCRIPT_NAME:${PN}-ui = "nisetembeddeduixml"
+INITSCRIPT_PARAMS:${PN}-ui = "start 20 5 ."
+
+pkg_prerm_ontarget:${PN}-ui () {
+	rm -f ${systemsettingsdir}/ui_enable.ini
 }

--- a/recipes-ni/sysconfig-settings/sysconfig-settings.bb
+++ b/recipes-ni/sysconfig-settings/sysconfig-settings.bb
@@ -175,5 +175,6 @@ INITSCRIPT_NAME:${PN}-ui = "nisetembeddeduixml"
 INITSCRIPT_PARAMS:${PN}-ui = "start 20 5 ."
 
 pkg_prerm_ontarget:${PN}-ui () {
+	nirtcfg --set "section=systemsettings,token=ui.enabled,value=False"
 	rm -f ${systemsettingsdir}/ui_enable.ini
 }


### PR DESCRIPTION
### Summary of Changes

1. Fixup the `sysconfig-settings-ui` `prerm` to remove any lingering symlinks.
1. Moved `sysconfig-settings-ui` to `packagegroup-ni-graphical`.
1. Syntax and styling of the `sysconfig-settings` recipe as a whole.
1. Non-functional cleanups in the `-runmode` and `-extra` packagegroups.


### Justification

This patchset makes the `sysconfig-settings-ui` package cleanly removable, which means that we can remove it from the SNAC configuration to prevent users from accidentally enabling the UI. Before this patchset, opkg would complain that removing `sysconfig-settings-ui` would break the `-base` and `-runmode` packagegroups.

[AB#2769018](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2769018)


### Testing

* [x] Built the affected packagegroups and upgraded a NILRT 25.0 runmode with their new versions. `sysconfig-settings-ui` can now be removed without complaining.
* [x] Confirmed that the UI toggle is removed in MAX when the above package is removed.
* [x] Built the runmode image and confirmed that the `sysconfig-settings-ui` package is still installed by default.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
