### PR TITLE
[next] Subpackage consoleout sysconfig settings

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -90,6 +90,7 @@ RDEPENDS:${PN} += "\
 	run-postinsts \
 	sudo \
 	sysconfig-settings \
+	sysconfig-settings-console \
 	syslog-ng \
 	sysvinit \
 	tar \

--- a/recipes-ni/sysconfig-settings/sysconfig-settings.bb
+++ b/recipes-ni/sysconfig-settings/sysconfig-settings.bb
@@ -11,7 +11,6 @@ DEPENDS += "shadow-native pseudo-native niacctbase base-files-nilrt"
 
 # SOURCE VARIABLES #
 SRC_URI = "\
-	file://systemsettings/consoleout.ini \
 	file://systemsettings/fpga_target.ini \
 	file://systemsettings/rt_target.ini \
 	file://systemsettings/target_common.ini \
@@ -82,25 +81,17 @@ pkg_postinst_ontarget:${PN} () {
 	if ! [ "$TARGET_CLASS" = "cDAQ" -o "$TARGET_CLASS" = "CVS" ]; then
 		ln -sf ${settingsdatadir}/fpga_target.ini ${systemsettingsdir}/fpga_target.ini
 	fi
-
-	# add console out if we have a firmware variable for it (x86_64 targets only)
-	efiConsoleOutEnable=$(fw_printenv -n BootFirmwareConsoleOutEnable 2>/dev/null || true)
-	if ! [ -z "$efiConsoleOutEnable" ]; then
-		ln -sf ${settingsdatadir}/consoleout.ini ${systemsettingsdir}/consoleout.ini
-	fi
 }
 
 pkg_prerm_ontarget:${PN} () {
 	rm -f ${systemsettingsdir}/target_common.ini \
 		${systemsettingsdir}/rt_target.ini \
-		${systemsettingsdir}/fpga_target.ini \
-		${systemsettingsdir}/consoleout.ini
+		${systemsettingsdir}/fpga_target.ini
 }
 
 
 # PACKAGE VARAIBLES #
 FILES:${PN} = "\
-	${settingsdatadir}/consoleout.ini \
 	${settingsdatadir}/fpga_target.ini \
 	${settingsdatadir}/rt_target.ini \
 	${settingsdatadir}/target_common.ini \
@@ -115,6 +106,35 @@ RDEPENDS:${PN} += "niacctbase bash fw-printenv"
 
 # SUBPACKAGES #
 ###############
+
+# sysconfig-settings-console package
+PACKAGES += "${PN}-console"
+SUMMARY:${PN}-console = "System configuration files to control console output"
+DESCRIPTION:${PN}-console = "Configuration files that allow NI hardware configuration applications to control the consoleout firmware setting."
+
+SRC_URI:append = "\
+	file://systemsettings/consoleout.ini \
+"
+
+FILES:${PN}-console = "\
+	${settingsdatadir}/consoleout.ini \
+"
+
+RDEPENDS:${PN}-console += "sysconfig-settings fw-printenv"
+
+
+pkg_postinst_ontarget:${PN}-console () {
+	# add console out if we have a firmware variable for it (x86_64 targets only)
+	efiConsoleOutEnable=$(fw_printenv -n BootFirmwareConsoleOutEnable 2>/dev/null || true)
+	if ! [ -z "$efiConsoleOutEnable" ]; then
+		ln -sf ${settingsdatadir}/consoleout.ini ${systemsettingsdir}/consoleout.ini
+	fi
+}
+
+pkg_prerm_ontarget:${PN}-console () {
+	rm -f ${systemsettingsdir}/consoleout.ini
+}
+
 
 # sysconfig-settings-ssh package
 PACKAGES += "${PN}-ssh"


### PR DESCRIPTION
### Summary of Changes

This patchset creates a new `sysconfig-settings-console` subpackage - similar to `sysconfig-settings-ui` - that subpackages the `consoleout` MAX toggles.

Unlike the `-ui` subpackage, this new one has not been removed from `packagegroup-ni-base` because I cannot justify a consoleless configuration as a conceptually distinct set. So the nilrt-snac configuration tool will just forcefully remove the `sysconfig-settings-console` package, instead of de-installing a packagegroup.


### Justification

The NILRT SNAC configuration disables consoleout by policy. This subpackage will let us remove the tempting MAX toggle to re-enable it. The toggle will still be present in safemode.

[AB#2769023](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2769023)


### Testing

* [x] I have built the base packagegroup with this change and tested its functionality on a NILRT VM.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
