### PR TITLE
meta-nilrt: update default BUILDNAME in local conf and use it in opkg-keyrings bitbake file

### DIFF
--- a/conf/templates/default/local.conf.sample
+++ b/conf/templates/default/local.conf.sample
@@ -187,7 +187,9 @@ PACKAGECONFIG:append:pn-nativesdk-qemu = " sdl"
 # concatentation of the currrent $DATE and $TIME - which is not very meaningful
 # and can lead to taskhash issues in recipes which are sensitive to it (like
 # os-release.)
-BUILDNAME ?= "dev-nilrt"
+# Setting the version to majorMinorUpdate based, that wouldn't cause issues with
+# NI-MAX recognising the target.
+BUILDNAME ?= "99.0.0d0"
 
 # CONF_VERSION is increased each time build/conf/ changes incompatibly and is used to
 # track the version of this file when it was generated. This can safely be ignored if

--- a/recipes-devtools/opkg/opkg-keyrings_%.bbappend
+++ b/recipes-devtools/opkg/opkg-keyrings_%.bbappend
@@ -1,6 +1,14 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-PV = "${DISTRO_VERSION}"
+python () {
+    buildname = d.getVar('BUILDNAME')
+    import re
+    # Allow for BUILDNAME to be in the form of major.Minor or major.Minor.Update
+    package_version = re.match(r'(\d+\.\d+\.\d+|\d+\.\d+)', buildname)
+    if package_version:
+        buildname = package_version.group(1)
+    d.setVar('PKGV', buildname)
+}
 
 SRC_URI += " \
 	file://nilrt-feed-2019.gpg \


### PR DESCRIPTION
### Justification

- Changed the default BUILDNAME in local build configuration file to 99.0.0d0 so that the default value does not cause issues while recognizing the target in NI-MAX.
- Updated the PV variable to use BUILDNAME instead of DISTRO_VERSION for opkg-keyrings so that the newly generated BSI would use nibuild based versioning instead of OE versions in order to make to easily maintainable the newer ipks in the dist feed.

[AB#2346871](https://dev.azure.com/ni/DevCentral/_workitems/edit/2346871)

### Testing

* [X] `bitbake opkg-keyrings` generated ipks have the new default BUILDNAME (99.0.0d0)
* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [X] Upgrade Downgrade testing
**Upgrading** from existing distro version (11.0) to nibuild specific version (25.0.0 and newer)
![image](https://github.com/user-attachments/assets/ed71c5d4-03bc-45c2-b5d5-4e6714f2f82a)
**Upgrading** from existing new version (25.0.0 to newer) to latest available version in the feeds (11.0) does not work
![image](https://github.com/user-attachments/assets/1c5a5021-b1af-4342-a58a-031f6d4c2387)

Most of the BUILDNAME/version utilization for building opkg-keyrings has been covered in [this PR](https://dev.azure.com/ni/DevCentral/_git/ni-central/pullrequest/817262). More info about validation and testing can be found there.
### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
