### PR TITLE
build-containers: Disable DOCKER_BUILDKIT builds of images

### DIFF
--- a/recipes-kernel/kernel-tests/files/build-containers
+++ b/recipes-kernel/kernel-tests/files/build-containers
@@ -2,7 +2,7 @@
 
 if [ "$(docker images -q cyclictest-container:latest)" = "" ]; then
     echo "Building cyclictest-container..."
-    DOCKER_BUILDKIT=1 \
+    DOCKER_BUILDKIT=0 \
         docker build -t cyclictest-container --network=host ./cyclictest-container
     if [ "$(docker images -q cyclictest-container:latest)" = "" ]; then
         echo "Failed to build cyclictest-container"
@@ -12,7 +12,7 @@ fi
 
 if [ "$(docker images -q parallel-container:latest)" = "" ]; then
     echo "Building parallel-container..."
-    DOCKER_BUILDKIT=1 \
+    DOCKER_BUILDKIT=0 \
         docker build -t parallel-container --network=host ./parallel-container
     if [ "$(docker images -q parallel-container:latest)" = "" ]; then
         echo "Failed to build parallel-container"


### PR DESCRIPTION
### Summary of Changes

Disable BUILDKIT builds of images for kernel containerized performance tests

### Justification

[AB#2923737](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2923737)


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have built the kernel performance tests with this PR in place (`bitbake kernel-containerized-performance-tests`)
* [x] Executed the updated build-containers script on a target system

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
