### PR TITLE
Remove deprecated skyline clients from BSI

### DIFF
--- a/recipes-core/images/includes/nilrt-proprietary.inc
+++ b/recipes-core/images/includes/nilrt-proprietary.inc
@@ -13,9 +13,6 @@ NI_PROPRIETARY_COMMON_PACKAGES = "\
         ni-rt-exec-webservice \
         ni-sdmon \
         ni-service-locator \
-        ni-skyline-file-client \
-        ni-skyline-message-client \
-        ni-skyline-tag-client \
         ni-software-action-services \
         ni-software-installation-websvc \
         ni-ssl-webserver-support \


### PR DESCRIPTION
### Summary of Changes

Remove deprecated skyline clients from BSI


### Justification

These components depend on nissl so they got impacted by the removal of nissl from BSI. Finally, SL Team decided to remove these deprecated clients entirely from BSI & feeds

### Testing

N/A
* [ ] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
