### PR TITLE
add onboard to packagefeed-ni-core

### DIFF
--- a/recipes-core/packagegroups/packagefeed-ni-core.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-core.bb
@@ -25,6 +25,7 @@ RDEPENDS:${PN} = "\
 	packagegroup-ni-wifi \
 	dkms \
 	bolt \
+	onboard \
 "
 
 RDEPENDS:${PN}:append = "\


### PR DESCRIPTION
### Summary of Changes

This PR adds onboard to the list of recipes that gets built by packagefeed-ni-core so that it can be built and exported through the nickdanger server.


### Justification

[#AB2491688](https://dev.azure.com/ni/DevCentral/_workitems/edit/2491688/)
The above work item requires a virtual keyboard to be made available to users who access their targets by hooking them up to touch screen inputs.

### Testing

TODO: Detail what testing has been done to ensure this submission meets requirements.

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
