### PR TITLE
packagegroup-ni-snac.bb: add ni-firewalld-servicedefs

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-snac.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-snac.bb
@@ -8,6 +8,7 @@ inherit packagegroup
 RDEPENDS:${PN} = "\
 	cryptsetup \
 	firewalld \
+	ni-firewalld-servicedefs \
 	libpwquality \
 	nilrt-snac \
 	ntp \


### PR DESCRIPTION
Get this recipe building through an RDEPENDS reference.

### Testing

Edited inplace on Github.

* [N/A] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
