### PR TITLE
opkg-utils: Add metadata parsing functionality to opkg-utils

### DIFF
--- a/recipes-devtools/opkg-utils/opkg-utils/0002-parse-user_defined_fields-in-control-file.patch
+++ b/recipes-devtools/opkg-utils/opkg-utils/0002-parse-user_defined_fields-in-control-file.patch
@@ -1,0 +1,27 @@
+From c58f7da958a65cfc7a38836ad0be72a6bdf62fd8 Mon Sep 17 00:00:00 2001
+From: pratheekshasn <pratheeksha.s.n@ni.com>
+Date: Tue, 10 Dec 2024 10:27:14 +0530
+Subject: [PATCH] parse user_defined_fields in control file
+
+Upstream-Status: Pending [This will get submitted to the ni/nilrt repo before upstreaming it.]
+
+Signed-off by: Pratheeksha S N <pratheeksha.s.n@ni.com>
+
+---
+ opkg.py | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/opkg.py b/opkg.py
+index e5a65dd..0e469e0 100644
+--- a/opkg.py
++++ b/opkg.py
+@@ -294,8 +294,7 @@ class Package(object):
+                 elif all_fields:
+                     self.user_defined_fields[name] = value
+                 else:
+-                    print("Lost field %s, %s" % (name,value))
+-                    pass
++                    self.user_defined_fields[name] = value
+ 
+                 if line and line[0] == '\n':
+                     return # consumes one blank line at end of package descriptoin

--- a/recipes-devtools/opkg-utils/opkg-utils_%.bbappend
+++ b/recipes-devtools/opkg-utils/opkg-utils_%.bbappend
@@ -1,4 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-SRC_URI += "file://0001-Revert-opkg-feed-Fix-adding-feeds-with-same-name-as-.patch"
+SRC_URI += " \
+            file://0001-Revert-opkg-feed-Fix-adding-feeds-with-same-name-as-.patch \
+            file://0002-parse-user_defined_fields-in-control-file.patch \
+            "
 


### PR DESCRIPTION
### Summary of Changes

The package opkg-keyrings needs to become user visible on MAX so that the users can directly upgrade their keyrings from MAX through the dist feed. This PR adds code to opkg-utils through a patch that lets it parse metadata for `UserVisible` and `DisplayName` added to opkg-keyrings.


### Justification

[#AB2866259](https://ni.visualstudio.com/DevCentral/_workitems/edit/2866259/)


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have verified that the package file generated has the metadata for UserVisible and DisplalyName under the rest of the info for opkg-keyrings.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
