### PR TITLE
opkg-keyrings: Upgrade package in BSI's postinst

### DIFF
--- a/recipes-core/images/files/nilrt-base-system-image.postinst
+++ b/recipes-core/images/files/nilrt-base-system-image.postinst
@@ -110,3 +110,7 @@ for pid in $(pidof gpg-agent); do
 		break
 	fi
 done
+
+# Upgrade opkg-keyrings so that users can get the latest signing keys
+opkg -o /mnt/userfs/ update
+opkg -o /mnt/userfs/ upgrade opkg-keyrings


### PR DESCRIPTION
### Summary of Changes

This is part of the change required for [Feature 2346818](https://dev.azure.com/ni/DevCentral/_workitems/edit/2346818): NILRT distributions use a rotating package feed signing key.

Users want the BSI installation process to automatically attempt an upgrade of the opkg keyrings, so that they can get the latest signing keys.

### Justification

[#AB2351670](https://dev.azure.com/ni/DevCentral/_workitems/edit/2351670/)


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have tested the workflow of installing a BSI with a lower version of opkg-keyrings, and having the postinst script upgrade the package automatically.

The below image shows the upgrade running during postinst:
![image](https://github.com/user-attachments/assets/4cd4430b-a3db-4d5f-a3c9-f8b715c8d63b)

The below image shows that the package has been upgraded on run mode:
![image](https://github.com/user-attachments/assets/f5eb637b-6caf-435f-ab46-198edd93f93d)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
