### PR TITLE
opkg-keyrings: Add metadata to make package visible on MAX

### DIFF
--- a/recipes-devtools/opkg/opkg-keyrings_%.bbappend
+++ b/recipes-devtools/opkg/opkg-keyrings_%.bbappend
@@ -20,3 +20,5 @@ do_install:append() {
 	install -m 0444 ${WORKDIR}/nilrt-feed-2019.gpg ${D}${datadir}/opkg/keyrings/
 	install -m 0444 ${WORKDIR}/nilrt-feed-2023.gpg ${D}${datadir}/opkg/keyrings/
 }
+
+PACKAGE_ADD_METADATA_IPK:opkg-keyrings = "DisplayName: Opkg-Keyrings\nUserVisible: yes\n"


### PR DESCRIPTION
### Summary of Changes

The package opkg-keyrings needs to become user visible on MAX so that the users can directly upgrade their keyrings from MAX through the dist feed.


### Justification

[#AB2866259](https://ni.visualstudio.com/DevCentral/_workitems/edit/2866259/)


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have verified that the control file generated in the package has the metadata for UserVisible and DisplalyName under the rest of the info for opkg-keyrings.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
