### PR TITLE
packagegroup-ni-internal-dep: add mosquitto and paho-mqtt-cpp dep to …

### DIFF
--- a/files/group
+++ b/files/group
@@ -65,6 +65,7 @@ sshd:x:344:
 rwhod:x:343:
 opensaf:x:342:
 tracing:x:341:
+mosquitto:x:340:
 # free space
 radiusd:x:301:
 postgres:x:28:

--- a/files/passwd
+++ b/files/passwd
@@ -53,6 +53,7 @@ avahi:x:348::::
 sshd:x:344::::
 rwhod:x:343::::
 opensaf:x:342::::
+mosquitto:x:340::::
 # free space
 radiusd:x:301::::
 postgres:x:28::::

--- a/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
@@ -113,3 +113,11 @@ RDEPENDS:${PN} += "\
 	ntp-tickadj \
 	ntp-utils \
 "
+
+# Required by PESS hps, volta, ers-sic
+# TEAM: T&M BU - PESS
+# Contact: Bart Decoutere <leuven.sw@ni.com>
+RDEPENDS:${PN} += "\
+	mosquitto \
+	paho-mqtt-cpp \
+"


### PR DESCRIPTION
…PESS

Add `mosquitto` and `paho-mqtt-cpp` packages to internal dep packagegroup. Including static user and group `mosquitto`.

Many of the products of PESS depend on `mosquitto` message broker and the `paho-mqtt-cpp` libraries.

 `[AB#2944380](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2944380)`.


### Testing

* [x] I have built the package feed with this PR in place. (`bitbake packagegroup-ni-internal-deps`) after which the new package `.ipk` 's where available.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
