### PR TITLE
ni-firewalld-servicedefs: more additions

### DIFF
--- a/recipes-ni/ni-firewalld-servicedefs/files/services/ni-mxs.xml
+++ b/recipes-ni/ni-firewalld-servicedefs/files/services/ni-mxs.xml
@@ -3,4 +3,7 @@
   <short>NI MXS</short>
   <description>The NI Configuration Manager ("MXS") stores configuration information on behalf of components of the NI software platform.</description>
   <port protocol="tcp" port="51700"/>
+  <port protocol="tcp" port="57616"/>
+  <port protocol="tcp" port="61900"/>
+  <port protocol="tcp" port="62602"/>
 </service>

--- a/recipes-ni/ni-firewalld-servicedefs/files/services/ni-rpc-server.xml
+++ b/recipes-ni/ni-firewalld-servicedefs/files/services/ni-rpc-server.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>NI RPC Server</short>
+  <description></description>
+  <port protocol="tcp" port="43973"/>
+</service>

--- a/recipes-ni/ni-firewalld-servicedefs/ni-firewalld-servicedefs.bb
+++ b/recipes-ni/ni-firewalld-servicedefs/ni-firewalld-servicedefs.bb
@@ -19,9 +19,11 @@ SRC_URI = "\
 	file://services/ni-labview-realtime.xml \
 	file://services/ni-labview-viserver.xml \
 	file://services/ni-logos-xt.xml \
+	file://services/ni-mxs.xml \
 	file://services/ni-rfsa-classic-sfp.xml \
 	file://services/ni-rfsa-sfp.xml \
 	file://services/ni-rfsg-sfp.xml \
+	file://services/ni-rpc-server.xml \
 	file://services/ni-scope-sfp.xml \
 	file://services/ni-service-locator.xml \
 	file://services/ni-sync-remote.xml \


### PR DESCRIPTION
### Summary of Changes
Add ni-rpc-server and extend ni-mxs.

### Testing
Build succeeded; testing in progress.

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)

### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
