### PR TITLE
nilrt-snac: include ${datadir}

### DIFF
--- a/recipes-ni/nilrt-snac/nilrt-snac_git.bb
+++ b/recipes-ni/nilrt-snac/nilrt-snac_git.bb
@@ -31,6 +31,9 @@ do_install_ptest() {
 	install -m 0755 ${WORKDIR}/run-ptest ${D}${PTEST_PATH}
 }
 
+FILES:${PN} += "\
+	${datadir}/* \
+"
 
 RDEPENDS:${PN} = "\
 	bash \


### PR DESCRIPTION
A recent change to nilrt-snac installed a file under /usr/share, which should be included in the main nilrt-snac package. This needs to be explicitly added to FILES.

### Testing

QA error fixed.

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)

### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
