### PR TITLE
nilrt-snac: Point to release branch and pin SRCREV

### DIFF
--- a/recipes-ni/nilrt-snac/nilrt-snac_git.bb
+++ b/recipes-ni/nilrt-snac/nilrt-snac_git.bb
@@ -9,11 +9,11 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=380df876633ca23587b9851600778cc0"
 
 
 SRC_URI = "\
-	git://github.com/ni/nilrt-snac;branch=master;protocol=https \
+	git://github.com/ni/nilrt-snac;branch=stable/v1.0;protocol=https \
 	file://run-ptest \
 "
 
-SRCREV = "${AUTOREV}"
+SRCREV = "ec655ebbfaa34d07a8773ff024342f1076e5136c"
 PV = "0.1.1+git${SRCPV}"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
### Summary of Changes

Point nilrt-snac recipe to release branch and pin SRCREV to latest HEAD as of this time.

### Justification

Release finalization work.

WI: [AB#2836234](https://dev.azure.com/ni/DevCentral/_workitems/edit/2836234)

### Testing

* [x] `bitbake nilrt-snac` succeeds.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).

### Note
Should **not** be cherry-picked into any other branches.