### PR TITLE
opkg-keyrings: Mark opkg-keyrings to be essential

### DIFF
--- a/recipes-devtools/opkg/opkg-keyrings_%.bbappend
+++ b/recipes-devtools/opkg/opkg-keyrings_%.bbappend
@@ -21,4 +21,4 @@ do_install:append() {
 	install -m 0444 ${WORKDIR}/nilrt-feed-2023.gpg ${D}${datadir}/opkg/keyrings/
 }
 
-PACKAGE_ADD_METADATA_IPK:opkg-keyrings = "DisplayName: Opkg-Keyrings\nUserVisible: yes\n"
+PACKAGE_ADD_METADATA_IPK:opkg-keyrings = "DisplayName: Opkg-Keyrings\nUserVisible: yes\nEssential: yes\n"


### PR DESCRIPTION
### Summary of Changes

Since opkg-keyrings has been made user-visible in commit [b84cb0c](https://github.com/ni/meta-nilrt/tree/b84cb0c99c744097c13c15b4b171f61e99d20ff3), it can now be seen through MAX and users might accidentally delete it. To avoid this, the current PR marks the package as "Essential".


### Justification

[#AB2955131](https://ni.visualstudio.com/DevCentral/_workitems/edit/2955131)


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have installed the new version of the package, opkg-keyrings on the target and have ensured that it cannot be uninstalled through MAX.
![image](https://github.com/user-attachments/assets/6424b8cb-7839-443b-be7b-da146b56ac14)



### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
