### PR TITLE
opkg-keyrings: Mask possible errors on upgrading opkg-keyrings

### DIFF
--- a/recipes-core/images/files/nilrt-base-system-image.postinst
+++ b/recipes-core/images/files/nilrt-base-system-image.postinst
@@ -112,5 +112,5 @@ for pid in $(pidof gpg-agent); do
 done
 
 # Upgrade opkg-keyrings so that users can get the latest signing keys
-opkg -o /mnt/userfs/ update
-opkg -o /mnt/userfs/ upgrade opkg-keyrings
+# OR the command with true since the postinst script shouldn't return an error if the opkg update + upgrade fails.
+opkg -o /mnt/userfs/ update && opkg -o /mnt/userfs/ upgrade opkg-keyrings || true


### PR DESCRIPTION
### Summary of Changes

Since the postinst script might fail when the target is not connected to the internet, and that error can be ignored, the command is OR'd with true.

### Justification

[#AB2351670](https://dev.azure.com/ni/DevCentral/_workitems/edit/2351670/)


### Testing

* [ ] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] Verified that no errors are generated even when the target is not connected to the internet.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
