### PR TITLE
opkg-keyrings: Fix syntax as per sumo

### DIFF
--- a/recipes-devtools/opkg/opkg-keyrings_%.bbappend
+++ b/recipes-devtools/opkg/opkg-keyrings_%.bbappend
@@ -6,7 +6,7 @@ SRC_URI += " \
 	file://nilrt-feed-2025.gpg \
 "
 
-do_install:append() {
+do_install_append() {
 	# Install NI signing keys
 	install -m 0444 ${WORKDIR}/nilrt-feed-2019.gpg ${D}${datadir}/opkg/keyrings/
 	install -m 0444 ${WORKDIR}/nilrt-feed-2023.gpg ${D}${datadir}/opkg/keyrings/


### PR DESCRIPTION
### Summary of Changes

nilrt/master/sumo still uses the `_` in the append functions. This PR changes the `:` that was accidentally added in commit [c5aca13](https://github.com/ni/meta-nilrt/commit/c5aca13f9f69170f0b21b05ea5adde77253f7279).


### Justification

Changed `do_install:append()` to `do_install_append()`.


### Testing

* [ ] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [ ] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
