### PR TITLE
nilrt-base-system-image.postinst: Upgrade opkg-keyrings before updating other opkg sources

### DIFF
--- a/recipes-core/images/files/nilrt-base-system-image.postinst
+++ b/recipes-core/images/files/nilrt-base-system-image.postinst
@@ -113,4 +113,6 @@ done
 
 # Upgrade opkg-keyrings so that users can get the latest signing keys
 # OR the command with true since the postinst script shouldn't return an error if the opkg update + upgrade fails.
-opkg -o /mnt/userfs/ update && opkg -o /mnt/userfs/ upgrade opkg-keyrings || true
+# Upgrade the opkg-keyrings first to avoid the "unknown key" error when updating the package list. Since the
+# opkg-keyrings IPK is present in the dist feed, and signed with the previous key, the keyring upgrade will not fail.
+opkg -o /mnt/userfs/ upgrade opkg-keyrings && opkg -o /mnt/userfs/ update || true


### PR DESCRIPTION
### Summary of Changes

The BSI postinst script previously upgraded opkg-keyrings (to get the newly added signing key) after running the command `opkg update`, which in turn verifies the validity of all the feeds accessible by opkg.

This PR changes the order in which these commands are run because:
1. The dist feed (where opkg-keyrings is present) does not require another update, since it is already signed with the previous public key.
2. The validation of the other feeds would fail if they are already signed with the new key, and the target hasn't obtained the new key yet. This can be fixed by obtaining the new key first, i.e., upgrading opkg-keyrings.

### Justification

Although the postinst script does not throw any errors, upgrading the keyring before validating the other opkg sources makes more sense.

### Testing

Tested by building the base system image and installing on a target. Made sure that the opkg-keyrings gets updated before the other opkg sources are fetched and validated.

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
