### PR TITLE
linux-nilrt*: Update to 6.6 kernel

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-debug_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-debug_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NILRT linux kernel debug build"
 NI_RELEASE_VERSION = "master"
-LINUX_VERSION = "6.1"
+LINUX_VERSION = "6.6"
 LINUX_VERSION:xilinx-zynq = "4.14"
 LINUX_KERNEL_TYPE = "debug"
 

--- a/recipes-kernel/linux/linux-nilrt-nohz_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-nohz_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NILRT linux kernel full dynamic ticks (NO_HZ_FULL) build"
 NI_RELEASE_VERSION = "master"
-LINUX_VERSION = "6.1"
+LINUX_VERSION = "6.6"
 LINUX_KERNEL_TYPE = "nohz"
 
 require linux-nilrt-alternate.inc

--- a/recipes-kernel/linux/linux-nilrt_git.bb
+++ b/recipes-kernel/linux/linux-nilrt_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Linux kernel based on nilrt branch"
 NI_RELEASE_VERSION = "master"
-LINUX_VERSION = "6.1"
+LINUX_VERSION = "6.6"
 LINUX_VERSION:xilinx-zynq = "4.14"
 
 require linux-nilrt.inc


### PR DESCRIPTION
### Summary of Changes

Update default, debug and nohz kernels to 6.6.

### Justification

WI: [AB#2776115](https://dev.azure.com/ni/DevCentral/_workitems/edit/2776115)

### Testing

None

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
