### PR TITLE
Initial update of meta-nilrt to support SystemD

### DIFF
--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -15,7 +15,8 @@ DISTRO_FEATURES += "\
         xattr \
         zeroconf \
         pci \
-        sysvinit \
+        systemd \
+        usrmerge \
         pam \
         ptest \
         selinux \
@@ -74,7 +75,7 @@ VIRTUAL-RUNTIME_base-utils-hwclock = "util-linux-hwclock"
 
 VIRTUAL-RUNTIME_initscripts = "initscripts"
 
-VIRTUAL-RUNTIME_init_manager = "sysvinit"
+VIRTUAL-RUNTIME_init_manager = "systemd"
 
 # For qemu images
 VIRTUAL-RUNTIME_keymaps = ""

--- a/conf/templates/default/local.conf.sample
+++ b/conf/templates/default/local.conf.sample
@@ -197,5 +197,5 @@ BUILDNAME ?= "99.0.0d0"
 CONF_VERSION = "1"
 
 # Explicitly set system initialization method
-INIT_MANAGER = "sysvinit"
+INIT_MANAGER = "systemd"
 

--- a/files/group
+++ b/files/group
@@ -5,6 +5,11 @@ nogroup:x:65534:
 ni:x:500:
 openvpn:x:499:
 niwscerts:x:498:
+systemd-bus-proxy:x:497:
+systemd-network:x:496:
+systemd-resolve:x:495:
+render:x:494:
+sgx:x:493:
 # free space
 arpwatch:x:402:
 ptest:x:401:

--- a/files/passwd
+++ b/files/passwd
@@ -1,4 +1,5 @@
 nobody:x:65534::::
+nitest:x:1000::::
 # NOTE: static assignments for openembedded packages should be
 #       below the 'webserv' user. Range 502-999 is reserved for system
 #       users installed at runtime (e.g. packages from NIFeeds).

--- a/files/passwd
+++ b/files/passwd
@@ -5,6 +5,9 @@ nobody:x:65534::::
 webserv:x:501::::
 lvuser:x:500::::
 openvpn:x:499::::
+systemd-bus-proxy:x:498::::
+systemd-network:x:497::::
+systemd-resolve:x:496::::
 # free space
 arpwatch:x:402::::
 ptest:x:401::::

--- a/recipes-core/images/includes/nilrt-image-base.inc
+++ b/recipes-core/images/includes/nilrt-image-base.inc
@@ -8,6 +8,7 @@ do_rootfs[depends] += "depmodwrapper-cross:do_populate_sysroot"
 
 # without package-management update-rc.d gets removed from image
 IMAGE_FEATURES += "package-management"
+PACKAGE_WRITE_DEPS:append = " ${@bb.utils.contains('DISTRO_FEATURES','systemd','systemd-sysctl-native','',d)}"
 
 IMAGE_INSTALL += "\
 	packagegroup-ni-base \

--- a/recipes-core/images/nilrt-runmode-rootfs.bb
+++ b/recipes-core/images/nilrt-runmode-rootfs.bb
@@ -9,6 +9,7 @@ IMAGE_INSTALL = "\
 	packagegroup-ni-wifi \
 	dkms \
 	nilrt-grub-runmode \
+	systemd \
 	"
 
 require includes/nilrt-image-base.inc
@@ -22,6 +23,8 @@ IMAGE_INSTALL_NODEPS += "\
 
 # Ensure that rauc does not end up in this image.
 PACKAGE_EXCLUDE += "rauc rauc-mark-good"
+PACKAGE_WRITE_DEPS:append = " ${@bb.utils.contains('DISTRO_FEATURES','systemd','systemd-systemctl-native','',d)}"
+DEPENDS:append = " ${@bb.utils.contains('DISTRO_FEATURES','systemd','systemd-systemctl-native','',d)}"
 
 # on older NILRT distro flavors the kernel is installed in non-standard paths
 # for backward compatibility

--- a/recipes-core/images/nilrt-safemode-initramfs.bb
+++ b/recipes-core/images/nilrt-safemode-initramfs.bb
@@ -24,6 +24,9 @@ IMAGE_INSTALL_NODEPS += "\
 
 BAD_RECOMMENDATIONS:append:pn-${PN} = " shared-mime-info"
 
+PACKAGE_WRITE_DEPS:append = " ${@bb.utils.contains('DISTRO_FEATURES','systemd','systemd-systemctl-native','',d)}"
+DEPENDS:append = " ${@bb.utils.contains('DISTRO_FEATURES','systemd','systemd-systemctl-native','',d)}"
+
 # Do not allow python to be installed into safemode ramdisk due to size
 PACKAGE_EXCLUDE += "python-core python3-core"
 

--- a/recipes-core/packagegroups/packagefeed-ni-core.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-core.bb
@@ -24,6 +24,7 @@ RDEPENDS:${PN} = "\
 	packagegroup-ni-tzdata \
 	packagegroup-ni-wifi \
 	dkms \
+	bolt \
 	onboard \
 "
 

--- a/recipes-core/packagegroups/packagefeed-ni-core.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-core.bb
@@ -24,7 +24,6 @@ RDEPENDS:${PN} = "\
 	packagegroup-ni-tzdata \
 	packagegroup-ni-wifi \
 	dkms \
-	bolt \
 	onboard \
 "
 

--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -45,7 +45,6 @@ RDEPENDS:${PN} += "\
 	efibootmgr \
 	efivar \
 	ethtool \
-	eudev \
 	fw-printenv \
 	glibc-gconv-utf-16 \
 	gptfdisk \
@@ -92,7 +91,7 @@ RDEPENDS:${PN} += "\
 	sysconfig-settings \
 	sysconfig-settings-console \
 	syslog-ng \
-	sysvinit \
+	systemd \
 	tar \
 	udev-extraconf \
 	usbutils \

--- a/recipes-core/packagegroups/packagegroup-ni-restoremode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-restoremode.bb
@@ -17,7 +17,6 @@ RDEPENDS:${PN} += "\
 	e2fsprogs-tune2fs \
 	efibootmgr \
 	efivar \
-	eudev \
 	findutils \
 	fw-printenv \
 	gawk \
@@ -33,7 +32,7 @@ RDEPENDS:${PN} += "\
 	parted \
 	procps \
 	sed \
-	sysvinit \
+	systemd \
 	tar \
 	util-linux \
 	util-linux-agetty \

--- a/recipes-ni/ni-sysd-workarounds/files/init_script_removal
+++ b/recipes-ni/ni-sysd-workarounds/files/init_script_removal
@@ -1,0 +1,79 @@
+#!/bin/sh
+set -e
+
+niauth () {
+	/sbin/update-rc.d -f niauth remove
+	rm -f /etc/init.d/niauth
+	rm -f /usr/local/natinst/etc/init.d/niauth
+	systemctl daemon-reload
+	systemctl enable niauth.service
+	systemctl start niauth.service
+}
+
+nirtmdnsd () {
+   /sbin/update-rc.d -f nirtmdnsd remove
+   rm -f /usr/local/natinst/etc/init.d/nirtmdnsd
+   rm -f /etc/init.d/nirtmdnsd
+   systemctl daemon-reload
+   systemctl enable nirtmdnsd.service
+   systemctl start nirtmdnsd.service
+}
+
+niminionagent () {
+   /sbin/update-rc.d -f niminionagent remove
+   rm -f /etc/init.d/niminionagent
+   systemctl daemon-reload
+   systemctl enable niminionagent.service
+   systemctl start niminionagent.service
+}
+
+nisvcloc () {
+   /sbin/update-rc.d -f nisvcloc remove
+   rm -f /etc/init.d/nisvcloc
+   systemctl daemon-reload
+   systemctl enable nisvcloc.service
+   systemctl start nisvcloc.service
+}
+
+systemWebServer () {
+   /sbin/update-rc.d -f systemWebServer remove
+   rm -f /usr/local/natinst/etc/init.d/systemWebServer
+   rm -f /etc/init.d/systemWebServer
+   systemctl daemon-reload
+   systemctl enable systemWebServer.service
+   systemctl start systemWebServer.service
+}
+
+nisysmgmtmdnspublisher () {
+   /sbin/update-rc.d -f nisysmgmtmdnspublisher remove
+   rm -f /etc/init.d/nisysmgmtmdnspublisher
+   systemctl daemon-reload
+   systemctl enable nisysmgmtmdnspublisher.service
+   systemctl start nisysmgmtmdnspublisher.service
+}
+
+case "$1" in
+   niauth)
+      niauth
+      ;;
+   nirtmdnsd)
+      nirtmdnsd
+      ;;
+   niminionagent)
+      niminionagent
+      ;;
+   nisvcloc)
+      nisvcloc
+      ;;
+   systemWebServer)
+      systemWebServer
+      ;;
+   nisysmgmtmdnspublisher)
+      nisysmgmtmdnspublisher
+      ;;
+   *)
+      echo "Usage: $0 {niauth|nirtmdnsd|niminionagent|nisvcloc|systemWebServer|nisymgmtmdnspublisher}" >&2
+      exit 1
+esac
+
+exit 0

--- a/recipes-ni/ni-sysd-workarounds/files/niauth.service
+++ b/recipes-ni/ni-sysd-workarounds/files/niauth.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=NIAuth Database
+
+[Service]
+Type=simple
+WorkingDirectory=/usr/local/natinst/share/NIAuth
+ExecStartPre=/usr/local/natinst/share/NIAuth/niauth_service pre_start
+ExecStart=/usr/local/natinst/share/NIAuth/niauth_daemon
+ExecStartPost=/usr/local/natinst/share/NIAuth/niauth_service post_start
+ExecStop=/usr/local/natinst/share/NIAuth/niauth_service stop
+ExecStop=/usr/local/natinst/share/NIAuth/niauth_daemon
+Restart=always
+User=root
+Group=root
+Environment=PATH=/sbin/:/bin:/usr/bin:/usr/local/bin:/usr/local/natinst/share/NIAuth
+
+[Install]
+WantedBy=default.target

--- a/recipes-ni/ni-sysd-workarounds/files/niauth_service
+++ b/recipes-ni/ni-sysd-workarounds/files/niauth_service
@@ -1,0 +1,64 @@
+#!/bin/sh
+set -e
+
+usrPath="/usr/local/natinst/share/NIAuth"
+varPath="/run/natinst/niauth"
+enableFilePath="$varPath/enable_nss_pam"
+dbPath="/etc/natinst/share/niauth"
+
+pre_start() {
+	# Create the database directory with the proper permissions. (If the 
+	# directory already exists, retouch its permissions.)
+	if [ -d "$dbPath" ]; then
+		dir="$dbPath"
+	elif ! dir=`mktemp -d -p /etc/natinst/share`; then
+		echo "Couldn't create temporary directory for NIAuth"
+		exit 1
+	fi
+
+	if ! chown webserv:ni "$dir"; then
+		echo "Couldn't set NIAuth database directory owner"
+		exit 1
+	fi
+	if ! chmod 700 "$dir"; then
+		echo "Warning: Couldn't set NIAuth database directory permissions"
+	fi
+
+	# Atomically move the database directory into place if it was just created.
+	if [ ! -d "$dbPath" ]; then
+		if ! mv "$dir" "$dbPath"; then
+			echo "Couldn't create NIAuth database directory"
+			exit 1
+		fi
+	fi
+
+	mkdir -p "$varPath"
+}
+
+post_start () {
+	# Enable the NSS/PAM module.
+	echo "1" > "$enableFilePath"
+}
+
+stop() {
+	mkdir -p "$varPath"
+	echo "0" > "$enableFilePath"
+}
+
+case "$1" in
+	pre_start)
+		pre_start
+		;;
+	post_start)
+		post_start
+		;;
+	stop)
+		stop
+		;;
+	*)
+		echo "Usage: $0 {pre_start|post_start|stop}"
+		exit 1
+		;;
+esac
+
+exit 0

--- a/recipes-ni/ni-sysd-workarounds/files/niminionagent.service
+++ b/recipes-ni/ni-sysd-workarounds/files/niminionagent.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=niminionagent
+
+[Service]
+Type=simple
+WorkingDirectory=/usr/bin/
+ExecStart=/usr/bin/niminionagent
+ExecStop=/usr/bin/niminionagent
+Restart=always
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-ni/ni-sysd-workarounds/files/nirtmdnsd.service
+++ b/recipes-ni/ni-sysd-workarounds/files/nirtmdnsd.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=nirtmdnsd
+
+[Service]
+Type=simple
+WorkingDirectory=/usr/local/natinst/bin/
+ExecStart=/usr/local/natinst/bin/nirtmdnsd
+ExecStop=/usr/local/natinst/bin/nirtmdnsd
+Restart=always
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-ni/ni-sysd-workarounds/files/nisvcloc.service
+++ b/recipes-ni/ni-sysd-workarounds/files/nisvcloc.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=NI Service Locator
+
+[Service]
+Type=simple
+WorkingDirectory=/usr/bin
+ExecStart=/usr/bin/nisvcloc -D -n
+ExecStop=/usr/bin/nisvcloc
+Restart=always
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-ni/ni-sysd-workarounds/files/nisysmgmtmdnspublisher.service
+++ b/recipes-ni/ni-sysd-workarounds/files/nisysmgmtmdnspublisher.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=nisysmgmtmdnspublisher
+
+[Service]
+Type=simple
+WorkingDirectory=/usr/bin/
+ExecStart=/usr/bin/ni_sysmgmt_mdns_publisher
+ExecStop=/usr/bin/ni_sysmgmt_mdns_publisher
+Restart=always
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-ni/ni-sysd-workarounds/files/systemWebServer.service
+++ b/recipes-ni/ni-sysd-workarounds/files/systemWebServer.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=systemWebServer
+
+[Service]
+Type=simple
+WorkingDirectory=/usr/local/natinst/share/NIWebServer/
+ExecStart=/usr/local/natinst/share/NIWebServer/systemWebServer_service start
+ExecStop=/usr/local/natinst/share/NIWebServer/systemWebServer_service stop
+Restart=always
+User=webserv
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-ni/ni-sysd-workarounds/files/systemWebServer_service
+++ b/recipes-ni/ni-sysd-workarounds/files/systemWebServer_service
@@ -1,0 +1,46 @@
+#! /bin/sh
+#
+
+ulimit -s 256
+
+certInitPath=/usr/local/natinst/share/NIWebServer/certInit
+progname=systemWebServer
+progpath=/usr/local/natinst/share/NIWebServer/SystemWebServer
+arguments="-timeout 50 -child-timeout 20 -system"
+stopargs="-stop -system"
+
+# init.d script from National Instruments
+test -x "$progpath" || exit 0
+
+start(){
+	echo -n "Starting $progname: "
+	if ! $certInitPath; then
+		echo "Certificate initialization failed!"
+	fi
+	if [ ! -f /etc/natinst/safemode ]; then
+		$progpath $arguments
+	else
+		capsh --caps=cap_setpcap,cap_setuid,cap_setgid,cap_net_bind_service,cap_net_admin,cap_sys_time+ep --inh=cap_net_bind_service,cap_net_admin,cap_sys_time --keep=1 --addamb=cap_net_bind_service,cap_net_admin,cap_sys_time -- "$progpath $arguments"
+	fi
+    test $? -eq 1 || echo "done"
+}
+stop(){
+	echo -n "Stopping $progname: "
+	$progpath $stopargs
+	echo "done"
+}
+
+case "$1" in
+  start)
+	start
+	;;
+  stop)
+  	stop
+	;;
+  *)
+	echo "Usage: $progname {start|stop}" >&2
+	exit 1
+	;;
+esac
+
+exit 0

--- a/recipes-ni/ni-sysd-workarounds/ni-sysd-workarounds.bb
+++ b/recipes-ni/ni-sysd-workarounds/ni-sysd-workarounds.bb
@@ -1,0 +1,72 @@
+SUMMARY = "SystemD nilrt workaround files"
+DESCRIPTION = "Workaround Files for SystemD implementation"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+SECTION = "base"
+
+SRC_URI = " \
+	file://niauth.service \
+	file://niauth_service \
+	file://nirtmdnsd.service \
+	file://niminionagent.service \
+	file://nisvcloc.service \
+	file://systemWebServer.service \
+	file://systemWebServer_service \
+	file://nisysmgmtmdnspublisher.service \
+	file://init_script_removal \
+"
+
+DEPENDS += " \
+	update-rc.d-native \
+"
+
+inherit allarch
+
+PACKAGES = "${PN}"
+
+# Create niauth.service and install to /etc/systemd/system
+FILES:${PN} += " \
+	${sysconfdir}/systemd/system/niauth.service \
+	${sysconfdir}/systemd/system/nirtmdnsd.service \
+	${sysconfdir}/systemd/system/niminionagent.service \
+	${sysconfdir}/systemd/system/nisvcloc.service \
+	${sysconfdir}/systemd/system/systemWebServer.service \
+	${sysconfdir}/systemd/system/nisysmgmtmdnspublisher.service \
+	/usr/local/natinst/share/NIAuth/niauth_service \
+	/usr/local/natinst/share/NIWebServer/systemWebServer_service \
+	/usr/local/natinst/share/init_script_removal \
+"
+
+S = "${WORKDIR}"
+
+# Create folder /etc/natinst/share/niauth
+do_install () {
+	install -d ${D}${sysconfdir}/systemd/system/
+	install -m 0755 ${S}/niauth.service ${D}${sysconfdir}/systemd/system/niauth.service
+	install -m 0755 ${S}/nirtmdnsd.service ${D}${sysconfdir}/systemd/system/nirtmdnsd.service
+	install -m 0755 ${S}/niminionagent.service ${D}${sysconfdir}/systemd/system/niminionagent.service
+	install -m 0755 ${S}/nisvcloc.service ${D}${sysconfdir}/systemd/system/nisvcloc.service
+	install -m 0755 ${S}/systemWebServer.service ${D}${sysconfdir}/systemd/system/systemWebServer.service
+	install -m 0755 ${S}/nisysmgmtmdnspublisher.service ${D}${sysconfdir}/systemd/system/nisysmgmtmdnspublisher.service
+
+	install -d ${D}/usr/local/natinst/share/NIAuth/
+	install -d ${D}/usr/local/natinst/share/NIWebServer
+	install -m 0755 ${S}/init_script_removal ${D}/usr/local/natinst/share/init_script_removal
+	install -m 0755 ${S}/niauth_service ${D}/usr/local/natinst/share/NIAuth/niauth_service
+	install -m 0755 ${S}/niauth_service ${D}/usr/local/natinst/share/NIWebServer/systemWebServer_service
+}
+
+pkg_postinst_ontarget:${PN} () {
+	/usr/local/natinst/share/init_script_removal niauth
+	/usr/local/natinst/share/init_script_removal nirtmdnsd
+	# The execution of this seems to fail due to
+   # "Error: Unable to load library: "libnidaqmx.so.1" ...
+	# /usr/local/natinst/share/init_script_removal niminionagent
+	/usr/local/natinst/share/init_script_removal nisvcloc
+	# systemWebServer service is currently failing to execute
+	# When running manually, error: "SystemWebServer: cannot execute binary file"
+	# /usr/local/natinst/share/init_script_removal systemWebServer
+	# nisysmgmtmdnspublisher service is currently failing to execute
+	# "nismsmDNSPublisher: Unhandled exception: No such node (local.productcode)"
+	# /usr/local/natinst/share/init_script_removal nisysmgmtmdnspublisher
+}

--- a/recipes-ni/niacctbase/niacctbase.bb
+++ b/recipes-ni/niacctbase/niacctbase.bb
@@ -30,12 +30,18 @@ GROUPADD_PARAM:${PN} = " \
 	--system niwscerts; \
 	--system network"
 
+nitest_password = "\$5\$7S6FITmDf/QG.7cV\$YOrD6xTh7DYoO1qneHsszqi6QFh.ICzxL1WwRSY6l31"
 # add parameter -m if you want home directories created with default files (.profile, .bashrc)
 USERADD_PARAM:${PN} = " \
 	-m -N -g ${LVRT_GROUP} -G network,niwscerts,plugdev,tty,video -c 'LabVIEW user' ${LVRT_USER}; \
 	-m -N -g ${LVRT_GROUP} -G niwscerts,plugdev,adm,tty -c 'Web services user' webserv; \
 	-N -g openvpn -G network -c 'OpenVPN' -r openvpn; \
+	-m -N -g sudo -p '${nitest_password}' nitest; \
 "
+
+# Add password for root
+inherit extrausers
+EXTRA_USERS_PARAMS = "usermod -p ${nitest_password} root;"
 
 useradd_preinst:append () {
 	eval ${PSEUDO} chmod g+sw ${SYSROOT}/home/${LVRT_USER} || true

--- a/recipes-xfce/xserver-xfce-init/xserver-xfce-init.bb
+++ b/recipes-xfce/xserver-xfce-init/xserver-xfce-init.bb
@@ -34,6 +34,7 @@ do_install() {
 	fi
 	if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
 		install -d ${D}${systemd_unitdir}/system
+		install -d ${D}${sysconfdir}/default/
 		install -m 0644 xserver-xfce.conf ${D}${sysconfdir}/default/xserver-xfce
 		install -m 0644 ${WORKDIR}/xserver-xfce.service ${D}${systemd_unitdir}/system
 	fi
@@ -42,7 +43,11 @@ do_install() {
 }
 
 
-FILES_${PN} += "${sysconfdir}/default/xserver-xfce"
+FILES:${PN} += " \
+	${sysconfdir}/default/xserver-xfce \
+	${systemd_unitdir}/system/xserver-xfce.service \
+"
+
 # Get util-linux for su
 RDEPENDS:${PN} = "xserver-common (>= 1.30) xinit xfce4-session util-linux"
 RCONFLICTS:${PN} = "xserver-nodm-init"


### PR DESCRIPTION
### Summary of Changes

Initial update of meta-nilrt to support systemd


### Justification

[AB#2573012](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2573012)
[AB#2572977](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2572977)

### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have built the index package feed with this PR in place. (`bitake package-index`)
* [x] I have built the safemode images with this PR in place. (`bitbake nilrt-safemode-rootfs`)
* [x] I have built the base system images with this PR in place. (`bitbake nilrt-base-system-image`)
* [x] I have built the bootable recovery media with this PR in place. (`bitbake nilrt-recovery-media`) 


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
