### PR TITLE
kernel_dmesg_diff: Add command-line option for previous kernel dmesg logs

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-tests-files/kernel_dmesg_diff.py
+++ b/recipes-kernel/kernel-tests/kernel-tests-files/kernel_dmesg_diff.py
@@ -284,25 +284,37 @@ def parse_args():
                              'database, so the --skip_upload flag is not needed. This flag is useful for debugging issues with this test.')
     parser.add_argument('--skip_upload', help='Skip upload of dmesg record to database. Useful when debugging.', action="store_true")
     parser.add_argument('--suppress_diff_output', help='Reduces test output noise by removing the dmesg log diff from the output. Useful when debugging.', action="store_true")
+    parser.add_argument('--basis_log_db_date', metavar="<date>",
+                        help='Use this flag to supply a date string that will be used to locate a dmesg log in the database. That log will be used as the basis dmseg log. '\
+                             'Should be of the format "2023-03-30 15:32:43.203476". Date strings for previous dmesg logs can be found in the output of previous runs of this '\
+                             'test or can be extracted from the Mongo database using a viewer tool like Compass. This flag is useful for resetting the comparison baseline for the test.')
     return parser.parse_args()
 
 logger = Logger()
 args = parse_args()
 db = DB(args.server, args.user, args.password)
 
+# Retrieve the current dmesg log
 if args.current_log_db_date:
     current_dmesg_record = get_dmesg_record_by_date(db, args.current_log_db_date, logger)
     assert current_dmesg_record, "Could not find matching current log record from database."
-    current_dmesg_log = strip_headers(current_dmesg_record['dmesg_log'])
 
-    previous_dmesg_record = get_previous_dmesg_record(db, KernelVersion(current_dmesg_record['kernel_version_full']), current_dmesg_record['os_version_major_minor'], current_dmesg_record['device_desc'], logger)
+    current_dmesg_log = strip_headers(current_dmesg_record['dmesg_log'])
+    kernel_version = KernelVersion(current_dmesg_record['kernel_version_full'])
+    os_version = current_dmesg_record['os_version_major_minor']
+    device_desc = current_dmesg_record['device_desc']
 else:
     current_dmesg_log = get_dmesg_log()
-
     kernel_version = KernelVersion()
     os_version = OsVersion()
     device_desc = get_device_desc()
-    previous_dmesg_record = get_previous_dmesg_record(db, kernel_version, os_version.major_minor, device_desc, logger)
+
+# Retrieve the previous dmesg log
+if args.basis_log_db_date:
+    previous_dmesg_record = get_dmesg_record_by_date(db, args.basis_log_db_date, logger)
+    assert previous_dmesg_record, "Could not find matching basis log record from database."
+else:
+    previous_dmesg_record = get_previous_dmesg_record(db, kernel_version, os_version, device_desc, logger)
 
 previous_dmesg_log = strip_headers(previous_dmesg_record['dmesg_log']) if previous_dmesg_record else ''
 

--- a/recipes-kernel/kernel-tests/kernel-tests-files/test_kernel_dmesg_diff.sh
+++ b/recipes-kernel/kernel-tests/kernel-tests-files/test_kernel_dmesg_diff.sh
@@ -5,7 +5,11 @@ source $(dirname "$0")/ptest-format.sh
 ptest_change_test $(basename "$0" ".sh") "" "Diff dmesg log with with previous"
 
 source /home/admin/.mongodb.creds
-python3 kernel_dmesg_diff.py --server $MONGO_SERVER --user $MONGO_USER --password $MONGO_PASSWORD
+if [ -e /home/admin/.test.kernel_dmesg_diff.args ]; then
+   source /home/admin/.test.kernel_dmesg_diff.args
+fi
+
+python3 kernel_dmesg_diff.py --server $MONGO_SERVER --user $MONGO_USER --password $MONGO_PASSWORD "${KERNEL_DMESG_DIFF_TEST_EXTRA_ARGS[@]}"
 
 if [ $? -eq 0 ]; then
    ptest_pass


### PR DESCRIPTION
### Summary of Changes

Add the ability to set a particular log as the basis against which the current build's kernel_dmesg_diff test log should be compared against. This is so that newer kernel dmesg outputs can be accepted without triggering the test failure for innocuous changes in the kernel dmesg output.


### Justification

[#AB2990690](https://dev.azure.com/ni/DevCentral/_workitems/edit/2990690/)

### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] Built the package and installed it on a target, ran the test and verified that the test can fetch records from the database based on the date provided. It also generates the logs.

### Procedure
* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
