### PR TITLE
kernel-tests: replace 'nproc --all' calls with 'nproc'

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_hackbench_containerized.sh
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_hackbench_containerized.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 source "$(dirname "$0")"/common.cfg
 
-CPUS=`nproc --all`
+CPUS=`nproc`
 if [ $CPUS -lt 2 ]; then
 	echo "ERROR: the containerized hackbench test requires a system with at least 2 CPUs"
 	echo "SKIP: test_kernel_hackbench_containerized"

--- a/recipes-kernel/kernel-tests/kernel-test-nohz.bb
+++ b/recipes-kernel/kernel-tests/kernel-test-nohz.bb
@@ -36,7 +36,7 @@ do_install_ptest:append() {
 }
 
 pkg_postinst_ontarget:${PN}-ptest:append() {
-    CPUS=`nproc --all`
+    CPUS=`nproc`
     ISOLATED_CPU=$((CPUS - 1))
 
     if [ $ISOLATED_CPU -gt 0 ]; then


### PR DESCRIPTION
Starting with NILRT 25.0, a glibc upgrade changed the behavior of 'nproc --all' to include CPUs that might possibly be added via hotplugging:
https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=97a912f7a832a662960749948049e15f3aecb2a7

This affected at least cRIO-904x NILRT targets and possibly others.

By calling nproc, we will only get available CPUs which is what we intend in these use cases.

### Summary of Changes

Change 'nproc --all' calls to 'nproc'.

### Justification

[AB#3021906](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3021906)

### Testing

Built affected packages via bitbake and installed corresponding -ptest packages to a target to confirm correct behavior.

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)

### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
