### PR TITLE
kernel perf tests: Fix distro codename reporting

### DIFF
--- a/recipes-kernel/kernel-tests/files/upload_cyclictest_results.py
+++ b/recipes-kernel/kernel-tests/files/upload_cyclictest_results.py
@@ -146,7 +146,7 @@ def get_distro_info():
         return ('unknown', 'unknown')
     pairs = dict(map(lambda e: e.split('='), os_release_stmts))
     version = pairs.get('VERSION_ID', 'unknown').strip()
-    name = pairs.get('DISTRO_CODENAME', 'unknown').strip()[1:-1]
+    name = pairs.get('VERSION_CODENAME', 'unknown').strip().strip('"')
     return (version, name)
 
 def read_data(path):


### PR DESCRIPTION
### Summary of Changes

Starting in mickledore, upstream OE has removed the DISTRO_CODENAME field from /etc/os-release in favor of VERSION_CODENAME. We picked up this change in scarthgap.

The kernel performance tests were using that field to get the distro codename when uploading test results to our database. This change switches to using VERSION_CODENAME instead. This change also fixes a string handling bug which was incorrectly removing characters from the beginning and end of the default "unknown" codename value when the intention was only to strip surrounding quotes from the value obtained from /etc/os-release.

### Justification

[AB#3034561](https://dev.azure.com/ni/DevCentral/_workitems/edit/3034561)

### Testing

Built kernel-performance-tests and kernel-containerized-performance-tests targets and installed both of the corresponding -ptest packages on a system. Then visually confirmed the presence of the fix and ran a hand-test to confirm correct behavior.

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
