### PR TITLE
Initial update of meta-nilrt to support systemd

### DIFF
--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -15,7 +15,8 @@ DISTRO_FEATURES += "\
         xattr \
         zeroconf \
         pci \
-        sysvinit \
+        systemd \
+        usrmerge \
         pam \
         ptest \
         selinux \
@@ -74,7 +75,7 @@ VIRTUAL-RUNTIME_base-utils-hwclock = "util-linux-hwclock"
 
 VIRTUAL-RUNTIME_initscripts = "initscripts"
 
-VIRTUAL-RUNTIME_init_manager = "sysvinit"
+VIRTUAL-RUNTIME_init_manager = "systemd"
 
 # For qemu images
 VIRTUAL-RUNTIME_keymaps = ""

--- a/conf/templates/default/local.conf.sample
+++ b/conf/templates/default/local.conf.sample
@@ -197,5 +197,5 @@ BUILDNAME ?= "99.0.0d0"
 CONF_VERSION = "1"
 
 # Explicitly set system initialization method
-INIT_MANAGER = "sysvinit"
+INIT_MANAGER = "systemd"
 

--- a/files/group
+++ b/files/group
@@ -5,6 +5,9 @@ nogroup:x:65534:
 ni:x:500:
 openvpn:x:499:
 niwscerts:x:498:
+systemd-network:x:497:
+systemd-resolve:x:496:
+render:x:495:
 # free space
 arpwatch:x:402:
 ptest:x:401:

--- a/files/passwd
+++ b/files/passwd
@@ -5,6 +5,8 @@ nobody:x:65534::::
 webserv:x:501::::
 lvuser:x:500::::
 openvpn:x:499::::
+systemd-network:x:498::::
+systemd-resolve:x:497::::
 # free space
 arpwatch:x:402::::
 ptest:x:401::::

--- a/files/passwd
+++ b/files/passwd
@@ -1,4 +1,5 @@
 nobody:x:65534::::
+nitest:x:1000::::
 # NOTE: static assignments for openembedded packages should be
 #       below the 'webserv' user. Range 502-999 is reserved for system
 #       users installed at runtime (e.g. packages from NIFeeds).

--- a/recipes-core/images/includes/nilrt-image-base.inc
+++ b/recipes-core/images/includes/nilrt-image-base.inc
@@ -8,6 +8,7 @@ do_rootfs[depends] += "depmodwrapper-cross:do_populate_sysroot"
 
 # without package-management update-rc.d gets removed from image
 IMAGE_FEATURES += "package-management"
+PACKAGE_WRITE_DEPS:append = " ${@bb.utils.contains('DISTRO_FEATURES','systemd','systemd-sysctl-native','',d)}"
 
 IMAGE_INSTALL += "\
 	packagegroup-ni-base \

--- a/recipes-core/images/nilrt-runmode-rootfs.bb
+++ b/recipes-core/images/nilrt-runmode-rootfs.bb
@@ -22,6 +22,8 @@ IMAGE_INSTALL_NODEPS += "\
 
 # Ensure that rauc does not end up in this image.
 PACKAGE_EXCLUDE += "rauc rauc-mark-good"
+PACKAGE_WRITE_DEPS:append = " ${@bb.utils.contains('DISTRO_FEATURES','systemd','systemd-systemctl-native','',d)}"
+DEPENDS:append = " ${@bb.utils.contains('DISTRO_FEATURES','systemd','systemd-systemctl-native','',d)}"
 
 # on older NILRT distro flavors the kernel is installed in non-standard paths
 # for backward compatibility

--- a/recipes-core/images/nilrt-safemode-initramfs.bb
+++ b/recipes-core/images/nilrt-safemode-initramfs.bb
@@ -24,6 +24,9 @@ IMAGE_INSTALL_NODEPS += "\
 
 BAD_RECOMMENDATIONS:append:pn-${PN} = " shared-mime-info"
 
+PACKAGE_WRITE_DEPS:append = " ${@bb.utils.contains('DISTRO_FEATURES','systemd','systemd-systemctl-native','',d)}"
+DEPENDS:append = " ${@bb.utils.contains('DISTRO_FEATURES','systemd','systemd-systemctl-native','',d)}"
+
 # Do not allow python to be installed into safemode ramdisk due to size
 PACKAGE_EXCLUDE += "python-core python3-core"
 

--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -25,6 +25,8 @@ RDEPENDS:${PN} += "\
 	${@bb.utils.contains('COMBINED_FEATURES', 'pci', 'pciutils-ids', '',d)} \
 	${@bb.utils.contains('MACHINE_FEATURES', 'acpi', 'busybox-acpid', '', d)} \
 	${@bb.utils.contains('MACHINE_FEATURES', 'keyboard', 'keymaps', '', d)} \
+	${@bb.utils.contains('INIT_MANAGER', 'systemd', 'systemd', 'sysvinit', d)} \
+	${@bb.utils.contains('INIT_MANAGER', 'sysvinit', 'eudev', '', d)} \
 	avahi-daemon \
 	base-files \
 	base-files-nilrt \
@@ -45,7 +47,6 @@ RDEPENDS:${PN} += "\
 	efibootmgr \
 	efivar \
 	ethtool \
-	eudev \
 	fw-printenv \
 	glibc-gconv-utf-16 \
 	gptfdisk \
@@ -92,7 +93,6 @@ RDEPENDS:${PN} += "\
 	sysconfig-settings \
 	sysconfig-settings-console \
 	syslog-ng \
-	sysvinit \
 	tar \
 	udev-extraconf \
 	usbutils \

--- a/recipes-core/packagegroups/packagegroup-ni-restoremode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-restoremode.bb
@@ -6,6 +6,8 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 inherit packagegroup
 
 RDEPENDS:${PN} += "\
+	${@bb.utils.contains('INIT_MANAGER', 'systemd', 'systemd', 'sysvinit', d)} \
+	${@bb.utils.contains('INIT_MANAGER', 'sysvinit', 'eudev', '', d)} \
 	base-passwd \
 	bash \
 	bzip2 \
@@ -17,7 +19,6 @@ RDEPENDS:${PN} += "\
 	e2fsprogs-tune2fs \
 	efibootmgr \
 	efivar \
-	eudev \
 	findutils \
 	fw-printenv \
 	gawk \
@@ -33,7 +34,6 @@ RDEPENDS:${PN} += "\
 	parted \
 	procps \
 	sed \
-	sysvinit \
 	tar \
 	util-linux \
 	util-linux-agetty \

--- a/recipes-ni/ni-sysd-workarounds/files/niauth_systemd
+++ b/recipes-ni/ni-sysd-workarounds/files/niauth_systemd
@@ -1,0 +1,64 @@
+#!/bin/sh
+set -e
+
+usrPath="/usr/local/natinst/share/NIAuth"
+varPath="/run/natinst/niauth"
+enableFilePath="$varPath/enable_nss_pam"
+dbPath="/etc/natinst/share/niauth"
+
+pre_start() {
+	# Create the database directory with the proper permissions. (If the
+	# directory already exists, retouch its permissions.)
+	if [ -d "$dbPath" ]; then
+		dir="$dbPath"
+	elif ! dir=`mktemp -d -p /etc/natinst/share`; then
+		echo "Couldn't create temporary directory for NIAuth"
+		exit 1
+	fi
+
+	if ! chown webserv:ni "$dir"; then
+		echo "Couldn't set NIAuth database directory owner"
+		exit 1
+	fi
+	if ! chmod 700 "$dir"; then
+		echo "Warning: Couldn't set NIAuth database directory permissions"
+	fi
+
+	# Atomically move the database directory into place if it was just created.
+	if [ ! -d "$dbPath" ]; then
+		if ! mv "$dir" "$dbPath"; then
+			echo "Couldn't create NIAuth database directory"
+			exit 1
+		fi
+	fi
+
+	mkdir -p "$varPath"
+}
+
+post_start () {
+	# Enable the NSS/PAM module.
+	echo "1" > "$enableFilePath"
+}
+
+stop() {
+	mkdir -p "$varPath"
+	echo "0" > "$enableFilePath"
+}
+
+case "$1" in
+	pre_start)
+		pre_start
+		;;
+	post_start)
+		post_start
+		;;
+	stop)
+		stop
+		;;
+	*)
+		echo "Usage: $0 {pre_start|post_start|stop}"
+		exit 1
+		;;
+esac
+
+exit 0

--- a/recipes-ni/ni-sysd-workarounds/files/niauth_systemd.service
+++ b/recipes-ni/ni-sysd-workarounds/files/niauth_systemd.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=NIAuth Database
+
+[Service]
+Type=simple
+WorkingDirectory=/usr/local/natinst/share/NIAuth
+ExecStartPre=/usr/local/natinst/share/NIAuth/niauth_systemd pre_start
+ExecStart=/usr/local/natinst/share/NIAuth/niauth_daemon
+ExecStartPost=/usr/local/natinst/share/NIAuth/niauth_systemd post_start
+ExecStop=/usr/local/natinst/share/NIAuth/niauth_systemd stop
+ExecStop=/usr/local/natinst/share/NIAuth/niauth_daemon
+Restart=always
+User=root
+Group=root
+Environment=PATH=/sbin/:/bin:/usr/bin:/usr/local/bin:/usr/local/natinst/share/NIAuth
+
+[Install]
+WantedBy=default.target

--- a/recipes-ni/ni-sysd-workarounds/niauth-workaround.bb
+++ b/recipes-ni/ni-sysd-workarounds/niauth-workaround.bb
@@ -1,0 +1,45 @@
+SUMMARY = "ni-auth systemD workaround files"
+DESCRIPTION = "Workaround for ni-auth systemD implementation"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+SECTION = "base"
+
+SRC_URI = " \
+	file://niauth_systemd.service \
+	file://niauth_systemd \
+"
+
+DEPENDS += " \
+	update-rc.d-native \
+"
+
+inherit allarch
+
+PACKAGES = "${PN}"
+
+SYSTEMD_SERVICE:${PN} = "niauth_systemd.service"
+
+# Create niauth.service and install to /etc/systemd/system
+FILES:${PN} += " \
+	${sysconfdir}/systemd/system/niauth_systemd.service \
+	/usr/local/natinst/share/NIAuth/niauth_systemd \
+"
+
+S = "${WORKDIR}"
+
+# Create folder /etc/natinst/share/niauth
+do_install () {
+	install -d ${D}${sysconfdir}/systemd/system/
+	install -m 0755 ${S}/niauth_systemd.service ${D}${sysconfdir}/systemd/system/
+
+	install -d ${D}/usr/local/natinst/share/NIAuth/
+	install -m 0755 ${S}/niauth_systemd ${D}/usr/local/natinst/share/NIAuth/
+}
+
+pkg_postinst_ontarget:${PN} () {
+	/etc/init.d/niauth stop
+	/sbin/update-rc.d -f niauth remove
+	/bin/systemctl daemon-reload
+	/bin/systemctl enable niauth_systemd.service
+	/bin/systemctl start niauth_systemd.service
+}

--- a/recipes-ni/niacctbase/niacctbase.bb
+++ b/recipes-ni/niacctbase/niacctbase.bb
@@ -30,12 +30,19 @@ GROUPADD_PARAM:${PN} = " \
 	--system niwscerts; \
 	--system network"
 
+nitest_password = "\$5\$7S6FITmDf/QG.7cV\$YOrD6xTh7DYoO1qneHsszqi6QFh.ICzxL1WwRSY6l31"
+
 # add parameter -m if you want home directories created with default files (.profile, .bashrc)
 USERADD_PARAM:${PN} = " \
 	-m -N -g ${LVRT_GROUP} -G network,niwscerts,plugdev,tty,video -c 'LabVIEW user' ${LVRT_USER}; \
 	-m -N -g ${LVRT_GROUP} -G niwscerts,plugdev,adm,tty -c 'Web services user' webserv; \
 	-N -g openvpn -G network -c 'OpenVPN' -r openvpn; \
+	-m -N -g sudo -p '${nitest_password}' nitest; \
 "
+
+# Add password for root
+inherit extrausers
+EXTRA_USERS_PARAMS = "usermod -p ${nitest_password} root;"
 
 useradd_preinst:append () {
 	eval ${PSEUDO} chmod g+sw ${SYSROOT}/home/${LVRT_USER} || true

--- a/recipes-xfce/xserver-xfce-init/xserver-xfce-init.bb
+++ b/recipes-xfce/xserver-xfce-init/xserver-xfce-init.bb
@@ -34,6 +34,7 @@ do_install() {
 	fi
 	if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
 		install -d ${D}${systemd_unitdir}/system
+		install -d ${D}${sysconfdir}/default/
 		install -m 0644 xserver-xfce.conf ${D}${sysconfdir}/default/xserver-xfce
 		install -m 0644 ${WORKDIR}/xserver-xfce.service ${D}${systemd_unitdir}/system
 	fi
@@ -42,7 +43,9 @@ do_install() {
 }
 
 
-FILES_${PN} += "${sysconfdir}/default/xserver-xfce"
+FILES:${PN} += "${sysconfdir}/default/xserver-xfce"
+FILES:${PN} += "${@bb.utils.contains('DISTRO_FEATURES','systemd','${systemd_unitdir}/system/xserver-xfce.service','', d)}"
+
 # Get util-linux for su
 RDEPENDS:${PN} = "xserver-common (>= 1.30) xinit xfce4-session util-linux"
 RCONFLICTS:${PN} = "xserver-nodm-init"


### PR DESCRIPTION
### Summary of Changes

Initial update of meta-nilrt to support systemd

### Justification

[AB#2573012](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2573012)
[AB#2572977](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2572977)


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have built the index package feed with this PR in place. (`bitbake package-index`)
* [x] I have built the safemode images with this PR in place. (`bitbake nilrt-safemode-rootfs`)
* [x] I have built the base system image with this PR in place. (`bitbake nilrt-base-system-image`)
* [x] I have built the bootable recovery media with this PR in place. (`bitbake nilrt-recovery-media`)
* [x] I have applied the systemd nilrt-base-system-image on top of a sysv nilrt-safemode-rootfs
* [x] I have installed the niauth_systemd service onto nilrt-base-system-image and verified admin login

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
