### PR TITLE
fs_permissions_diff: Strip commit hash from file name

### DIFF
--- a/recipes-ni/ni-base-system-image-tests/files/fs_permissions_diff.py
+++ b/recipes-ni/ni-base-system-image-tests/files/fs_permissions_diff.py
@@ -207,7 +207,7 @@ def strip_versions_from_path(path):
     stripped_path = re.sub(r"salt-\d+\.\d+_\d+_g[0-9a-f]+", "salt-SALTVERSION", path)
     stripped_path = re.sub(r"salt-\d+\.\d+\+\d+\.g[0-9a-f]+", "salt-SALTVERSION", stripped_path)
     # Strip everything that looks like an RT kernel version (so module and kernel version changes are ignored)
-    stripped_path = re.sub(r"\d+\.\d+\.\d+-rt\d+", "VERSION.VERSION.VERSION-rtVERSION", stripped_path)
+    stripped_path = re.sub(r"\d+\.\d+\.\d+-rt\d+(-next)?(-g[a-f0-9]+)?", "VERSION.VERSION.VERSION-rtVERSION", stripped_path)
     # Strip everything that looks like 1.2.3
     stripped_path = re.sub(r"\d+\.\d+\.\d+", "VERSION.VERSION.VERSION", stripped_path)
     # Strip everything that looks like 1.2


### PR DESCRIPTION
### Summary of Changes

While comparing files across different builds, the version commit hashes in the file names are not currently stripped off before comparing.

This PR adds the extra regex that matches the commit hashes in the file names.


### Justification

[AB#3014543](https://dev.azure.com/ni/DevCentral/_workitems/edit/3014543)


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have built and installed the new changes and tested on a target, and the logs added because of the difference in file names caused by the commit hash are no longer present.
* [x] The test has been run on the current kernel and the next kernel.



### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
