### PR TITLE
kernel_dmesg_diff: Fetch previous dmesg_record with OS major-minor version

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-tests-files/kernel_dmesg_diff.py
+++ b/recipes-kernel/kernel-tests/kernel-tests-files/kernel_dmesg_diff.py
@@ -315,7 +315,7 @@ if args.basis_log_db_date:
     previous_dmesg_record = get_dmesg_record_by_date(db, args.basis_log_db_date, logger)
     assert previous_dmesg_record, "Could not find matching basis log record from database."
 else:
-    previous_dmesg_record = get_previous_dmesg_record(db, kernel_version, os_version, device_desc, logger)
+    previous_dmesg_record = get_previous_dmesg_record(db, kernel_version, os_version.major_minor, device_desc, logger)
 
 previous_dmesg_log = strip_headers(previous_dmesg_record['dmesg_log']) if previous_dmesg_record else ''
 


### PR DESCRIPTION
### Summary of Changes

The function get_previous_dmesg_record() expects the OS version to be passed as the major-minor version. The change introduced in PR [801](https://github.com/ni/meta-nilrt/pull/801) passed the whole version instead.

This PR fixes that issue.

### Justification

[AB#3014551](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3014551).


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] Installed the modified test on a target and tested that it runs fine.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
