### PR TITLE
packagegroup-ni-*: Move trace-cmd into runmode

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-desirable.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-desirable.bb
@@ -46,7 +46,6 @@ RDEPENDS:${PN} += "\
 	rsync \
 	sshpass \
 	strace \
-	trace-cmd \
 	valgrind \
 	vim \
 "

--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -115,6 +115,7 @@ RDEPENDS:${PN} = "\
 	salt-minion \
 	sysconfig-settings \
 	systemimageupdateinfo \
+	trace-cmd \
 	util-linux-sfdisk \
 	vlan \
 	zip \


### PR DESCRIPTION
### Summary of Changes
Moved `trace-cmd` from `packagegroup-ni-desirable` to `packagegroup-ni-runmode`.

604KB increase in BSI install size on disk.

### Justification
trace-cmd is required to be in BSI for LabVIEW tracing VIs.

WI: [AB#2958882](https://dev.azure.com/ni/DevCentral/_workitems/edit/2958882)

### Testing

- [x] Built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
- [x] Built BSI
- [x] Verified that BSI now contains `trace-cmd`.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
