### PR TITLE
Enable systemd services-nilrt

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -27,6 +27,7 @@ RDEPENDS:${PN} += "\
 	${@bb.utils.contains('MACHINE_FEATURES', 'keyboard', 'keymaps', '', d)} \
 	${@bb.utils.contains('INIT_MANAGER', 'systemd', 'systemd', 'sysvinit', d)} \
 	${@bb.utils.contains('INIT_MANAGER', 'systemd', 'systemd-nilrt', '', d)} \
+	${@bb.utils.contains('INIT_MANAGER', 'systemd', 'services-nilrt', 'initscripts-nilrt', d)} \
 	${@bb.utils.contains('INIT_MANAGER', 'sysvinit', 'eudev', '', d)} \
 	${@bb.utils.contains('INIT_MANAGER', 'systemd', 'niauth-workaround', '', d)} \
 	avahi-daemon \
@@ -54,7 +55,6 @@ RDEPENDS:${PN} += "\
 	gptfdisk \
 	init-ifupdown \
 	initscripts \
-	initscripts-nilrt \
 	iproute2 \
 	iptables \
 	kernel-modules \

--- a/recipes-core/packagegroups/packagegroup-ni-safemode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-safemode.bb
@@ -10,7 +10,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 inherit packagegroup
 
 RDEPENDS:${PN} = " \
-	initscripts-nilrt-safemode \
+	${@bb.utils.contains('INIT_MANAGER', 'systemd', 'services-nilrt-safemode', 'initscripts-nilrt-safemode', d)} \
 	e2fsprogs \
 	e2fsprogs-e2fsck \
 	e2fsprogs-mke2fs \

--- a/recipes-extended/procps/files/sysctl.conf
+++ b/recipes-extended/procps/files/sysctl.conf
@@ -36,3 +36,6 @@ fs.suid_dumpable=1
 #  >1 - bitmask of allowed sysrq functions
 #   (See https://www.kernel.org/doc/html/latest/admin-guide/sysrq.html)
 kernel.sysrq=1
+
+# Disable fs.protected_regular for proper nirtcfg functionality
+fs.protected_regular=0

--- a/recipes-ni/ni-netcfgutil/ni-netcfgutil.bb
+++ b/recipes-ni/ni-netcfgutil/ni-netcfgutil.bb
@@ -42,8 +42,8 @@ FILES:${PN} += "\
 
 RDEPENDS:${PN} += "\
 	${@bb.utils.contains('INIT_MANAGER', 'systemd', 'systemd-nilrt', '', d)} \
+	${@bb.utils.contains('INIT_MANAGER', 'systemd', 'services-nilrt', 'initscripts-nilrt', d)} \
 	bash \
 	initscripts \
-	initscripts-nilrt \
 	ni-utils \
 "

--- a/recipes-ni/services-nilrt/files/cleanvarcache.service
+++ b/recipes-ni/services-nilrt/files/cleanvarcache.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Clean /var/cache Directory
+ConditionPathIsDirectory=/var/cache
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStartPre=/bin/echo Cleaning up the /var/cache directory
+ExecStart=/bin/rm -rf /var/cache
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-ni/services-nilrt/files/firewall
+++ b/recipes-ni/services-nilrt/files/firewall
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Copyright (c) 2019 National Instruments.
+# All rights reserved.
+
+IPTABLES_CONF=/etc/sysconfig/iptables
+IP6TABLES_CONF=/etc/sysconfig/ip6tables
+
+has_errors=false
+
+# The VERBOSE setting in /etc/default/rcS is deliberately ignored: the existence
+# of a firewall or VPN configuration must always be logged to the console.
+
+report_permissions_failure () {
+	local files="$1"
+	local req="$2"
+
+	cat >&2 <<EOF
+ERROR: The following files/directories possess incorrect permissions:
+ERROR:
+EOF
+	for f in $files ; do
+		echo -n "ERROR: " >&2
+		ls -ld "$f" >&2
+	done
+
+	cat >&2 <<EOF
+ERROR:
+ERROR: Ensure that these files/directories are
+ERROR: $req.
+ERROR:
+ERROR: Because of these permissions issues, the firewall service will not run.
+EOF
+}
+
+# Check that firewall configs are only root writable
+check_permissions () {
+	local config_file="$1"
+
+	local files=$(find "$config_file" \! \( -user root \( \
+		\! -perm +022 -o \
+		-group root \! -perm +002 \) \))
+
+	if [ -n "$files" ] ; then
+		has_errors=true
+		report_permissions_failure "$files" "only writable by root"
+		false
+	fi
+}
+
+restore_config_ifexists () {
+	local tool_name="$1"
+	local config_file="$2"
+
+	if [ -f "$config_file" ]; then
+		if check_permissions "$config_file"; then
+			echo -n "Loading $tool_name firewall configuration '$config_file': "
+			$tool_name <"$config_file" && echo "DONE" || has_errors=true
+		fi
+	fi
+}
+
+clear_config () {
+	local tool_name="$1"
+
+	echo -n "Clearing $tool_name firewall configuration: "
+	$tool_name -P INPUT ACCEPT || has_errors=true
+	$tool_name -P FORWARD ACCEPT || has_errors=true
+	$tool_name -P OUTPUT ACCEPT || has_errors=true
+	$tool_name -F && echo "DONE" || has_errors=true
+}
+
+case "$1" in
+	start)
+		restore_config_ifexists "iptables-restore" "$IPTABLES_CONF"
+		restore_config_ifexists "ip6tables-restore" "$IP6TABLES_CONF"
+		;;
+
+	stop)
+		clear_config "ip6tables"
+		clear_config "iptables"
+		;;
+
+	*)
+		has_errors=true
+		echo "Usage: $0 {start|stop}" >&2
+		;;
+esac
+
+if "$has_errors"; then
+	exit 1
+fi

--- a/recipes-ni/services-nilrt/files/firewall.service
+++ b/recipes-ni/services-nilrt/files/firewall.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Firewall Service
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/lib/systemd/scripts/firewall start
+ExecStop=/lib/systemd/scripts/firewall stop
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-ni/services-nilrt/files/iso3166-translation.txt
+++ b/recipes-ni/services-nilrt/files/iso3166-translation.txt
@@ -1,0 +1,263 @@
+# This is a lookup table to convert between ISO 3166-1 codes for the user
+# setting of the device country code, and ISO 3166-1 alpha2 codes for the
+# purpose of setting the region for cfg80211. The format of this file is:
+#
+# <ISO3166-1numeric> <wireless-regdb alpha2> <actual alpha2> <comment>
+#
+# There are a number of countries that don't have info in wireless-regdb;
+# for those we always map to '00'. Not all of these are settable from the
+# UI, but we try to support as many as possible in case the UI adds stuff
+# in the future and the user downgrades their firmware. The 'comment' and
+# 'actual alpha2' fields are present for developer aid, in order to check
+# that this table is correct.
+
+-01 00 00 World
+004 00 AF Afganistan
+008 AL AL Albania
+010 00 AQ Antarctica
+012 DZ DZ Algeria
+016 00 AS American Samoa
+020 00 AD Andorra
+024 00 AO Angola
+028 00 AG Antigua and Barbuda
+031 AZ AZ Azerbaijan
+032 AR AR Argentina
+036 AU AU Australia
+040 AT AT Austria
+044 00 BS Bahamas
+048 BH BH Bahrain
+050 BD BD Bangladesh
+051 AM AM Armenia
+052 BB BB Barbados
+056 BE BE Belgium
+060 00 BM Bermuda
+064 00 BT Bhutan
+068 BO BO Bolivia
+070 BA BA Bosnia and Herzegovina
+072 00 BW Botswana
+074 00 BV Bouvet Island
+076 BR BR Brazil
+084 BZ BZ Belize
+086 00 IO British Indian Ocean Territory
+090 00 SB Solomon Islands
+092 00 VG Virgin Islands (British)
+096 BN BN Brunei Darussalam
+100 BG BG Bulgaria
+104 00 MM Myanmar
+108 00 BI Burundi
+112 BY BY Belarus
+116 KH KH Cambodia
+120 00 CM Cameroon
+124 CA CA Canada
+132 00 CV Cape Verde
+136 00 KY Cayman Islands
+140 00 CF Central African Republic
+144 LK LK Sri Lanka
+148 00 TD Chad
+152 CL CL Chile
+156 CN CN China
+158 TW TW Taiwan
+162 00 CX Christmas Island
+166 00 CC Cocos (Keeling) Islands
+170 CO CO Colombia
+174 00 KM Comoros
+175 00 YT Mayotte
+178 00 CG Congo
+180 00 CD Congo, the Democratic Republic of
+184 00 CK Cook Islands
+188 CR CR Costa Rica
+191 HR HR Croatia
+192 00 CU Cuba
+196 CY CY Cyprus
+203 CZ CZ Czech Republic
+204 00 BJ Benin
+208 DK DK Denmark
+212 00 DM Dominica
+214 DO DO Dominican Republic
+218 EC EC Ecuador
+222 SV SV El Salvador
+226 00 GQ Equatorial Guinea
+231 00 ET Ethiopia
+232 00 ER Eritrea
+233 EE EE Estonia
+234 00 FO Faroe Islands
+238 00 FK Falkland Islands
+239 00 GS South Georgia and the South Sandwich Islands
+242 00 FJ Fiji
+246 FI FI Finland
+248 00 AX Aaland Islands
+250 FR FR France
+254 00 GF French Guiana
+258 00 PF French Polynesia
+260 00 TF French Southern Territories
+262 00 DJ Djibouti
+266 00 GA Gabon
+268 GE GE Georgia
+270 00 GM Gambia
+275 00 PS Palestinian Territory, Occupied
+276 DE DE Germany
+288 00 GH Ghana
+292 00 GI Gibraltar
+296 00 KI Kiribati
+300 GR GR Greece
+304 GL GL Greenland
+308 GD GD Grenada
+312 00 GP Guadeloupe
+316 GU GU Guam
+320 GT GT Guatemala
+324 00 GN Guinea
+328 00 GY Guyana
+332 HT HT Haiti
+334 00 HM Heard Island and McDonald Islands
+336 00 VA Holy See (Vatican City State)
+340 HN HN Honduras
+344 HK HK Hong Kong
+348 HU HU Hungary
+352 IS IS Iceland
+356 IN IN India
+360 ID ID Indonesia
+364 IR IR Iran
+368 00 IQ Iraq
+372 IE IE Ireland
+376 IL IL Israel
+380 IT IT Italy
+384 00 CI Cote d'Ivoire
+388 JM JM Jamaica
+392 JP JP Japan
+398 KZ KZ Kazakhstan
+400 JO JO Jordan
+404 KE KE Kenya
+408 KP KP Korea, Democratic People's Republic of
+410 KR KR Korea, Republic of
+414 KW KW Kuwait
+417 00 KG Kyrgyzstan
+418 00 LA Lao People's Democratic Republic
+422 LB LB Lebanon
+426 00 LS Lesotho
+428 LV LV Latvia
+430 00 LR Liberia
+434 00 LY Libyan Arab Jamahiriya
+438 LI LI Liechtenstein
+440 LT LT Lithuania
+442 LU LU Luxembourg
+446 MO MO Macao
+450 00 MG Madagascar
+454 00 MW Malawi
+458 MY MY Malaysia
+462 00 MV Maldives
+466 00 ML Mali
+470 MT MT Malta
+474 00 MQ Martinique
+478 00 MR Mauritania
+480 00 MU Mauritius
+484 MX MX Mexico
+492 MC MC Monaco
+496 00 MN Mongolia
+498 00 MD Moldova, Republic of
+499 CS ME Montenegro
+500 00 MS Montserrat
+504 MA MA Morocco
+508 00 MZ Mozambique
+512 OM OM Oman
+516 00 NA Namibia
+520 00 NR Nauru
+524 NP NP Nepal
+528 NL NL Netherlands
+530 AN AN Netherlands Antilles
+531 00 CW Curacao
+533 AW AW Aruba
+534 00 SX Sint Maarten (Dutch)
+535 00 BQ Bonaire, Saint Eustatus and Saba
+540 00 NC New Caledonia
+548 00 VU Vanuatu
+554 NZ NZ New Zealand
+558 00 NI Nicaragua
+562 00 NE Niger
+566 00 NG Nigeria
+570 00 NU Niue
+574 00 NF Norfolk Island
+578 NO NO Norway
+580 00 MP Northern Mariana Islands
+581 00 UM United States Minor Outlying Islands
+583 00 FM Micronesia
+584 00 MH Marshall Islands
+585 00 PW Palau
+586 PK PK Pakistan
+591 PA PA Panama
+598 PG PG Papua New Guinea
+600 00 PY Paraguay
+604 PE PE Peru
+608 PH PH Philippines
+612 00 PN Pitcairn
+616 PL PL Poland
+620 PT PT Portugal
+624 00 GW Guinea-Bissau
+626 00 TL Timor-Leste
+630 PR PR Puerto Rico
+634 QA QA Quatar
+638 00 RE Reunion
+642 RO RO Romania
+643 RU RU Russian Federation
+646 00 RW Rwanda
+652 BL BL Saint Barthelemy
+654 00 SH Saint Helena, Ascension and Tristan da Cunha
+659 00 KN Saint Kitts and Nevis
+660 00 AI Anguilla
+662 00 LC Saint Lucia
+663 00 MF Saint Martin (French)
+666 00 PM Saint Pierre and Miquelon
+670 00 VC Saint Vincent and the Grenadines
+674 00 SM San Marino
+678 00 ST Sao Tome and Principe
+682 SA SA Saudi Arabia
+686 00 SN Senegal
+688 CS RS Serbia, Republic of
+690 00 SC Seychelles
+694 00 SL Sierra Leone
+702 SG SG Singapore
+703 SK SK Slovakia
+704 VN VN Viet Nam
+705 SI SI Slovenia
+706 00 SO Somalia
+710 ZA ZA South Africa
+716 ZW ZW Zimbabwe
+724 ES ES Spain
+732 00 EH Western Sahara
+736 00 SD Sudan
+740 00 SR Suriname
+744 00 SJ Svalbard and Jan Mayen
+748 00 SZ Swaziland
+752 SE SE Sweden
+756 CH CH Switzerland
+760 SY SY Syrian Arab Republic
+762 00 TJ Tajikistan
+764 TH TH Thailand
+768 00 TG Togo
+772 00 TK Tokelau
+776 00 TO Tonga
+780 TT TT Trinidad and Tobago
+784 AE AE Uinted Arab Emirates
+788 TN TN Tunisia
+792 TR TR Turkey
+795 00 TM Turkmenistan
+796 00 TC Turks and Caicos Islands
+798 00 TV Tuvalu
+800 00 UG Uganda
+804 UA UA Ukraine
+807 MK MK Macedonia
+818 EG EG Egype
+826 GB GB United Kingdom
+831 00 GG Guernsey
+832 00 JE Jersey
+833 00 IM Isle of Man
+834 00 TZ Tanzania
+840 US US United States
+850 00 VI Virgin Islands (US)
+854 00 BF Burkina Faso
+858 UY UY Uruguay
+860 UZ UZ Uzbekistan
+862 VE VE Venezuela
+876 00 WF Wallis and Futuna
+882 00 WS Samoa
+887 YE YE Yemen
+894 00 ZM Zambia

--- a/recipes-ni/services-nilrt/files/lvrt-cgroup
+++ b/recipes-ni/services-nilrt/files/lvrt-cgroup
@@ -1,0 +1,5 @@
+# This variable can be used to explicitly set the cgroup version used by LabVIEW
+# Real-Time cgroup related init scripts. A value of '0' leaves cgroups under OS
+# control.
+#
+# LVRT_CGROUP_VERSION=0

--- a/recipes-ni/services-nilrt/files/lvrt-cgroup.sh
+++ b/recipes-ni/services-nilrt/files/lvrt-cgroup.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+. /etc/default/lvrt-cgroup
+
+identify_lvrt_cgroup_version()
+{
+	# Return early if a version is already set
+	[ -z "$LVRT_CGROUP_VERSION" ] || return 0
+
+	# If lvrt is not installed set version to 0, cgroups not used
+	lvrt_installed=$(opkg list-installed ni-labview-realtime)
+	if [ -z "$lvrt_installed" ]; then
+		LVRT_CGROUP_VERSION=0
+		return 1
+	fi
+
+	# By default assume LabVIEW RT uses cgroups-v1 (current situation). This
+	# will be amended when LV cgroup-v2 upgrade is implemented.
+	LVRT_CGROUP_VERSION=1
+	return 0
+}

--- a/recipes-ni/services-nilrt/files/mountcompatibility
+++ b/recipes-ni/services-nilrt/files/mountcompatibility
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Mounts a "/C" and "/c" directory to support legacy
+# projects which may be dumping files here
+
+# Bail out on first error
+set -o errexit
+
+[ -d /c -a ! -L /c ] && rmdir /c
+ln -sf /mnt/userfs/c /
+
+[ -d /C -a ! -L /C ] && rmdir /C
+ln -sf /mnt/userfs/C /
+
+exit 0

--- a/recipes-ni/services-nilrt/files/mountcompatibility.service
+++ b/recipes-ni/services-nilrt/files/mountcompatibility.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Mount Compatibility Service
+DefaultDependencies=no
+After=local-fs.target
+ConditionPathExists=/etc/natinst/safemode
+
+[Service]
+Type=oneshot
+ExecStart=/lib/systemd/scripts/mountcompatibility
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-ni/services-nilrt/files/mountconfig
+++ b/recipes-ni/services-nilrt/files/mountconfig
@@ -1,0 +1,58 @@
+#!/bin/sh
+# Copyright (c) 2012-2013 National Instruments.
+# All rights reserved.
+
+partition_label="boot-config"
+volume_label="config"
+volume_number="3"
+mount_point="/etc/natinst/share"
+mount_args="-o sync"
+RESTORECON="/sbin/restorecon"
+
+if [ -e /etc/init.d/mountutils ] ; then
+    # include common utilities
+    . /etc/init.d/mountutils
+fi
+
+# Bail out on first error
+set -o errexit
+
+mount_config()
+{
+    # Don't mount if already mounted
+    if ! grep -q " $mount_point " /proc/self/mounts; then
+        if cat /sys/class/mtd/mtd*/name 2>/dev/null | grep -q ^$partition_label\$
+        then
+            # If an mtd partition has this partition label, use
+            # mount_ubi_volume
+            mount_ubi_volume "$partition_label" "$volume_label" \
+                "$volume_number" "$mount_point" "$mount_args"
+        elif grep -q "[ \\t]$mount_point[ \\t]" /etc/fstab
+        then
+            # If the mount point is in fstab, use that
+            mount $mount_point
+        else
+            echo "ERROR: Unable to mount config partition" >&2
+            exit 1
+        fi
+    fi
+
+    chown lvuser:ni $mount_point
+    chmod ug=rwx,o=rx $mount_point
+    [ -e ${RESTORECON} ] && ${RESTORECON} -R ${mount_point} || true
+}
+
+unmount_config()
+{
+    # Don't try to umount if not already mounted
+    if grep -q " $mount_point " /proc/self/mounts; then
+        umount $mount_point
+    fi
+}
+
+case "$1" in
+    start) mount_config;;
+    stop) unmount_config;;
+esac
+
+exit 0

--- a/recipes-ni/services-nilrt/files/mountconfig.service
+++ b/recipes-ni/services-nilrt/files/mountconfig.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Mount Config Partition
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/lib/systemd/scripts/mountconfig start
+ExecStop=/lib/systemd/scripts/mountconfig stop
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-ni/services-nilrt/files/mountuserfs
+++ b/recipes-ni/services-nilrt/files/mountuserfs
@@ -1,0 +1,110 @@
+#!/bin/sh
+
+partition_label="root"
+volume_label="rootfs"
+volume_number="0"
+userfs_mount_point="/mnt/userfs"
+shared_mount_point="/etc/natinst/share"
+volatile_mount_point="/var/volatile"
+var_natinst_dir="/var/local/natinst"
+webservices_dir="/var/local/natinst/webservices"
+
+if [ -e /etc/init.d/mountutils ] ; then
+	# include common utilities
+	. /etc/init.d/mountutils
+fi
+
+# Bail out on first error
+set -o errexit
+
+try_mount_bind () {
+	from_dir="$1"
+	to_dir="$2"
+	mkdir -p "$to_dir"
+	if ! mountpoint -q "$to_dir"; then
+		mount -o bind "$from_dir" "$to_dir" || return
+	fi
+}
+
+try_unmount_bind () {
+	dir="$1"
+	# Opening through symlinks doesn't lock the symlink-containing filesystem, and
+	# the symlink destination can (and does in the case of very old safemodes)
+	# symlink to places we don't want to unmount anyway. So skip symlinks.
+	if [ -L "$1" ]; then
+		echo "umount $1 skipped (symbolic link)." >&2
+		return
+	fi
+	while mountpoint -q "$dir"; do
+		umount "$dir" || return
+	done
+}
+
+mount_userfs()
+{
+	# Don't mount if already mounted
+	if ! mountpoint -q "$userfs_mount_point"; then
+		if cat /sys/class/mtd/mtd*/name 2>/dev/null | grep -q ^$partition_label\$
+		then
+			# If an mtd partition has this partition label, use
+			# mount_ubi_volume
+			mount_ubi_volume "$partition_label" "$volume_label" \
+				"$volume_number" "$userfs_mount_point"
+		elif grep -q "[ \\t]$mount_point[ \\t]" /etc/fstab
+		then
+			# If the mount point is in fstab, use that
+			mount $userfs_mount_point
+		else
+			echo "ERROR: Unable to mount userfs partition" >&2
+			exit 1
+		fi
+	fi
+
+	mkdir -p $userfs_mount_point/.syscfg-action
+	chown lvuser:ni $userfs_mount_point/.syscfg-action
+	chmod ug=rwx,o=rx $userfs_mount_point/.syscfg-action
+
+	# bind shared mount point
+	try_mount_bind $shared_mount_point $userfs_mount_point$shared_mount_point
+	try_mount_bind $volatile_mount_point $userfs_mount_point$volatile_mount_point
+
+	# bind /boot, /proc, /dev, /run and /sys into userfs
+	try_mount_bind /boot $userfs_mount_point/boot
+	try_mount_bind /proc $userfs_mount_point/proc
+	try_mount_bind /dev $userfs_mount_point/dev
+	try_mount_bind /run $userfs_mount_point/run
+	try_mount_bind /sys $userfs_mount_point/sys
+
+	# Create the webservices folder in runmode and modify its permissions
+	mkdir -p $userfs_mount_point$webservices_dir/temp
+	chown lvuser:ni $userfs_mount_point$var_natinst_dir
+	chmod g+w,u+w $userfs_mount_point$var_natinst_dir
+	chown webserv:ni $userfs_mount_point$webservices_dir
+	chmod 700 $userfs_mount_point$webservices_dir
+	chown webserv:root $userfs_mount_point$webservices_dir/temp
+	chmod 700 $userfs_mount_point$webservices_dir/temp
+	if [ -d $webservices_dir ]; then
+		# this won't exist in restore mode and that's okay, otherwise,
+		# make safemode's webservices temp dir point to runmode
+		ln -sf $userfs_mount_point$webservices_dir/temp $webservices_dir/temp
+	fi
+}
+
+unmount_userfs()
+{
+	try_unmount_bind $userfs_mount_point/dev || return
+	try_unmount_bind $userfs_mount_point/proc || return
+	try_unmount_bind $userfs_mount_point/run || return
+	try_unmount_bind $userfs_mount_point/sys || return
+	try_unmount_bind $userfs_mount_point/boot || return
+	try_unmount_bind $userfs_mount_point$volatile_mount_point || return
+	try_unmount_bind $userfs_mount_point$shared_mount_point || return
+	try_unmount_bind $userfs_mount_point || return
+}
+
+case "$1" in
+	start) mount_userfs || exit ;;
+	stop) unmount_userfs || exit ;;
+esac
+
+exit 0

--- a/recipes-ni/services-nilrt/files/mountuserfs.service
+++ b/recipes-ni/services-nilrt/files/mountuserfs.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Mount User Filesystem Service
+DefaultDependencies=no
+After=local-fs.target
+ConditionPathExists=/etc/natinst/safemode
+
+[Service]
+Type=oneshot
+ExecStart=/lib/systemd/scripts/mountuserfs start
+ExecStop=/lib/systemd/scripts/mountuserfs stop
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-ni/services-nilrt/files/nicheckbiosconfig
+++ b/recipes-ni/services-nilrt/files/nicheckbiosconfig
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Copyright (c) 2015 National Instruments.
+# All rights reserved.
+#
+# This script is designed to verify that the BIOS has correctly configured
+# the system hardware for deterministic performance by checking the
+# IsNILinuxRTBoot flag from the NIOSSharedData EFI variable.
+#
+# If the IsNILinuxRTBoot flag is not set, set it now and reboot to allow
+# the BIOS to configure the system.
+SCRIPTNAME="${0##*/}"
+REBOOT_ATTEMPT_FILE=/var/lib/nicheckbiosflag
+
+# If variable does not exist, we are not on NI hardware,
+# so do nothing to automatically configure the system.
+if RT_BIOS_CONFIG=$(/sbin/fw_printenv -n IsNILinuxRTBoot 2> /dev/null); then
+	if [ $RT_BIOS_CONFIG -eq 0 ]; then
+		# We are on NI hardware, but it is not configured.
+		if [ ! -e $REBOOT_ATTEMPT_FILE ]; then
+			fw_setenv IsNILinuxRTBoot 1
+			touch $REBOOT_ATTEMPT_FILE
+			logger -s -t $SCRIPTNAME "Rebooting system to finish configuring for maximum determinism."
+			sleep 5
+			reboot
+		else
+			# Give up; we can't set the variable
+			# Do not delete REBOOT_ATTEMPT_FILE, to
+			# avoid a double reboot on every boot.
+			logger -s -t $SCRIPTNAME "Warning, system cannot be configured for maximum determinism."
+		fi
+	else
+		# System was correctly configured; delete the
+		# file to allow a future configuration attempt.
+		rm -f $REBOOT_ATTEMPT_FILE
+	fi
+fi

--- a/recipes-ni/services-nilrt/files/nicheckbiosconfig.service
+++ b/recipes-ni/services-nilrt/files/nicheckbiosconfig.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=NI Checkout BIOS Config
+After=multi-user.target
+
+[Service]
+Type=oneshot
+ExecStart=/lib/systemd/scripts/nicheckbiosconfig
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-ni/services-nilrt/files/nicleanefivars.service
+++ b/recipes-ni/services-nilrt/files/nicleanefivars.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Clean old EFI-pstore information
+DefaultDependencies=no
+Before=sysinit.target
+ConditionPathExists=/sys/firmware/efi/efivars
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c '\
+  EFI_CRASH_CLEANUP=y; \
+  [ -r /etc/default/nicleanefivars ] && . /etc/default/nicleanefivars; \
+  case "$EFI_CRASH_CLEANUP" in \
+    [Nn]*) exit 0 ;; \
+  esac; \
+  LINUX_EFI_CRASH_GUID="cfc8fc79-be2e-4ddc-97f0-9f98bfe298a0"; \
+  find /sys/firmware/efi/efivars -name "*-${LINUX_EFI_CRASH_GUID}" -exec /bin/rm {} +; \
+'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=sysinit.target

--- a/recipes-ni/services-nilrt/files/nicleanstalelinks.service
+++ b/recipes-ni/services-nilrt/files/nicleanstalelinks.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Clean up stale compatibility symlinks for hot-plugged mass storage devices
+DefaultDependencies=no
+Before=sysinit.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c '\
+  for symlink in u v w x y z U V W X Y Z; do \
+    if [ -h "/$symlink" ]; then \
+      symlink_target=$(readlink /$symlink); \
+      if [ ! -e "$symlink_target" ]; then \
+        rm "/$symlink"; \
+      else \
+        grep -q -F "$symlink_target" /proc/mounts || rm "/$symlink"; \
+      fi; \
+    fi; \
+  done; \
+'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=sysinit.target

--- a/recipes-ni/services-nilrt/files/niconfiguretracefs
+++ b/recipes-ni/services-nilrt/files/niconfiguretracefs
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Copyright (c) 2012-2025 National Instruments.
+# All rights reserved.
+
+debugfs_path="/sys/kernel/debug"
+tracefs_path="/sys/kernel/debug/tracing"
+
+# Change the permissions so lvrt user can control ftrace
+chmod a+rx $debugfs_path
+chown -R lvuser $tracefs_path

--- a/recipes-ni/services-nilrt/files/niconfiguretracefs.service
+++ b/recipes-ni/services-nilrt/files/niconfiguretracefs.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Configure Tracefs
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/lib/systemd/scripts/niconfiguretracefs
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-ni/services-nilrt/files/nicreatecpuacctgroups
+++ b/recipes-ni/services-nilrt/files/nicreatecpuacctgroups
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Copyright (c) 2012-2023 National Instruments.
+# All rights reserved.
+
+# Exit early if LabVIEW RT does not use cgroup-v1
+. /usr/share/services-nilrt/lvrt-cgroup.sh
+identify_lvrt_cgroup_version || exit 0
+[ "$LVRT_CGROUP_VERSION" -eq 1 ] || exit 0
+
+#echo -n "Creating cgroups for CPU accounting for National Instruments LabVIEW Real-Time:"
+[ "${VERBOSE}" != "no" ] && echo -n "Starting nicreatecpuacctgroups:"
+mkdir -p /dev/cgroup/cpuacct
+mount -t cgroup -ocpuacct none /dev/cgroup/cpuacct
+cd /dev/cgroup/cpuacct
+mkdir LabVIEW_Timed-Structures_group
+mkdir LabVIEW_Time-Critical_group
+mkdir ISR_group
+mkdir other_group
+
+# fast_task_writes was added to 3.2 for performance reasons, but does not exist and is not
+# necessary in the 3.10 kernel. 
+[ -e ./other_group/cgroup.fast_task_writes ] && echo 1 > ./other_group/cgroup.fast_task_writes
+while read TASK
+do
+	echo $TASK > "./other_group/tasks" 2> /dev/null 
+	# cgroup behavior as of 3.10 kernel has been altered 
+	# such that certain tasks cannot be assigned to any cgroup.
+	# Because of this change an error for trying to assign those
+	# tasks can be ignored in this loop and the following loop. 
+done < "tasks"
+[ -e ./other_group/cgroup.fast_task_writes ] && echo 0 > ./other_group/cgroup.fast_task_writes
+
+#If we cannot move a task from the root cpuset, that task is softirq
+# or realted to system timer task
+[ -e ./ISR_group/cgroup.fast_task_writes ] && echo 1 > ./ISR_group/cgroup.fast_task_writes
+while read TASK
+do
+	echo $TASK > "./ISR_group/tasks" 2> /dev/null
+done < "/dev/cgroup/cpuset/tasks"
+[ -e ./ISR_group/cgroup.fast_task_writes ] && echo 0 > ./ISR_group/cgroup.fast_task_writes
+chown -R lvuser:ni /dev/cgroup/cpuacct
+[ "${VERBOSE}" != "no" ] && echo "done"

--- a/recipes-ni/services-nilrt/files/nicreatecpuacctgroups.service
+++ b/recipes-ni/services-nilrt/files/nicreatecpuacctgroups.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Create cgroups for CPU accounting for National Instruments LabVIEW Real-Time
+DefaultDependencies=no
+After=multi-user.target
+
+[Service]
+Type=oneshot
+ExecStart=/lib/systemd/scripts/nicreatecpuacctgroups
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-ni/services-nilrt/files/nicreatecpusets
+++ b/recipes-ni/services-nilrt/files/nicreatecpusets
@@ -1,0 +1,44 @@
+#!/bin/sh
+# Copyright (c) 2012-2023 National Instruments.
+# All rights reserved.
+
+# Exit early if LabVIEW RT does not use cgroup-v1
+. /usr/share/services-nilrt/lvrt-cgroup.sh
+identify_lvrt_cgroup_version || exit 0
+[ "$LVRT_CGROUP_VERSION" -eq 1 ] || exit 0
+
+#echo -n "Creating CPU sets for National Instruments LabVIEW Real-Time:"
+[ "${VERBOSE}" != "no" ] && echo -n "Starting nicreatecpusets:"
+mkdir -p /dev/cgroup/cpuset
+mount -t cpuset none /dev/cgroup/cpuset
+cd /dev/cgroup/cpuset
+
+mkdir LabVIEW_ScanEngine_set
+mkdir LabVIEW_tl_set
+mkdir system_set
+
+#cpus and mems cannot be empty while tasks are added to tasks file
+#in a cpuset
+cat cpus > ./system_set/cpus
+cat mems > ./system_set/mems
+
+cat cpus > ./LabVIEW_tl_set/cpus
+cat mems > ./LabVIEW_tl_set/mems
+
+cat cpus > ./LabVIEW_ScanEngine_set/cpus
+cat mems > ./LabVIEW_ScanEngine_set/mems
+
+# fast_task_writes was added to 3.2 for performance reasons, but does not exist and is not
+# necessary in the 3.10 kernel. 
+[ -e ./system_set/cgroup.fast_task_writes ] && echo 1 > ./system_set/cgroup.fast_task_writes
+while read TASK
+do
+	echo $TASK > "./system_set/tasks" 2> /dev/null
+	# Following system tasks are specifically affined to run on a core
+	# and cannot be moved. So, the above line does thrown
+	# an error for these tasks and those can be ignored.
+	# kworker|ksoftirqd|posixcputmr|migration
+done < "tasks"
+[ -e ./system_set/cgroup.fast_task_writes ] && echo 0 > ./system_set/cgroup.fast_task_writes
+chown -R lvuser:ni /dev/cgroup/cpuset
+[ "${VERBOSE}" != "no" ] && echo "done"

--- a/recipes-ni/services-nilrt/files/nicreatecpusets.service
+++ b/recipes-ni/services-nilrt/files/nicreatecpusets.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Create cpusets for National Instruments LabVIEW Real-Time
+After=multi-user.target
+
+[Service]
+Type=oneshot
+ExecStart=/lib/systemd/scripts/nicreatecpusets
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-ni/services-nilrt/files/nidisablecstates.service
+++ b/recipes-ni/services-nilrt/files/nidisablecstates.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=For x86_64 architectures, disable all c_states except for C0 (state0) in all CPU cores
+DefaultDependencies=no
+Before=multi-user.target sysinit.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c '\
+  shopt -s nullglob; \
+  for CSTATE_DISABLE in /sys/devices/system/cpu/cpu*/cpuidle/state[^0]/disable; do \
+    echo 1 > $CSTATE_DISABLE; \
+  done; \
+'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target sysinit.target

--- a/recipes-ni/services-nilrt/files/nipopulateconfigdir.service
+++ b/recipes-ni/services-nilrt/files/nipopulateconfigdir.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Populate NILRT runtime config files
+DefaultDependencies=no
+Before=sysinit.target
+ConditionPathIsDirectory=/etc/populateconfig.d
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c '\
+  for i in /etc/populateconfig.d/*.sh; do \
+    [ -x "$i" ] && "$i"; \
+  done; \
+'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=sysinit.target

--- a/recipes-ni/services-nilrt/files/nisafemodereason
+++ b/recipes-ni/services-nilrt/files/nisafemodereason
@@ -1,0 +1,108 @@
+#!/bin/sh
+
+REASON_FILE=/etc/natinst/share/safemode_reason
+SYSTEM_STATE_FILE=/tmp/ni_system_state
+CONFIG_OLD=/etc/natinst/share/config.old
+CONFIG_CDF=/etc/natinst/share/config.cdf
+STATUS_LED=/usr/bin/status_led
+RESTOREMODE_FLAG=/etc/natinst/restoremode
+SMBIOS_HELPER=/usr/share/nisysinfo/smbios_helper
+
+arch=`uname -m`
+if [ "$arch" = "armv7l" ]; then
+	RESET_SOURCE_LOCATION=/sys/bus/i2c/devices/0-0040/reset_source
+elif [ "$arch" = "x86_64" ]; then
+	RESET_SOURCE_LOCATION=/dev/nirtfeatures/reset_source
+fi
+
+if [ -f $RESTOREMODE_FLAG ]; then
+	MODE=Restore
+else
+	MODE=Safe
+fi
+
+# known reasons
+IMPROPER="$MODE Mode (Improper Installation)"
+NO_SW="$MODE Mode (No Software Installed)"
+DIRECTED="$MODE Mode (User Directed)"
+SW_ERROR="$MODE Mode (Software Error)"
+INSTALL="Install Mode"
+
+# switch LED watchdog from boot mode to user mode, and turn off the LED
+$STATUS_LED init
+
+if [ -r $REASON_FILE -a -s $REASON_FILE ]; then
+	read REASON < $REASON_FILE
+	rm $REASON_FILE
+else
+	# previous boot didn't leave us a breadcrumb, try to figure it out
+	if [ -r $RESET_SOURCE_LOCATION ]; then
+		read RESET_SOURCE < $RESET_SOURCE_LOCATION 2>/dev/null
+	elif [ -r $SMBIOS_HELPER ]; then
+	# Try to determine from SMBIOS
+		source $SMBIOS_HELPER
+		if is_ni_device; then
+			if get_forced_safemode; then
+				RESET_SOURCE="button"
+			fi
+		fi
+	fi
+
+	if [ "$RESET_SOURCE" == "button" ]; then
+		REASON=$DIRECTED
+	elif [ -s $CONFIG_OLD ]; then
+		# non-empty config.old means an install failed
+		REASON=$IMPROPER
+	else
+		if [ -s $CONFIG_CDF ]; then
+			# no config.old, non-empty config.cdf --
+			# maybe this was user-directed (see below),
+			# but if not, something's wrong
+			REASON=$SW_ERROR
+		else
+			# missing/empty config.cdf means no software installed
+			REASON=$NO_SW
+		fi
+	fi
+fi
+
+arch=`uname -m`
+
+if [ "$arch" = "armv7l" ]; then
+	dip_enable_path=/sys/bus/i2c/devices/0-0040/safe_mode
+elif [ "$arch" = "x86_64" ]; then
+	dip_enable_path=/sys/bus/acpi/devices/NIC775D\:00/safe_mode
+fi
+
+if [ ! -z $dip_enable_path -a -f $dip_enable_path ]; then
+	dip_enable=`head -n1 $dip_enable_path`
+else
+	dip_enable=0
+fi
+
+if [ $dip_enable -eq 1 ]; then
+	# DIP/HW switch overrides
+	REASON=$DIRECTED
+fi
+
+enable=`/usr/local/natinst/bin/nirtcfg --get section=SystemSettings,token=SafeMode.enabled,value="true" |tr "[:upper:]" "[:lower:]"`
+if [ "$enable" != "false" ]; then
+	# DIP switch overrides any other reason we might be here
+	REASON=$DIRECTED
+fi
+
+echo "System state:" $REASON
+echo $REASON > $SYSTEM_STATE_FILE
+case $REASON in
+  $IMPROPER|$NO_SW)
+	$STATUS_LED blink_count 2
+	;;
+  $INSTALL|$DIRECTED|*)
+	$STATUS_LED blink_count 3
+	;;
+  $SW_ERROR)
+	# this is normally a run-mode error (LabVIEW crashed repeatedly),
+	# in safe mode it essentially means we don't know why we're here
+	$STATUS_LED blink_count 4
+	;;
+esac

--- a/recipes-ni/services-nilrt/files/nisafemodereason.service
+++ b/recipes-ni/services-nilrt/files/nisafemodereason.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Compute the reason for being in safe mode
+DefaultDependencies=no
+After=local-fs.target
+ConditionPathExists=/etc/natinst/safemode
+
+[Service]
+Type=oneshot
+ExecStart=/lib/systemd/scripts/nisafemodereason
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-ni/services-nilrt/files/niselectnetnaming
+++ b/recipes-ni/services-nilrt/files/niselectnetnaming
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# On safe-mode only, and on every boot, detect the target and select the net device naming scheme.
+
+class="`/sbin/fw_printenv -n TargetClass`"
+
+# Use persistent names on PXI, not on any other targets
+[ "$class" = "PXI" ] || touch /etc/udev/rules.d/80-net-name-slot.rules
+

--- a/recipes-ni/services-nilrt/files/niselectnetnaming.service
+++ b/recipes-ni/services-nilrt/files/niselectnetnaming.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Select Network Device Naming Scheme
+DefaultDependencies=no
+After=local-fs.target
+ConditionPathExists=/etc/natinst/safemode
+
+[Service]
+Type=oneshot
+ExecStart=/lib/systemd/scripts/niselectnetnaming
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-ni/services-nilrt/files/nisetcommitratio
+++ b/recipes-ni/services-nilrt/files/nisetcommitratio
@@ -1,0 +1,153 @@
+#!/bin/sh
+
+# Suppose that your driver kmallocs lots of memory. overcommit_ratio needs to be
+# adjusted to avoid OOMs under overcommit_memory=2. Doing so is the purpose of
+# this initscript.
+#
+# Instructions: your driver package should install a file under
+# /etc/memreserve.d/. Each line should contain either a number representing
+# estimated kernelspace memory allocations in megabytes, or a comment (starting
+# with #). Syntax errors are silently ignored.
+#
+# This script sets the overcommit ratio for the system. The value set is the
+# calculated number. If there is an error nothing is set. Reserved memory is
+# specified in /etc/natinst/share/ni-rt.ini in the RtLinuxMemReserve section.
+
+set -e
+SCRIPTNAME="${0##*/}"
+SYSCTL_OVERCOMMIT_KEY="vm.overcommit_ratio"
+
+: ${MEMRESERVE_DIR:=/etc/memreserve.d}
+
+SYSTEM_MEMORY=0
+RESERVED_TOTAL=0
+COMMIT_RATIO=0
+
+log()
+{
+   { [ "${VERBOSE}" != "no" ] && echo "$SCRIPTNAME: $1"; } || true
+}
+
+get_memreserve_kb () {
+   # Don't execute the `cat | awk` unless at least one file exists
+   for f in "$MEMRESERVE_DIR"/*; do
+      [ -f "$f" ] || break
+      # Grep for all lines containing only a single natural number,
+      # sum them together, and convert to KB
+      cat "$MEMRESERVE_DIR"/* | awk \
+         '/^[[:space:]]*[[:digit:]]+[[:space:]]*$/ {s+=$1} END {print s*1024}'
+      return 0
+   done
+   echo 0
+}
+
+get_total_memory_reserved()
+{
+   local list element mem
+   local cmd="/usr/local/natinst/bin/nirtcfg --list"
+   local cmd_tr="/usr/bin/tr '[:upper:]' '[:lower:]'"
+   local reserved=false
+
+   list=$($cmd | $cmd_tr)
+   if [ "$list" ]; then
+      for element in $list; do
+         case $element in
+            *"[rtlinuxmemreserve]"*)
+               mem="${element#*=}"
+               mem=$((mem*1024))
+               RESERVED_TOTAL=$((RESERVED_TOTAL+mem))
+               reserved=true
+            ;;
+         esac
+      done
+   else
+      log "Unable to get valid output from $cmd"
+   fi
+
+   # Also look for reservations in the memreserve location
+   RESERVED_TOTAL=$((RESERVED_TOTAL + `get_memreserve_kb`))
+
+   if $reserved; then
+      log "NI reserved memory: $RESERVED_TOTAL"
+      return 0
+   else
+      log "No NI reserved memory, using system default"
+      return 1
+   fi
+}
+
+get_memory_total()
+{
+   if SYSTEM_MEMORY=$(awk '/MemTotal/{print $2}' /proc/meminfo); then
+      log "Total system memory: $SYSTEM_MEMORY"
+   else
+      log "Failed to get system memory."
+   fi
+}
+
+calculate_commit_ratio()
+{
+   local unreserved percentage
+   # Get the unreserved amount of memory
+   if ! unreserved=$((SYSTEM_MEMORY - RESERVED_TOTAL)); then
+       log "Failed to calculate unreserved memory"
+   fi
+
+   # Get the commit percentage (unreserved/total memory)*100
+   if ! percentage=$(awk -v x=$unreserved -v y=$SYSTEM_MEMORY \
+                      'BEGIN {print ((x/y)*100)}'); then
+       log "Failed to calculate commit ratio"
+   fi
+
+   # Floor the percentage
+   COMMIT_RATIO=${percentage%.*}
+   log "Calculated commit ratio: $COMMIT_RATIO"
+}
+
+write_commit_ratio()
+{
+   validate_commit_ratio
+   sysctl -w $SYSCTL_OVERCOMMIT_KEY=$COMMIT_RATIO
+   log "Wrote $SYSCTL_OVERCOMMIT_KEY=$COMMIT_RATIO"
+}
+
+validate_commit_ratio()
+{
+   if [ "$COMMIT_RATIO" -le 0 ]; then
+      log "Calculated bad commit ratio '$COMMIT_RATIO'. Leaving system default."
+      return 1
+   fi
+   return 0
+}
+
+do_start()
+{
+   get_total_memory_reserved
+   get_memory_total
+   calculate_commit_ratio
+   write_commit_ratio
+}
+
+do_status()
+{
+   set +e
+   get_total_memory_reserved
+   get_memory_total
+   calculate_commit_ratio
+   local actual=$(sysctl $SYSCTL_OVERCOMMIT_KEY)
+   log "Actual $actual"
+   set -e
+}
+
+case "$1" in
+  start)
+   do_start
+   ;;
+  status)
+   do_status
+   ;;
+  *)
+   echo "Usage: $0 {start|status}" >&2
+   exit 3
+   ;;
+esac

--- a/recipes-ni/services-nilrt/files/nisetcommitratio.service
+++ b/recipes-ni/services-nilrt/files/nisetcommitratio.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Set overcommit ratio for National Instruments LabVIEW Real-Time
+DefaultDependencies=no
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/lib/systemd/scripts/nisetcommitratio start
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-ni/services-nilrt/files/nisetreboottype
+++ b/recipes-ni/services-nilrt/files/nisetreboottype
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# The purpose of this script is to set the reboot type of the controller based
+# on the value of ni_boot_mode_input. Reboots to install mode require a cold
+# reboot. All other modes should use the default reboot type
+
+NI_REQUESTED_REBOOT_TYPE_FILE=/sys/kernel/ni_requested_reboot_type
+BOOT_MODE_INPUT=/tmp/ni_boot_mode_input
+
+# If we're on cRIO and booting to install mode, request a cold reboot
+if [ "`/sbin/fw_printenv -n TargetClass`" = "cRIO" ]; then
+	if [ -f $NI_REQUESTED_REBOOT_TYPE_FILE ]; then
+		if [ -f $BOOT_MODE_INPUT ]; then
+			read NEXT_BOOT_MODE < $BOOT_MODE_INPUT
+			if [ -n "$NEXT_BOOT_MODE" ]; then
+				case "$NEXT_BOOT_MODE" in
+				install)
+					echo 1 > $NI_REQUESTED_REBOOT_TYPE_FILE
+					;;
+				esac
+			fi
+		fi
+	fi
+fi

--- a/recipes-ni/services-nilrt/files/nisetreboottype.service
+++ b/recipes-ni/services-nilrt/files/nisetreboottype.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Set reboot type for National Instruments controllers
+DefaultDependencies=no
+Before=reboot.target
+
+[Service]
+Type=oneshot
+ExecStop=/lib/systemd/scripts/nisetreboottype
+RemainAfterExit=yes
+
+[Install]
+WantedBy=reboot.target

--- a/recipes-ni/services-nilrt/files/nisetupkernelconfig
+++ b/recipes-ni/services-nilrt/files/nisetupkernelconfig
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Copyright (c) 2012-2013 National Instruments.
+# All rights reserved.
+[ "${VERBOSE}" != "no" ] && echo -n "Starting nisetupkernelconfig:"
+
+#Create core dump files in the root directory of runmode with the
+#executable name as the suffix.
+safemodeflag=/etc/natinst/safemode
+if [ -f $safemodeflag ]; then
+  if [ ! -d /mnt/userfs/var/local/natinst/log ]; then
+    mkdir -p /mnt/userfs/var/local/natinst/log
+  fi
+  echo "/mnt/userfs/var/local/natinst/log/core_dump.%E" > /proc/sys/kernel/core_pattern
+else
+  echo "/var/local/natinst/log/core_dump.%E" > /proc/sys/kernel/core_pattern
+fi
+
+#Enable core dump for tainted binaries
+echo 1 > /proc/sys/fs/suid_dumpable
+
+#This disables RT scheduler's CPU throttling for National Instruments LabVIEW Real-Time
+echo -1 > /proc/sys/kernel/sched_rt_runtime_us
+
+#This forces CPU affinity of IRQs to Core-0. Some reserved IRQs and specific IRQs
+#such as timer-watch-dog (twd) are per core and their affinity cannot be changed
+#and thus we ignore the errors on those by redirecting error to /dev/null.
+#Note: smp_affinity file accepts CPU mask
+echo 1 > /proc/irq/default_smp_affinity
+for x in /proc/irq/*/smp_affinity;
+do
+  echo 1 > $x
+done 2> /dev/null
+
+# Set affinity for running IRQ threads to Core-0 immediately.
+# Setting /proc/irq/default_smp_affinity and /proc/irq/*/smp_affinity as done above will
+# eventually cause the kernel to change the affinity for these threads automatically, but
+# not until the next time those threads are scheduled. We want to remove the possibility
+# of that happening during jitter-sensitive code in a user application.
+PIDS=`grep -l irq/ /proc/*/comm 2>/dev/null | cut -d/ -f3`
+if [ -z "$PIDS" ] ; then
+  echo $0: Warning: No IRQ threads found.
+  exit 0
+fi
+echo $PIDS | xargs -n1 taskset -p 1 >/dev/null 2>&1
+
+[ "${VERBOSE}" != "no" ] && echo "done"

--- a/recipes-ni/services-nilrt/files/nisetupkernelconfig.service
+++ b/recipes-ni/services-nilrt/files/nisetupkernelconfig.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Setup kernel configuration for National Instruments LabVIEW Real-Time
+After=multi-user.target
+
+[Service]
+Type=oneshot
+ExecStart=/lib/systemd/scripts/nisetupkernelconfig
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-ni/services-nilrt/files/populateconfig
+++ b/recipes-ni/services-nilrt/files/populateconfig
@@ -1,0 +1,100 @@
+#!/bin/sh
+# Copyright (c) 2012-2013 National Instruments.
+# All rights reserved.
+
+#check if the system is in reset state
+reset_state=`/sbin/fw_printenv -n sys_reset 2>&1`
+if [ "$reset_state" = "true" -o "$sys_reset" = "true" ]; then
+   #restore default environmnet vars
+   cp -fp /boot/grub/grubenv.bak /boot/grub/grubenv
+   chown root:ni /boot/grub/grubenv
+   chmod 664 /boot/grub/grubenv
+   /usr/local/natinst/bin/niresetip
+fi
+
+if [ -x /usr/local/natinst/bin/nirtcfg ]; then
+   [ "${VERBOSE}" != "no" ] && echo "Migrating bootloader env into ni-rt.ini"
+   /usr/local/natinst/bin/nirtcfg --migrate
+
+   # If IPReset.enabled was true on boot, the ip reset functionality is complete and need not stay set
+   IPRESET=`/usr/local/natinst/bin/nirtcfg --get section=SystemSettings,token="IPReset.enabled",value=false | tr "[:upper:]" "[:lower:]"`
+   if [ $IPRESET != "false" ]; then
+      /usr/local/natinst/bin/nirtcfg --set section=SystemSettings,token="IPReset.enabled",value=false
+   fi
+fi
+
+mkdir -p /etc/natinst/share/ssh
+chmod -t /etc/natinst/share
+test -L /etc/natinst/share/localtime || ( rm -f /etc/natinst/share/localtime && ln -s /usr/share/zoneinfo/UTC /etc/natinst/share/localtime )
+
+# Ensure that /etc/natinst/share/timestamp exists and that /etc/timestamp symlinks to it.
+LCLTIMESTAMP="/etc/timestamp"
+SHAREDTIMESTAMP="/etc/natinst/share/timestamp"
+if [ -f $LCLTIMESTAMP ]; then
+   # If /etc/natinst/share/timestamp doesn't exist, use /etc/timestamp to create it
+   if [ ! -e $SHAREDTIMESTAMP ]; then
+      mv $LCLTIMESTAMP $SHAREDTIMESTAMP
+   fi
+elif [ ! -e $SHAREDTIMESTAMP ]; then
+   touch $SHAREDTIMESTAMP
+fi
+
+ln -sf $SHAREDTIMESTAMP $LCLTIMESTAMP
+
+# BEGIN: Populate the certstore.
+#
+# IMPORTANT NOTE: Changes to any code in this section may require
+#  updating the "postinst" scripts of the noted components.
+
+# nisslinit
+mkdir -p "/etc/natinst/share/certstore"
+mkdir -p "/etc/natinst/share/certstore/open_csrs"
+mkdir -p "/etc/natinst/share/certstore/server_certs"
+mkdir -p "/etc/natinst/share/certstore/temp"
+
+if [ ! -x /var/local/natinst/certstore ] && [ -d /var/local/natinst ]; then
+   ln -sf -T /etc/natinst/share/certstore /var/local/natinst/certstore
+fi
+
+chown root:root "/etc/natinst/share/certstore"
+chmod 755 "/etc/natinst/share/certstore"
+
+chown webserv:root "/etc/natinst/share/certstore/open_csrs"
+chmod 700 "/etc/natinst/share/certstore/open_csrs"
+
+chown webserv:niwscerts "/etc/natinst/share/certstore/server_certs"
+chmod 750 "/etc/natinst/share/certstore/server_certs"
+
+chown webserv:root "/etc/natinst/share/certstore/temp"
+chmod 700 "/etc/natinst/share/certstore/temp"
+
+touch "/etc/natinst/share/certstore/nexthandle.dat"
+chown webserv:root "/etc/natinst/share/certstore/nexthandle.dat"
+chmod 600 "/etc/natinst/share/certstore/nexthandle.dat"
+
+# wireless certificates
+mkdir -p "/etc/natinst/share/certstore/wireless/trusted"
+mkdir -p "/etc/natinst/share/certstore/wireless/pac"
+mkdir -p "/etc/natinst/share/certstore/wireless/client"
+
+chown webserv:root "/etc/natinst/share/certstore/wireless"
+chmod 700 "/etc/natinst/share/certstore/wireless"
+
+chown webserv:root "/etc/natinst/share/certstore/wireless/trusted"
+chmod 700 "/etc/natinst/share/certstore/wireless/trusted"
+
+chown webserv:root "/etc/natinst/share/certstore/wireless/pac"
+chmod 700 "/etc/natinst/share/certstore/wireless/pac"
+
+chown webserv:root "/etc/natinst/share/certstore/wireless/client"
+chmod 700 "/etc/natinst/share/certstore/wireless/client"
+
+#default wireless configuration
+/etc/network/wpa_supplicant_conf
+
+# ws_core
+touch /etc/natinst/share/certstore/wsapi.key
+chown webserv:niwscerts /etc/natinst/share/certstore/wsapi.key
+chmod 640 /etc/natinst/share/certstore/wsapi.key
+
+# END: Populate the certstore.

--- a/recipes-ni/services-nilrt/files/populateconfig.service
+++ b/recipes-ni/services-nilrt/files/populateconfig.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Populate configuration for National Instruments LabVIEW Real-Time
+DefaultDependencies=no
+Before=sysinit.target halt.target reboot.target
+
+[Service]
+Type=oneshot
+ExecStart=/lib/systemd/scripts/populateconfig start
+RemainAfterExit=yes
+
+[Install]
+WantedBy=sysinit.target halt.target reboot.target

--- a/recipes-ni/services-nilrt/files/wirelesssetdomain
+++ b/recipes-ni/services-nilrt/files/wirelesssetdomain
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+[ "${VERBOSE}" != "no" ] && echo "Creating default reg domain."
+WIRELESS_REGION_FACTORY=`fw_printenv -n wirelessRegionFactory 2> /dev/null` ||
+    WIRELESS_REGION_FACTORY=-1
+
+# If wirelessRegionUser isn't set, we should default to the factory region (if set)
+WIRELESS_REGION_USER=$(/usr/local/natinst/bin/nirtcfg --get section=SystemSettings,token=wirelessRegionUser,value=${WIRELESS_REGION_FACTORY})
+
+WIRELESS_REGION_USER_ALPHA2=$(grep -v ^\# /etc/natinst/iso3166-translation.txt | grep -- $(printf "%03d" "${WIRELESS_REGION_USER}") | awk -F ' ' '{print $2}')
+if [ -n "${WIRELESS_REGION_USER_ALPHA2}" ]; then
+    # Only set if we found something. This should always be the case unless new
+    # countries were added in a future release and the user downgraded. In that
+    # case we don't apply wirelessRegionUser settings, and use the default
+    # regulatory domain (world).
+    if [ -f /etc/modprobe.d/cfg80211 ]; then
+        # If the cfg80211 parameters file does exist, check it is correct
+        PREVIOUS_REGION_USER=$(cat /etc/modprobe.d/cfg80211 | sed 's/.\+ieee80211_regdom=//')
+        if [ "${WIRELESS_REGION_USER_ALPHA2}" = "${PREVIOUS_REGION_USER}" ]; then
+            # Region is set correctly, exit normally
+            exit 0
+        fi
+    fi
+    # Wrong or not there, create it
+    echo "options cfg80211 ieee80211_regdom=${WIRELESS_REGION_USER_ALPHA2}" > /etc/modprobe.d/cfg80211
+fi

--- a/recipes-ni/services-nilrt/files/wirelesssetdomain.service
+++ b/recipes-ni/services-nilrt/files/wirelesssetdomain.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Wireless Set Domain
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/systemd/scripts/wirelesssetdomain
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-ni/services-nilrt/services-nilrt-safemode.bb
+++ b/recipes-ni/services-nilrt/services-nilrt-safemode.bb
@@ -15,6 +15,8 @@ SRC_URI = " \
 	file://mountuserfs \
 	file://nisafemodereason.service \
 	file://nisafemodereason \
+	file://niselectnetnaming.service \
+	file://niselectnetnaming \
 "
 
 inherit systemd
@@ -24,6 +26,7 @@ SYSTEMD_SERVICE:${PN} = " \
 	mountcompatibility.service \
 	mountuserfs.service \
 	nisafemodereason.service \
+	niselectnetnaming.service \
 "
 
 FILES:${PN} += " \
@@ -33,6 +36,8 @@ FILES:${PN} += " \
 	${libdir}/systemd/scripts/mountuserfs \
 	${systemd_unitdir}/system/nisafemodereason.service \
 	${libdir}/systemd/scripts/nisafemodereason \
+	${systemd_unitdir}/system/niselectnetnaming.service \
+	${libdir}/systemd/scripts/niselectnetnaming \
 "
 
 S = "${WORKDIR}"
@@ -47,6 +52,8 @@ do_install () {
 	install -m 0755 ${WORKDIR}/mountuserfs ${D}${libdir}/systemd/scripts
 	install -m 0644 ${WORKDIR}/nisafemodereason.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/nisafemodereason ${D}${libdir}/systemd/scripts
+	install -m 0644 ${WORKDIR}/niselectnetnaming.service ${D}${systemd_unitdir}/system
+	install -m 0755 ${WORKDIR}/niselectnetnaming ${D}${libdir}/systemd/scripts
 }
 
 REQUIRED_DISTRO_FEATURES = " systemd"

--- a/recipes-ni/services-nilrt/services-nilrt-safemode.bb
+++ b/recipes-ni/services-nilrt/services-nilrt-safemode.bb
@@ -11,6 +11,8 @@ RDEPENDS:${PN} += "bash niacctbase"
 SRC_URI = " \
 	file://mountcompatibility.service \
 	file://mountcompatibility \
+	file://mountuserfs.service \
+	file://mountuserfs \
 "
 
 inherit systemd
@@ -18,11 +20,14 @@ SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 SYSTEMD_SERVICE:${PN} = " \
 	mountcompatibility.service \
+	mountuserfs.service \
 "
 
 FILES:${PN} += " \
 	${systemd_unitdir}/system/mountcompatibility.service \
 	${libdir}/systemd/scripts/mountcompatibility \
+	${systemd_unitdir}/system/mountuserfs.service \
+	${libdir}/systemd/scripts/mountuserfs \
 "
 
 S = "${WORKDIR}"
@@ -33,6 +38,8 @@ do_install () {
 
 	install -m 0644 ${WORKDIR}/mountcompatibility.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/mountcompatibility ${D}${libdir}/systemd/scripts
+	install -m 0644 ${WORKDIR}/mountuserfs.service ${D}${systemd_unitdir}/system
+	install -m 0755 ${WORKDIR}/mountuserfs ${D}${libdir}/systemd/scripts
 }
 
 REQUIRED_DISTRO_FEATURES = " systemd"

--- a/recipes-ni/services-nilrt/services-nilrt-safemode.bb
+++ b/recipes-ni/services-nilrt/services-nilrt-safemode.bb
@@ -1,0 +1,30 @@
+SUMMARY = "SystemD nilrt services for safemode"
+DESCRIPTION = "nilrt distro-specific services to provide basic system functionality."
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+LICENSE = "MIT"
+SECTION = "base"
+
+DEPENDS += "shadow-native pseudo-native niacctbase"
+
+RDEPENDS:${PN} += "bash niacctbase"
+
+SRC_URI = " \
+"
+
+inherit systemd
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+SYSTEMD_SERVICE:${PN} = " \
+"
+
+FILES:${PN} += " \
+"
+
+S = "${WORKDIR}"
+
+REQUIRED_DISTRO_FEATURES = " systemd"
+
+RDEPENDS:${PN} += "\
+	bash \
+	niacctbase \
+"

--- a/recipes-ni/services-nilrt/services-nilrt-safemode.bb
+++ b/recipes-ni/services-nilrt/services-nilrt-safemode.bb
@@ -9,18 +9,31 @@ DEPENDS += "shadow-native pseudo-native niacctbase"
 RDEPENDS:${PN} += "bash niacctbase"
 
 SRC_URI = " \
+	file://mountcompatibility.service \
+	file://mountcompatibility \
 "
 
 inherit systemd
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 SYSTEMD_SERVICE:${PN} = " \
+	mountcompatibility.service \
 "
 
 FILES:${PN} += " \
+	${systemd_unitdir}/system/mountcompatibility.service \
+	${libdir}/systemd/scripts/mountcompatibility \
 "
 
 S = "${WORKDIR}"
+
+do_install () {
+	install -d ${D}${systemd_unitdir}/system
+	install -d ${D}${libdir}/systemd/scripts
+
+	install -m 0644 ${WORKDIR}/mountcompatibility.service ${D}${systemd_unitdir}/system
+	install -m 0755 ${WORKDIR}/mountcompatibility ${D}${libdir}/systemd/scripts
+}
 
 REQUIRED_DISTRO_FEATURES = " systemd"
 

--- a/recipes-ni/services-nilrt/services-nilrt-safemode.bb
+++ b/recipes-ni/services-nilrt/services-nilrt-safemode.bb
@@ -13,6 +13,8 @@ SRC_URI = " \
 	file://mountcompatibility \
 	file://mountuserfs.service \
 	file://mountuserfs \
+	file://nisafemodereason.service \
+	file://nisafemodereason \
 "
 
 inherit systemd
@@ -21,6 +23,7 @@ SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 SYSTEMD_SERVICE:${PN} = " \
 	mountcompatibility.service \
 	mountuserfs.service \
+	nisafemodereason.service \
 "
 
 FILES:${PN} += " \
@@ -28,6 +31,8 @@ FILES:${PN} += " \
 	${libdir}/systemd/scripts/mountcompatibility \
 	${systemd_unitdir}/system/mountuserfs.service \
 	${libdir}/systemd/scripts/mountuserfs \
+	${systemd_unitdir}/system/nisafemodereason.service \
+	${libdir}/systemd/scripts/nisafemodereason \
 "
 
 S = "${WORKDIR}"
@@ -40,6 +45,8 @@ do_install () {
 	install -m 0755 ${WORKDIR}/mountcompatibility ${D}${libdir}/systemd/scripts
 	install -m 0644 ${WORKDIR}/mountuserfs.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/mountuserfs ${D}${libdir}/systemd/scripts
+	install -m 0644 ${WORKDIR}/nisafemodereason.service ${D}${systemd_unitdir}/system
+	install -m 0755 ${WORKDIR}/nisafemodereason ${D}${libdir}/systemd/scripts
 }
 
 REQUIRED_DISTRO_FEATURES = " systemd"

--- a/recipes-ni/services-nilrt/services-nilrt.bb
+++ b/recipes-ni/services-nilrt/services-nilrt.bb
@@ -33,6 +33,8 @@ SRC_URI = "\
 	file://nipopulateconfigdir.service \
 	file://populateconfig.service \
 	file://populateconfig \
+	file://wirelesssetdomain.service \
+	file://wirelesssetdomain \
 "
 
 inherit systemd
@@ -53,6 +55,7 @@ SYSTEMD_SERVICE:${PN} = "\
 	nisetupkernelconfig.service \
 	nipopulateconfigdir.service \
 	populateconfig.service \
+	wirelesssetdomain.service \
 "
 
 S = "${WORKDIR}"
@@ -82,6 +85,8 @@ do_install () {
 	install -m 0644 ${WORKDIR}/nipopulateconfigdir.service ${D}${systemd_unitdir}/system
 	install -m 0644 ${WORKDIR}/populateconfig.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/populateconfig ${D}${libdir}/systemd/scripts
+	install -m 0644 ${WORKDIR}/wirelesssetdomain.service ${D}${systemd_unitdir}/system
+	install -m 0755 ${WORKDIR}/wirelesssetdomain ${D}${libdir}/systemd/scripts
 
 	install -m 0644 ${WORKDIR}/firewall.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/firewall ${D}${libdir}/systemd/scripts
@@ -127,6 +132,8 @@ FILES:${PN} += " \
 	${systemd_unitdir}/system/nipopulateconfigdir.service \
 	${systemd_unitdir}/system/populateconfig.service \
 	${libdir}/systemd/scripts/populateconfig \
+	${systemd_unitdir}/system/wirelesssetdomain.service \
+	${libdir}/systemd/scripts/wirelesssetdomain \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-ni/services-nilrt/services-nilrt.bb
+++ b/recipes-ni/services-nilrt/services-nilrt.bb
@@ -19,6 +19,8 @@ SRC_URI = "\
 	file://nicheckbiosconfig \
 	file://nicleanefivars.service \
 	file://nicleanstalelinks.service \
+	file://nicreatecpuacctgroups.service \
+	file://nicreatecpuacctgroups \
 "
 
 inherit systemd
@@ -31,6 +33,7 @@ SYSTEMD_SERVICE:${PN} = "\
 	nicheckbiosconfig.service \
 	nicleanefivars.service \
 	nicleanstalelinks.service \
+	nicreatecpuacctgroups.service \
 "
 
 S = "${WORKDIR}"
@@ -46,6 +49,8 @@ do_install () {
 	install -m 0755 ${WORKDIR}/nicheckbiosconfig ${D}${libdir}/systemd/scripts
 	install -m 0644 ${WORKDIR}/nicleanefivars.service ${D}${systemd_unitdir}/system
 	install -m 0644 ${WORKDIR}/nicleanstalelinks.service ${D}${systemd_unitdir}/system
+	install -m 0644 ${WORKDIR}/nicreatecpuacctgroups.service ${D}${systemd_unitdir}/system
+	install -m 0755 ${WORKDIR}/nicreatecpuacctgroups ${D}${libdir}/systemd/scripts
 
 	install -m 0644 ${WORKDIR}/firewall.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/firewall ${D}${libdir}/systemd/scripts
@@ -77,6 +82,8 @@ FILES:${PN} += " \
 	${libdir}/systemd/scripts/nicheckbiosconfig \
 	${systemd_unitdir}/system/nicleanefivars.service \
 	${systemd_unitdir}/system/nicleanstalelinks.service \
+	${systemd_unitdir}/system/nicreatecpuacctgroups.service \
+	${libdir}/systemd/scripts/nicreatecpuacctgroups \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-ni/services-nilrt/services-nilrt.bb
+++ b/recipes-ni/services-nilrt/services-nilrt.bb
@@ -8,6 +8,8 @@ DEPENDS += "shadow-native pseudo-native niacctbase"
 
 SRC_URI = "\
 	file://cleanvarcache.service \
+	file://firewall.service \
+	file://firewall \
 "
 
 inherit systemd
@@ -15,18 +17,30 @@ SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 SYSTEMD_SERVICE:${PN} = "\
 	cleanvarcache.service \
+	firewall.service \
 "
 
 S = "${WORKDIR}"
 
 do_install () {
 	install -d ${D}${systemd_unitdir}/system
+	install -d ${D}${libdir}/systemd/scripts
 
 	install -m 0644 ${WORKDIR}/cleanvarcache.service ${D}${systemd_unitdir}/system
+	install -m 0644 ${WORKDIR}/firewall.service ${D}${systemd_unitdir}/system
+	install -m 0755 ${WORKDIR}/firewall ${D}${libdir}/systemd/scripts
+
+	# Substitute configfs paths
+	sed -i 's|^IPTABLES_CONF=.*$|IPTABLES_CONF=/etc/natinst/share/iptables.conf|g' ${D}${libdir}/systemd/scripts/firewall
+	sed -i 's|^IP6TABLES_CONF=.*$|IP6TABLES_CONF=/etc/natinst/share/ip6tables.conf|g' ${D}${libdir}/systemd/scripts/firewall
+	# sanity check: break build if new _CONF vars exist which aren't substituted above
+	! egrep '^[a-zA-Z0-9]*_CONF=.*$' ${D}${libdir}/systemd/scripts/firewall | egrep -v '^(IPTABLES_CONF)|(IP6TABLES_CONF)=.*$'
 }
 
 FILES:${PN} += " \
 	${systemd_unitdir}/system/cleanvarcache.service \
+	${systemd_unitdir}/system/firewall.service \
+	${libdir}/systemd/scripts/firewall \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-ni/services-nilrt/services-nilrt.bb
+++ b/recipes-ni/services-nilrt/services-nilrt.bb
@@ -21,6 +21,8 @@ SRC_URI = "\
 	file://nicleanstalelinks.service \
 	file://nicreatecpuacctgroups.service \
 	file://nicreatecpuacctgroups \
+	file://nicreatecpusets.service \
+	file://nicreatecpusets \
 "
 
 inherit systemd
@@ -34,6 +36,7 @@ SYSTEMD_SERVICE:${PN} = "\
 	nicleanefivars.service \
 	nicleanstalelinks.service \
 	nicreatecpuacctgroups.service \
+	nicreatecpusets.service \
 "
 
 S = "${WORKDIR}"
@@ -51,6 +54,8 @@ do_install () {
 	install -m 0644 ${WORKDIR}/nicleanstalelinks.service ${D}${systemd_unitdir}/system
 	install -m 0644 ${WORKDIR}/nicreatecpuacctgroups.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/nicreatecpuacctgroups ${D}${libdir}/systemd/scripts
+	install -m 0644 ${WORKDIR}/nicreatecpusets.service ${D}${systemd_unitdir}/system
+	install -m 0755 ${WORKDIR}/nicreatecpusets ${D}${libdir}/systemd/scripts
 
 	install -m 0644 ${WORKDIR}/firewall.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/firewall ${D}${libdir}/systemd/scripts
@@ -84,6 +89,8 @@ FILES:${PN} += " \
 	${systemd_unitdir}/system/nicleanstalelinks.service \
 	${systemd_unitdir}/system/nicreatecpuacctgroups.service \
 	${libdir}/systemd/scripts/nicreatecpuacctgroups \
+	${systemd_unitdir}/system/nicreatecpusets.service \
+	${libdir}/systemd/scripts/nicreatecpusets \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-ni/services-nilrt/services-nilrt.bb
+++ b/recipes-ni/services-nilrt/services-nilrt.bb
@@ -30,6 +30,7 @@ SRC_URI = "\
 	file://nisetreboottype \
 	file://nisetupkernelconfig.service \
 	file://nisetupkernelconfig \
+	file://nipopulateconfigdir.service \
 "
 
 inherit systemd
@@ -48,6 +49,7 @@ SYSTEMD_SERVICE:${PN} = "\
 	nisetcommitratio.service \
 	nisetreboottype.service \
 	nisetupkernelconfig.service \
+	nipopulateconfigdir.service \
 "
 
 S = "${WORKDIR}"
@@ -74,6 +76,7 @@ do_install () {
 	install -m 0755 ${WORKDIR}/nisetreboottype ${D}${libdir}/systemd/scripts
 	install -m 0644 ${WORKDIR}/nisetupkernelconfig.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/nisetupkernelconfig ${D}${libdir}/systemd/scripts
+	install -m 0644 ${WORKDIR}/nipopulateconfigdir.service ${D}${systemd_unitdir}/system
 
 	install -m 0644 ${WORKDIR}/firewall.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/firewall ${D}${libdir}/systemd/scripts
@@ -116,6 +119,7 @@ FILES:${PN} += " \
 	${libdir}/systemd/scripts/nisetreboottype \
 	${systemd_unitdir}/system/nisetupkernelconfig.service \
 	${libdir}/systemd/scripts/nisetupkernelconfig \
+	${systemd_unitdir}/system/nipopulateconfigdir.service \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-ni/services-nilrt/services-nilrt.bb
+++ b/recipes-ni/services-nilrt/services-nilrt.bb
@@ -26,6 +26,8 @@ SRC_URI = "\
 	file://nidisablecstates.service \
 	file://nisetcommitratio.service \
 	file://nisetcommitratio \
+	file://nisetreboottype.service \
+	file://nisetreboottype \
 "
 
 inherit systemd
@@ -42,6 +44,7 @@ SYSTEMD_SERVICE:${PN} = "\
 	nicreatecpusets.service \
 	nidisablecstates.service \
 	nisetcommitratio.service \
+	nisetreboottype.service \
 "
 
 S = "${WORKDIR}"
@@ -64,6 +67,8 @@ do_install () {
 	install -m 0644 ${WORKDIR}/nidisablecstates.service ${D}${systemd_unitdir}/system
 	install -m 0644 ${WORKDIR}/nisetcommitratio.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/nisetcommitratio ${D}${libdir}/systemd/scripts
+	install -m 0644 ${WORKDIR}/nisetreboottype.service ${D}${systemd_unitdir}/system
+	install -m 0755 ${WORKDIR}/nisetreboottype ${D}${libdir}/systemd/scripts
 
 	install -m 0644 ${WORKDIR}/firewall.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/firewall ${D}${libdir}/systemd/scripts
@@ -102,6 +107,8 @@ FILES:${PN} += " \
 	${systemd_unitdir}/system/nidisablecstates.service \
 	${systemd_unitdir}/system/nisetcommitratio.service \
 	${libdir}/systemd/scripts/nisetcommitratio \
+	${systemd_unitdir}/system/nisetreboottype.service \
+	${libdir}/systemd/scripts/nisetreboottype \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-ni/services-nilrt/services-nilrt.bb
+++ b/recipes-ni/services-nilrt/services-nilrt.bb
@@ -17,6 +17,7 @@ SRC_URI = "\
 	file://mountconfig \
 	file://nicheckbiosconfig.service \
 	file://nicheckbiosconfig \
+	file://nicleanefivars.service \
 "
 
 inherit systemd
@@ -27,6 +28,7 @@ SYSTEMD_SERVICE:${PN} = "\
 	firewall.service \
 	mountconfig.service \
 	nicheckbiosconfig.service \
+	nicleanefivars.service \
 "
 
 S = "${WORKDIR}"
@@ -40,6 +42,7 @@ do_install () {
 	install -m 0755 ${WORKDIR}/mountconfig ${D}${libdir}/systemd/scripts
 	install -m 0644 ${WORKDIR}/nicheckbiosconfig.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/nicheckbiosconfig ${D}${libdir}/systemd/scripts
+	install -m 0644 ${WORKDIR}/nicleanefivars.service ${D}${systemd_unitdir}/system
 
 	install -m 0644 ${WORKDIR}/firewall.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/firewall ${D}${libdir}/systemd/scripts
@@ -69,6 +72,7 @@ FILES:${PN} += " \
 	${libdir}/systemd/scripts/mountconfig \
 	${systemd_unitdir}/system/nicheckbiosconfig.service \
 	${libdir}/systemd/scripts/nicheckbiosconfig \
+	${systemd_unitdir}/system/nicleanefivars.service \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-ni/services-nilrt/services-nilrt.bb
+++ b/recipes-ni/services-nilrt/services-nilrt.bb
@@ -23,6 +23,8 @@ SRC_URI = "\
 	file://nicreatecpuacctgroups \
 	file://nicreatecpusets.service \
 	file://nicreatecpusets \
+	file://niconfiguretracefs.service \
+	file://niconfiguretracefs \
 	file://nidisablecstates.service \
 	file://nisetcommitratio.service \
 	file://nisetcommitratio \
@@ -49,6 +51,7 @@ SYSTEMD_SERVICE:${PN} = "\
 	nicleanstalelinks.service \
 	nicreatecpuacctgroups.service \
 	nicreatecpusets.service \
+	niconfiguretracefs.service \
 	nidisablecstates.service \
 	nisetcommitratio.service \
 	nisetreboottype.service \
@@ -75,6 +78,8 @@ do_install () {
 	install -m 0755 ${WORKDIR}/nicreatecpuacctgroups ${D}${libdir}/systemd/scripts
 	install -m 0644 ${WORKDIR}/nicreatecpusets.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/nicreatecpusets ${D}${libdir}/systemd/scripts
+	install -m 0644 ${WORKDIR}/niconfiguretracefs.service ${D}${systemd_unitdir}/system
+	install -m 0755 ${WORKDIR}/niconfiguretracefs ${D}${libdir}/systemd/scripts
 	install -m 0644 ${WORKDIR}/nidisablecstates.service ${D}${systemd_unitdir}/system
 	install -m 0644 ${WORKDIR}/nisetcommitratio.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/nisetcommitratio ${D}${libdir}/systemd/scripts
@@ -122,6 +127,8 @@ FILES:${PN} += " \
 	${libdir}/systemd/scripts/nicreatecpuacctgroups \
 	${systemd_unitdir}/system/nicreatecpusets.service \
 	${libdir}/systemd/scripts/nicreatecpusets \
+	${systemd_unitdir}/system/niconfiguretracefs.service \
+	${libdir}/systemd/scripts/niconfiguretracefs \
 	${systemd_unitdir}/system/nidisablecstates.service \
 	${systemd_unitdir}/system/nisetcommitratio.service \
 	${libdir}/systemd/scripts/nisetcommitratio \

--- a/recipes-ni/services-nilrt/services-nilrt.bb
+++ b/recipes-ni/services-nilrt/services-nilrt.bb
@@ -15,6 +15,8 @@ SRC_URI = "\
 	file://lvrt-cgroup.sh \
 	file://mountconfig.service \
 	file://mountconfig \
+	file://nicheckbiosconfig.service \
+	file://nicheckbiosconfig \
 "
 
 inherit systemd
@@ -24,6 +26,7 @@ SYSTEMD_SERVICE:${PN} = "\
 	cleanvarcache.service \
 	firewall.service \
 	mountconfig.service \
+	nicheckbiosconfig.service \
 "
 
 S = "${WORKDIR}"
@@ -35,6 +38,8 @@ do_install () {
 	install -m 0644 ${WORKDIR}/cleanvarcache.service ${D}${systemd_unitdir}/system
 	install -m 0644 ${WORKDIR}/mountconfig.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/mountconfig ${D}${libdir}/systemd/scripts
+	install -m 0644 ${WORKDIR}/nicheckbiosconfig.service ${D}${systemd_unitdir}/system
+	install -m 0755 ${WORKDIR}/nicheckbiosconfig ${D}${libdir}/systemd/scripts
 
 	install -m 0644 ${WORKDIR}/firewall.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/firewall ${D}${libdir}/systemd/scripts
@@ -62,6 +67,8 @@ FILES:${PN} += " \
 	${datadir}/${BPN}/lvrt-cgroup.sh \
 	${systemd_unitdir}/system/mountconfig.service \
 	${libdir}/systemd/scripts/mountconfig \
+	${systemd_unitdir}/system/nicheckbiosconfig.service \
+	${libdir}/systemd/scripts/nicheckbiosconfig \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-ni/services-nilrt/services-nilrt.bb
+++ b/recipes-ni/services-nilrt/services-nilrt.bb
@@ -7,14 +7,26 @@ SECTION = "base"
 DEPENDS += "shadow-native pseudo-native niacctbase"
 
 SRC_URI = "\
+	file://cleanvarcache.service \
 "
 
+inherit systemd
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 SYSTEMD_SERVICE:${PN} = "\
+	cleanvarcache.service \
 "
 
 S = "${WORKDIR}"
 
+do_install () {
+	install -d ${D}${systemd_unitdir}/system
+
+	install -m 0644 ${WORKDIR}/cleanvarcache.service ${D}${systemd_unitdir}/system
+}
+
 FILES:${PN} += " \
+	${systemd_unitdir}/system/cleanvarcache.service \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-ni/services-nilrt/services-nilrt.bb
+++ b/recipes-ni/services-nilrt/services-nilrt.bb
@@ -28,6 +28,8 @@ SRC_URI = "\
 	file://nisetcommitratio \
 	file://nisetreboottype.service \
 	file://nisetreboottype \
+	file://nisetupkernelconfig.service \
+	file://nisetupkernelconfig \
 "
 
 inherit systemd
@@ -45,6 +47,7 @@ SYSTEMD_SERVICE:${PN} = "\
 	nidisablecstates.service \
 	nisetcommitratio.service \
 	nisetreboottype.service \
+	nisetupkernelconfig.service \
 "
 
 S = "${WORKDIR}"
@@ -69,6 +72,8 @@ do_install () {
 	install -m 0755 ${WORKDIR}/nisetcommitratio ${D}${libdir}/systemd/scripts
 	install -m 0644 ${WORKDIR}/nisetreboottype.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/nisetreboottype ${D}${libdir}/systemd/scripts
+	install -m 0644 ${WORKDIR}/nisetupkernelconfig.service ${D}${systemd_unitdir}/system
+	install -m 0755 ${WORKDIR}/nisetupkernelconfig ${D}${libdir}/systemd/scripts
 
 	install -m 0644 ${WORKDIR}/firewall.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/firewall ${D}${libdir}/systemd/scripts
@@ -109,6 +114,8 @@ FILES:${PN} += " \
 	${libdir}/systemd/scripts/nisetcommitratio \
 	${systemd_unitdir}/system/nisetreboottype.service \
 	${libdir}/systemd/scripts/nisetreboottype \
+	${systemd_unitdir}/system/nisetupkernelconfig.service \
+	${libdir}/systemd/scripts/nisetupkernelconfig \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-ni/services-nilrt/services-nilrt.bb
+++ b/recipes-ni/services-nilrt/services-nilrt.bb
@@ -1,0 +1,23 @@
+SUMMARY = "SystemD nilrt Services"
+DESCRIPTION = "nilrt distro-specific services to provide basic system functionality."
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+LICENSE = "MIT"
+SECTION = "base"
+
+DEPENDS += "shadow-native pseudo-native niacctbase"
+
+SRC_URI = "\
+"
+
+SYSTEMD_SERVICE:${PN} = "\
+"
+
+S = "${WORKDIR}"
+
+FILES:${PN} += " \
+"
+
+RDEPENDS:${PN} += "\
+	bash \
+	niacctbase \
+"

--- a/recipes-ni/services-nilrt/services-nilrt.bb
+++ b/recipes-ni/services-nilrt/services-nilrt.bb
@@ -13,6 +13,8 @@ SRC_URI = "\
 	file://iso3166-translation.txt \
 	file://lvrt-cgroup \
 	file://lvrt-cgroup.sh \
+	file://mountconfig.service \
+	file://mountconfig \
 "
 
 inherit systemd
@@ -21,6 +23,7 @@ SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 SYSTEMD_SERVICE:${PN} = "\
 	cleanvarcache.service \
 	firewall.service \
+	mountconfig.service \
 "
 
 S = "${WORKDIR}"
@@ -30,6 +33,9 @@ do_install () {
 	install -d ${D}${libdir}/systemd/scripts
 
 	install -m 0644 ${WORKDIR}/cleanvarcache.service ${D}${systemd_unitdir}/system
+	install -m 0644 ${WORKDIR}/mountconfig.service ${D}${systemd_unitdir}/system
+	install -m 0755 ${WORKDIR}/mountconfig ${D}${libdir}/systemd/scripts
+
 	install -m 0644 ${WORKDIR}/firewall.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/firewall ${D}${libdir}/systemd/scripts
 	# Substitute configfs paths
@@ -54,6 +60,8 @@ FILES:${PN} += " \
 	${libdir}/systemd/scripts/firewall \
 	${sysconfdir}/default/lvrt-cgroup \
 	${datadir}/${BPN}/lvrt-cgroup.sh \
+	${systemd_unitdir}/system/mountconfig.service \
+	${libdir}/systemd/scripts/mountconfig \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-ni/services-nilrt/services-nilrt.bb
+++ b/recipes-ni/services-nilrt/services-nilrt.bb
@@ -18,6 +18,7 @@ SRC_URI = "\
 	file://nicheckbiosconfig.service \
 	file://nicheckbiosconfig \
 	file://nicleanefivars.service \
+	file://nicleanstalelinks.service \
 "
 
 inherit systemd
@@ -29,6 +30,7 @@ SYSTEMD_SERVICE:${PN} = "\
 	mountconfig.service \
 	nicheckbiosconfig.service \
 	nicleanefivars.service \
+	nicleanstalelinks.service \
 "
 
 S = "${WORKDIR}"
@@ -43,6 +45,7 @@ do_install () {
 	install -m 0644 ${WORKDIR}/nicheckbiosconfig.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/nicheckbiosconfig ${D}${libdir}/systemd/scripts
 	install -m 0644 ${WORKDIR}/nicleanefivars.service ${D}${systemd_unitdir}/system
+	install -m 0644 ${WORKDIR}/nicleanstalelinks.service ${D}${systemd_unitdir}/system
 
 	install -m 0644 ${WORKDIR}/firewall.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/firewall ${D}${libdir}/systemd/scripts
@@ -73,6 +76,7 @@ FILES:${PN} += " \
 	${systemd_unitdir}/system/nicheckbiosconfig.service \
 	${libdir}/systemd/scripts/nicheckbiosconfig \
 	${systemd_unitdir}/system/nicleanefivars.service \
+	${systemd_unitdir}/system/nicleanstalelinks.service \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-ni/services-nilrt/services-nilrt.bb
+++ b/recipes-ni/services-nilrt/services-nilrt.bb
@@ -24,6 +24,8 @@ SRC_URI = "\
 	file://nicreatecpusets.service \
 	file://nicreatecpusets \
 	file://nidisablecstates.service \
+	file://nisetcommitratio.service \
+	file://nisetcommitratio \
 "
 
 inherit systemd
@@ -39,6 +41,7 @@ SYSTEMD_SERVICE:${PN} = "\
 	nicreatecpuacctgroups.service \
 	nicreatecpusets.service \
 	nidisablecstates.service \
+	nisetcommitratio.service \
 "
 
 S = "${WORKDIR}"
@@ -59,6 +62,8 @@ do_install () {
 	install -m 0644 ${WORKDIR}/nicreatecpusets.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/nicreatecpusets ${D}${libdir}/systemd/scripts
 	install -m 0644 ${WORKDIR}/nidisablecstates.service ${D}${systemd_unitdir}/system
+	install -m 0644 ${WORKDIR}/nisetcommitratio.service ${D}${systemd_unitdir}/system
+	install -m 0755 ${WORKDIR}/nisetcommitratio ${D}${libdir}/systemd/scripts
 
 	install -m 0644 ${WORKDIR}/firewall.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/firewall ${D}${libdir}/systemd/scripts
@@ -95,6 +100,8 @@ FILES:${PN} += " \
 	${systemd_unitdir}/system/nicreatecpusets.service \
 	${libdir}/systemd/scripts/nicreatecpusets \
 	${systemd_unitdir}/system/nidisablecstates.service \
+	${systemd_unitdir}/system/nisetcommitratio.service \
+	${libdir}/systemd/scripts/nisetcommitratio \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-ni/services-nilrt/services-nilrt.bb
+++ b/recipes-ni/services-nilrt/services-nilrt.bb
@@ -31,6 +31,8 @@ SRC_URI = "\
 	file://nisetupkernelconfig.service \
 	file://nisetupkernelconfig \
 	file://nipopulateconfigdir.service \
+	file://populateconfig.service \
+	file://populateconfig \
 "
 
 inherit systemd
@@ -50,6 +52,7 @@ SYSTEMD_SERVICE:${PN} = "\
 	nisetreboottype.service \
 	nisetupkernelconfig.service \
 	nipopulateconfigdir.service \
+	populateconfig.service \
 "
 
 S = "${WORKDIR}"
@@ -77,6 +80,8 @@ do_install () {
 	install -m 0644 ${WORKDIR}/nisetupkernelconfig.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/nisetupkernelconfig ${D}${libdir}/systemd/scripts
 	install -m 0644 ${WORKDIR}/nipopulateconfigdir.service ${D}${systemd_unitdir}/system
+	install -m 0644 ${WORKDIR}/populateconfig.service ${D}${systemd_unitdir}/system
+	install -m 0755 ${WORKDIR}/populateconfig ${D}${libdir}/systemd/scripts
 
 	install -m 0644 ${WORKDIR}/firewall.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/firewall ${D}${libdir}/systemd/scripts
@@ -120,6 +125,8 @@ FILES:${PN} += " \
 	${systemd_unitdir}/system/nisetupkernelconfig.service \
 	${libdir}/systemd/scripts/nisetupkernelconfig \
 	${systemd_unitdir}/system/nipopulateconfigdir.service \
+	${systemd_unitdir}/system/populateconfig.service \
+	${libdir}/systemd/scripts/populateconfig \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-ni/services-nilrt/services-nilrt.bb
+++ b/recipes-ni/services-nilrt/services-nilrt.bb
@@ -10,6 +10,7 @@ SRC_URI = "\
 	file://cleanvarcache.service \
 	file://firewall.service \
 	file://firewall \
+	file://iso3166-translation.txt \
 "
 
 inherit systemd
@@ -29,12 +30,14 @@ do_install () {
 	install -m 0644 ${WORKDIR}/cleanvarcache.service ${D}${systemd_unitdir}/system
 	install -m 0644 ${WORKDIR}/firewall.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/firewall ${D}${libdir}/systemd/scripts
-
 	# Substitute configfs paths
 	sed -i 's|^IPTABLES_CONF=.*$|IPTABLES_CONF=/etc/natinst/share/iptables.conf|g' ${D}${libdir}/systemd/scripts/firewall
 	sed -i 's|^IP6TABLES_CONF=.*$|IP6TABLES_CONF=/etc/natinst/share/ip6tables.conf|g' ${D}${libdir}/systemd/scripts/firewall
 	# sanity check: break build if new _CONF vars exist which aren't substituted above
 	! egrep '^[a-zA-Z0-9]*_CONF=.*$' ${D}${libdir}/systemd/scripts/firewall | egrep -v '^(IPTABLES_CONF)|(IP6TABLES_CONF)=.*$'
+
+	install -d ${D}${sysconfdir}/natinst
+	install -m 0644 ${WORKDIR}/iso3166-translation.txt ${D}${sysconfdir}/natinst
 }
 
 FILES:${PN} += " \

--- a/recipes-ni/services-nilrt/services-nilrt.bb
+++ b/recipes-ni/services-nilrt/services-nilrt.bb
@@ -23,6 +23,7 @@ SRC_URI = "\
 	file://nicreatecpuacctgroups \
 	file://nicreatecpusets.service \
 	file://nicreatecpusets \
+	file://nidisablecstates.service \
 "
 
 inherit systemd
@@ -37,6 +38,7 @@ SYSTEMD_SERVICE:${PN} = "\
 	nicleanstalelinks.service \
 	nicreatecpuacctgroups.service \
 	nicreatecpusets.service \
+	nidisablecstates.service \
 "
 
 S = "${WORKDIR}"
@@ -56,6 +58,7 @@ do_install () {
 	install -m 0755 ${WORKDIR}/nicreatecpuacctgroups ${D}${libdir}/systemd/scripts
 	install -m 0644 ${WORKDIR}/nicreatecpusets.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/nicreatecpusets ${D}${libdir}/systemd/scripts
+	install -m 0644 ${WORKDIR}/nidisablecstates.service ${D}${systemd_unitdir}/system
 
 	install -m 0644 ${WORKDIR}/firewall.service ${D}${systemd_unitdir}/system
 	install -m 0755 ${WORKDIR}/firewall ${D}${libdir}/systemd/scripts
@@ -91,6 +94,7 @@ FILES:${PN} += " \
 	${libdir}/systemd/scripts/nicreatecpuacctgroups \
 	${systemd_unitdir}/system/nicreatecpusets.service \
 	${libdir}/systemd/scripts/nicreatecpusets \
+	${systemd_unitdir}/system/nidisablecstates.service \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-ni/services-nilrt/services-nilrt.bb
+++ b/recipes-ni/services-nilrt/services-nilrt.bb
@@ -11,6 +11,8 @@ SRC_URI = "\
 	file://firewall.service \
 	file://firewall \
 	file://iso3166-translation.txt \
+	file://lvrt-cgroup \
+	file://lvrt-cgroup.sh \
 "
 
 inherit systemd
@@ -38,12 +40,20 @@ do_install () {
 
 	install -d ${D}${sysconfdir}/natinst
 	install -m 0644 ${WORKDIR}/iso3166-translation.txt ${D}${sysconfdir}/natinst
+
+	install -d ${D}${sysconfdir}/default
+	install -m 0644 lvrt-cgroup ${D}${sysconfdir}/default/lvrt-cgroup
+
+	install -d ${D}${datadir}/${BPN}
+	install -m 0755 lvrt-cgroup.sh ${D}${datadir}/${BPN}/lvrt-cgroup.sh
 }
 
 FILES:${PN} += " \
 	${systemd_unitdir}/system/cleanvarcache.service \
 	${systemd_unitdir}/system/firewall.service \
 	${libdir}/systemd/scripts/firewall \
+	${sysconfdir}/default/lvrt-cgroup \
+	${datadir}/${BPN}/lvrt-cgroup.sh \
 "
 
 RDEPENDS:${PN} += "\


### PR DESCRIPTION
### Summary of Changes

Create systemd equivalent of initscripts-nilrt-safemode -- services-nilrt-safemode
Create systemd equivalent of initscripts-nilrt -- services-nilrt

### Justification

[AB#2572995](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2572995)
[AB#2572980](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2572980)

### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have built the index package feed with this PR in place. (`bitbake package-index`)
* [x] I have built the safemode images with this PR in place. (`bitbake nilrt-safemode-rootfs`)
* [x] Verified services-nilrt-safemode services are enabled and started.
* [x] I have built the base system image with this PR in place. (`bitbake nilrt-base-system-image`)
* [x] I have applied the systemd nilrt-base-system-image on top of a sysv nilrt-safemode-rootfs
  * [x] Verified servies-nilrt services are enabled and started.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
