### PR TITLE
nilrt-snac: bump PV from 0.1.1 to 1.0.0

### DIFF
--- a/recipes-ni/nilrt-snac/nilrt-snac_git.bb
+++ b/recipes-ni/nilrt-snac/nilrt-snac_git.bb
@@ -14,7 +14,7 @@ SRC_URI = "\
 "
 
 SRCREV = "${AUTOREV}"
-PV = "0.1.1+git${SRCPV}"
+PV = "1.0.0+git${SRCPV}"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
The current release version of nilrt-snac is 1.0.0.

Update the recipe PV.


### Justification

https://github.com/ni/nilrt-snac/releases/tag/v1.0.0


### Testing

* [ ] Built the `nilrt-snac` recipe and confirmed that its version number is now `1.0.0`.
* [ ] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
