### PR TITLE
kernel_dmesg_diff: Fix OS version passed to fetch the dmesg_record

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-tests-files/kernel_dmesg_diff.py
+++ b/recipes-kernel/kernel-tests/kernel-tests-files/kernel_dmesg_diff.py
@@ -302,12 +302,13 @@ if args.current_log_db_date:
 
     current_dmesg_log = strip_headers(current_dmesg_record['dmesg_log'])
     kernel_version = KernelVersion(current_dmesg_record['kernel_version_full'])
-    os_version = current_dmesg_record['os_version_major_minor']
+    os_version_major_minor = current_dmesg_record['os_version_major_minor']
     device_desc = current_dmesg_record['device_desc']
 else:
     current_dmesg_log = get_dmesg_log()
     kernel_version = KernelVersion()
     os_version = OsVersion()
+    os_version_major_minor = os_version.major_minor
     device_desc = get_device_desc()
 
 # Retrieve the previous dmesg log
@@ -315,7 +316,7 @@ if args.basis_log_db_date:
     previous_dmesg_record = get_dmesg_record_by_date(db, args.basis_log_db_date, logger)
     assert previous_dmesg_record, "Could not find matching basis log record from database."
 else:
-    previous_dmesg_record = get_previous_dmesg_record(db, kernel_version, os_version.major_minor, device_desc, logger)
+    previous_dmesg_record = get_previous_dmesg_record(db, kernel_version, os_version_major_minor, device_desc, logger)
 
 previous_dmesg_log = strip_headers(previous_dmesg_record['dmesg_log']) if previous_dmesg_record else ''
 


### PR DESCRIPTION
### Summary of Changes

The os_version would get set to a string type when fetched from the current_dmesg_record, and the string would not have the property 'major_minor', like the object of OsVersion. The major_minor string value is necessary when fetching the previous_dmesg_record, while the whole OsVersion object instance is required when uploading the log to the database.

This PR fixes what was passed in PR 806.

Additionally, [AB#3014551](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3014551) reports the error "fail to initialize ptp_kvm". But rather than an error, this seems to be an entry in the previous_dmesg_log itself, and is getting reported as a difference. Specifying the basis_log_db_date fixes the issue.

I will be creating a follow-up PR that changes the event variables to pass the basis_log_db_date.

### Justification

[AB#3014551](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3014551)


### Testing

Tested by running the new code on a target, and specifying the basis_log_db_date.

I have verified that we get the "fail to initialize ptp_kvm" error with and without specifying the current_log_db_date, and that the error is absent when we specify the basis_log_db_date.

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
