### PR TITLE
nilrt-snac: update PV to v2.0.0

### DIFF
--- a/recipes-ni/nilrt-snac/nilrt-snac_git.bb
+++ b/recipes-ni/nilrt-snac/nilrt-snac_git.bb
@@ -14,7 +14,7 @@ SRC_URI = "\
 "
 
 SRCREV = "${AUTOREV}"
-PV = "0.1.1+git${SRCPV}"
+PV = "2.0.0+git${SRCPV}"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
The latest release of the nilrt-snac tool is versioned v2.0.0.

Update the recipe PV.


### Testing

* [x] Built the `nilrt-snac` recipe with this change and confirmed that it has the correct PV.
* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
