### PR TITLE
Remove nitest user account

### DIFF
--- a/files/passwd
+++ b/files/passwd
@@ -1,5 +1,4 @@
 nobody:x:65534::::
-nitest:x:1000::::
 # NOTE: static assignments for openembedded packages should be
 #       below the 'webserv' user. Range 502-999 is reserved for system
 #       users installed at runtime (e.g. packages from NIFeeds).

--- a/recipes-core/images/nilrt-runmode-rootfs.bb
+++ b/recipes-core/images/nilrt-runmode-rootfs.bb
@@ -9,6 +9,7 @@ IMAGE_INSTALL = "\
 	packagegroup-ni-wifi \
 	dkms \
 	nilrt-grub-runmode \
+	niauth-workaround \
 	"
 
 require includes/nilrt-image-base.inc

--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -27,6 +27,7 @@ RDEPENDS:${PN} += "\
 	${@bb.utils.contains('MACHINE_FEATURES', 'keyboard', 'keymaps', '', d)} \
 	${@bb.utils.contains('INIT_MANAGER', 'systemd', 'systemd', 'sysvinit', d)} \
 	${@bb.utils.contains('INIT_MANAGER', 'sysvinit', 'eudev', '', d)} \
+	${@bb.utils.contains('INIT_MANAGER', 'systemd', 'niauth-workaround', '', d)} \
 	avahi-daemon \
 	base-files \
 	base-files-nilrt \

--- a/recipes-ni/ni-sysd-workarounds/niauth-workaround.bb
+++ b/recipes-ni/ni-sysd-workarounds/niauth-workaround.bb
@@ -11,17 +11,18 @@ SRC_URI = " \
 
 DEPENDS += " \
 	update-rc.d-native \
+	shadow-native \
+	pseudo-native \
 "
 
-inherit allarch
-
-PACKAGES = "${PN}"
-
+inherit systemd
+SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE:${PN} = "niauth_systemd.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 
-# Create niauth.service and install to /etc/systemd/system
+# Create niauth.service and install to //usr/lib/systemd/system
 FILES:${PN} += " \
-	${sysconfdir}/systemd/system/niauth_systemd.service \
+	${systemd_unitdir}system/niauth_systemd.service \
 	/usr/local/natinst/share/NIAuth/niauth_systemd \
 "
 
@@ -29,17 +30,18 @@ S = "${WORKDIR}"
 
 # Create folder /etc/natinst/share/niauth
 do_install () {
-	install -d ${D}${sysconfdir}/systemd/system/
-	install -m 0755 ${S}/niauth_systemd.service ${D}${sysconfdir}/systemd/system/
+	install -d ${D}${systemd_unitdir}/system
+	install -m 0755 ${S}/niauth_systemd.service ${D}${systemd_unitdir}/system
 
 	install -d ${D}/usr/local/natinst/share/NIAuth/
 	install -m 0755 ${S}/niauth_systemd ${D}/usr/local/natinst/share/NIAuth/
 }
 
-pkg_postinst_ontarget:${PN} () {
+pkg_preinst_on_target:${PN} () {
 	/etc/init.d/niauth stop
 	/sbin/update-rc.d -f niauth remove
-	/bin/systemctl daemon-reload
-	/bin/systemctl enable niauth_systemd.service
-	/bin/systemctl start niauth_systemd.service
 }
+
+RDEPENDS:${PN} += " \
+	bash \
+"

--- a/recipes-ni/niacctbase/niacctbase.bb
+++ b/recipes-ni/niacctbase/niacctbase.bb
@@ -30,19 +30,12 @@ GROUPADD_PARAM:${PN} = " \
 	--system niwscerts; \
 	--system network"
 
-nitest_password = "\$5\$7S6FITmDf/QG.7cV\$YOrD6xTh7DYoO1qneHsszqi6QFh.ICzxL1WwRSY6l31"
-
 # add parameter -m if you want home directories created with default files (.profile, .bashrc)
 USERADD_PARAM:${PN} = " \
 	-m -N -g ${LVRT_GROUP} -G network,niwscerts,plugdev,tty,video -c 'LabVIEW user' ${LVRT_USER}; \
 	-m -N -g ${LVRT_GROUP} -G niwscerts,plugdev,adm,tty -c 'Web services user' webserv; \
 	-N -g openvpn -G network -c 'OpenVPN' -r openvpn; \
-	-m -N -g sudo -p '${nitest_password}' nitest; \
 "
-
-# Add password for root
-inherit extrausers
-EXTRA_USERS_PARAMS = "usermod -p ${nitest_password} root;"
 
 useradd_preinst:append () {
 	eval ${PSEUDO} chmod g+sw ${SYSROOT}/home/${LVRT_USER} || true


### PR DESCRIPTION
### Summary of Changes

Remove `nitest` user account



### Justification

[AB#3034727](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3034727)


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have built the index package feed with this PR in place. (`bitbake package-index`)
* [x] I have built the safemode images with this PR in place. (`bitbake nilrt-safemode-rootfs`)
* [x] I have built the bootable recovery media with this PR in place. (`bitbake nilrt-recovery-media`)
* [x] I have applied the systemd nirlt-base-system-image on top of a sysv nilrt-safemode-rootfs
  * [x] I have logged into the system via admin account
* [x] I have built the nilrt-recovery-media into a VM.
  * [x] VM launched and logged in via admin account 


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
