### PR TITLE
Fix hostname service for systemd

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -26,6 +26,7 @@ RDEPENDS:${PN} += "\
 	${@bb.utils.contains('MACHINE_FEATURES', 'acpi', 'busybox-acpid', '', d)} \
 	${@bb.utils.contains('MACHINE_FEATURES', 'keyboard', 'keymaps', '', d)} \
 	${@bb.utils.contains('INIT_MANAGER', 'systemd', 'systemd', 'sysvinit', d)} \
+	${@bb.utils.contains('INIT_MANAGER', 'systemd', 'systemd-nilrt', '', d)} \
 	${@bb.utils.contains('INIT_MANAGER', 'sysvinit', 'eudev', '', d)} \
 	avahi-daemon \
 	base-files \

--- a/recipes-ni/ni-netcfgutil/files/ninetcfgutil
+++ b/recipes-ni/ni-netcfgutil/files/ninetcfgutil
@@ -515,7 +515,11 @@ impl_pulldefault_kitchensink () {
 	run_cmd $NIRTCFG -s section=SYSTEMSETTINGS,token=host_name,value=
 
 	# hostname.sh is responsible for populating the default hostname
-	/etc/init.d/hostname.sh start
+	if [[ -f /etc/init.d/hostname.sh ]]; then
+		/etc/init.d/hostname.sh start
+	elif [[ -f /usr/lib/systemd/scripts/hostname.sh ]]; then
+		/usr/lib/systemd/scripts/hostname.sh start
+	fi
 
 	# populateconfig creates /etc/natinst/share/{ssh,certstore} if they don't
 	# exist

--- a/recipes-ni/ni-netcfgutil/ni-netcfgutil.bb
+++ b/recipes-ni/ni-netcfgutil/ni-netcfgutil.bb
@@ -41,6 +41,7 @@ FILES:${PN} += "\
 "
 
 RDEPENDS:${PN} += "\
+	${@bb.utils.contains('INIT_MANAGER', 'systemd', 'systemd-nilrt', '', d)} \
 	bash \
 	initscripts \
 	initscripts-nilrt \

--- a/recipes-ni/systemd-nilrt/files/hostname.sh
+++ b/recipes-ni/systemd-nilrt/files/hostname.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+#
+# hostname.sh   Set hostname.
+#
+# Version:      @(#)hostname.sh  1.10  26-Feb-2001  miquels@cistron.nl
+#
+
+start ()
+{
+   # Check if there is a hostname in ni-rt.ini
+   HOSTNAME=$(/usr/local/natinst/bin/nirtcfg --get section=SystemSettings,token=Host_Name)
+   if [ $? -eq 0 ] && [ -n "$HOSTNAME" ]; then
+      # Set the hostname based on ni-rt.ini
+      hostname "$HOSTNAME"
+      # Persist hostname in /etc/hostname file
+      hostname > /etc/hostname
+   else
+      # Generates a default hostname based on firmware DeviceDesc and serial# or MAC address
+
+      # Grab model number from firmware
+      # Fixup Embedded Controller name
+      # Strip whitespace and only use the last 20 characters
+      MODEL=$((/sbin/fw_printenv -n DeviceDesc 2>/dev/null || echo "Unknown") | sed "s/^NI //;s/ Embedded Controller//" | tr -d "\n " | tail -c 20)
+
+      # Grab serial number from firmware
+      # Strip whitespace and only use the last 20 characters
+      SERIAL=$((/sbin/fw_printenv -n serial# 2>/dev/null) | tr -d "\n " | tail -c 20)
+
+      if [ -z "$SERIAL" ]; then
+         # Fallback to MAC address from network driver
+         # Prefer eth0
+         # Filer out lo adapter's MAC (all zeros)
+         SERIAL=$((cat /sys/class/net/eth0/address /sys/class/net/*/address 2>/dev/null) | grep -v '^00:00:00:00:00:00$' | head -1 | tr -d "\n: " | tail -c 20)
+      fi
+
+      if [ -z "$SERIAL" ]; then
+         # Unknown serial number
+         SERIAL="Unknown"
+      fi
+
+      # Set new hostname
+      echo "NI-$MODEL-$SERIAL" | sed -r -e 's/[^a-zA-Z0-9]+/-/g' -e 's/^-//' | xargs hostname
+
+      # Persist new hostname in /etc/hostname file
+      hostname > /etc/hostname
+      # Persist new hostname in ni-rt.ini
+      /usr/local/natinst/bin/nirtcfg --set section=SystemSettings,token=Host_Name,value="$(hostname)"
+
+      # Print new hostname to screen
+      echo -n "New system hostname: "
+      hostname
+   fi
+}
+
+case "$1" in
+    start) start;;
+    stop) exit 0;;
+esac
+
+exit 0

--- a/recipes-ni/systemd-nilrt/files/nihostname.service
+++ b/recipes-ni/systemd-nilrt/files/nihostname.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Set hostname based on ni-rt.ini and nirtcfg configurations
+Before=systemd-hostnamed.service
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/systemd/scripts/hostname.sh start
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-ni/systemd-nilrt/systemd-nilrt.bb
+++ b/recipes-ni/systemd-nilrt/systemd-nilrt.bb
@@ -1,0 +1,37 @@
+SUMMARY = "NILRT systemd services"
+DESCRIPTION = "nilrt modifications for services provided by systemd"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+LICENSE = "MIT"
+SECTION = "base"
+
+DEPENDS += "systemd"
+
+SRC_URI += " \
+	file://nihostname.service \
+	file://hostname.sh \
+"
+
+inherit systemd
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+SYSTEMD_SERVICE:${PN}:append = " \
+	nihostname.service \
+"
+
+S = "${WORKDIR}"
+
+do_install() {
+	install -d ${D}${systemd_unitdir}/system
+	install -d ${D}${libdir}/systemd/scripts
+
+	install -m 0644 ${WORKDIR}/nihostname.service ${D}${systemd_unitdir}/system/nihostname.service
+	install -m 0755 ${WORKDIR}/hostname.sh ${D}${libdir}/systemd/scripts/hostname.sh
+}
+
+FILES:${PN}:append = " \
+	${libdir}/systemd/scripts/hostname.sh \
+"
+
+RDEPENDS:${PN} += " \
+	bash \
+"


### PR DESCRIPTION
### Summary of Changes

Create nihostname.service for systemd

### Justification

[AB#2572995](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2572995)


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have built the index package feed with this PR in place. (`bitbake package-index`)
* [x] I have built the safemode images with this PR in place. (`bitbake nilrt-safemode-rootfs`)
* [x] I have built the bootable recovery media with this PR in place. (`bitbake nilrt-recovery-media`)
* [x] I have built the nilrt-recovery-media into a VM.
  * [x] VM launched and validated hostname


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
