### PR TITLE
linux-nilrt-next: Update to 6.12 version branch

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-next_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-next_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NILRT linux kernel next development build"
 NI_RELEASE_VERSION = "master"
-LINUX_VERSION = "6.6"
+LINUX_VERSION = "6.12"
 LINUX_KERNEL_TYPE = "next"
 
 require linux-nilrt-alternate.inc

--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -13,11 +13,6 @@ KBUILD_FRAGMENTS_LOCATION ?= "nilrt"
 
 LINUX_VERSION_EXTENSION = "$([ "${LINUX_KERNEL_TYPE}" != "standard" ] && echo '-${LINUX_KERNEL_TYPE}')"
 
-# Setting EXTRA_OEMAKE to include CFLAGS settings is required as
-# the Kbuild system will clobber CC (which is used by OE for setting
-# the compiler and flags to the compiler/linker/etc.)
-EXTRA_OEMAKE += 'CFLAGS="${TOOLCHAIN_OPTIONS}"'
-
 # Kbuild intenionally clobbers CFLAGS/LDFLAGS for some binaries we ship in nilrt,
 # particularly in the tools/ dir (fixdep, genksyms etc), and OE has this insanity check
 # to see if binaries were built using the OE-supplied *FLAGS, so skip this sanity check to


### PR DESCRIPTION
Update kernel-next to 6.12 version branch

WI: [AB#2951013](https://dev.azure.com/ni/DevCentral/_workitems/edit/2951013)

### Testing
- [x] Built `packagefeed-ni-core`, `nilrt-base-system-image`, `packagegroup-ni-next-kerne`l with https://github.com/ni/openembedded-core/pull/159
- [x] Boot tested on a VM and cRIO-9049
- [x] Verified packagegroup-ni-next-kernel is installable and bootable
- [x] Verified that ni-kal could be installed/reversioned on 6.12 kernel

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).


### Note
Depends on https://github.com/ni/openembedded-core/pull/159. So only merge this after that.