### PR TITLE
ni-utils: Add support for systemd init manager

### DIFF
--- a/recipes-ni/ni-utils/files/nisetbootmode.service
+++ b/recipes-ni/ni-utils/files/nisetbootmode.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=NI Set Boot Mode Service
+DefaultDependencies=no
+Before=basic.target
+Conflicts=shutdown.target reboot.target
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/nisetbootmode start
+ExecStop=/usr/sbin/nisetbootmode stop
+RemainAfterExit=yes
+
+[Install]
+WantedBy=basic.target

--- a/recipes-ni/ni-utils/files/nisetled.service
+++ b/recipes-ni/ni-utils/files/nisetled.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=NI Set LED Service
+DefaultDependencies=no
+Before=basic.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/nisetled
+RemainAfterExit=yes
+
+[Install]
+WantedBy=basic.target

--- a/recipes-ni/ni-utils/files/nisetprimarymac.service
+++ b/recipes-ni/ni-utils/files/nisetprimarymac.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=NI Set Primary MAC Service
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/nisetprimarymac
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target graphical.target

--- a/recipes-ni/ni-utils/ni-utils.bb
+++ b/recipes-ni/ni-utils/ni-utils.bb
@@ -11,16 +11,23 @@ SRC_URI = "\
 	file://nisetled \
 	file://nisetprimarymac \
 	file://functions.common \
+	file://nisetbootmode.service \
+	file://nisetled.service \
+	file://nisetprimarymac.service \
 "
 
+script_location = "${@bb.utils.contains('INIT_MANAGER', 'sysvinit', '${sysconfdir}/init.d', '${sbindir}',d)}"
 FILES:${PN} += "\
 	${bindir}/status_led \
 	${libdir}/nisetbootmode.functions \
-	${sysconfdir}/init.d/nisetbootmode \
-	${sysconfdir}/init.d/nisetled \
-	${sysconfdir}/init.d/nisetprimarymac \
+	${script_location}/nisetbootmode \
+	${script_location}/nisetled \
+	${script_location}/nisetprimarymac \
 	${sysconfdir}/natinst/networking/functions.common \
 	/usr/local/natinst/bin/status_led \
+	${@bb.utils.contains('INIT_MANAGER', 'systemd', '${systemd_unitdir}/system/nisetbootmode.service', '',d)} \
+	${@bb.utils.contains('INIT_MANAGER', 'systemd', '${systemd_unitdir}/system/nisetled.service', '',d)} \
+	${@bb.utils.contains('INIT_MANAGER', 'systemd', '${systemd_unitdir}/system/nisetprimarymac.service', '',d)} \
 "
 
 DEPENDS += "shadow-native pseudo-native niacctbase update-rc.d-native"
@@ -31,27 +38,59 @@ RDEPENDS:${PN}:append:x64 = " fw-printenv"
 
 S = "${WORKDIR}"
 
+#systemd
+inherit systemd
+SYSTEMD_SERVICE:${PN} = " \
+	nisetbootmode.service \
+	nisetled.service \
+	nisetprimarymac.service \
+"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+
 do_install () {
 	install -d ${D}${bindir}
-	install -d ${D}${sysconfdir}/init.d
+	install -d ${D}${script_location}
 	install -d ${D}${libdir}
 	install -d ${D}${sysconfdir}/natinst/networking
 
 	install -m 0755   ${WORKDIR}/status_led                  ${D}${bindir}
 	install -m 0440   ${WORKDIR}/nisetbootmode.functions     ${D}${libdir}
-	install -m 0550   ${WORKDIR}/nisetbootmode               ${D}${sysconfdir}/init.d
-	install -m 0755   ${WORKDIR}/nisetled                    ${D}${sysconfdir}/init.d
-	install -m 0755   ${WORKDIR}/nisetprimarymac             ${D}${sysconfdir}/init.d
+	install -m 0550   ${WORKDIR}/nisetbootmode               ${D}${script_location}
+	install -m 0755   ${WORKDIR}/nisetled                    ${D}${script_location}
+	install -m 0755   ${WORKDIR}/nisetprimarymac             ${D}${script_location}
 	install -m 0755   ${WORKDIR}/functions.common            ${D}${sysconfdir}/natinst/networking
 
-	update-rc.d -r ${D} nisetled              start 40 S .
-	update-rc.d -r ${D} nisetbootmode         start 80 S . stop 0 0 6 .
-	update-rc.d -r ${D} nisetprimarymac       start 4 5 .
+
+	if ${@bb.utils.contains('INIT_MANAGER', 'sysvinit', 'true', 'false',d)}; then
+		update-rc.d -r ${D} nisetled              start 40 S .
+		update-rc.d -r ${D} nisetbootmode         start 80 S . stop 0 0 6 .
+		update-rc.d -r ${D} nisetprimarymac       start 4 5 .
+	else
+		install -d ${D}${systemd_unitdir}/system
+		install -d ${D}${sbindir}
+
+		install -m 0644   ${WORKDIR}/nisetbootmode.service       ${D}${systemd_unitdir}/system
+		install -m 0644   ${WORKDIR}/nisetled.service            ${D}${systemd_unitdir}/system
+		install -m 0644   ${WORKDIR}/nisetprimarymac.service     ${D}${systemd_unitdir}/system
+	fi
 
 	chown 0:${LVRT_GROUP} ${D}${bindir}/status_led
-	chown 0:${LVRT_GROUP} ${D}${sysconfdir}/init.d/nisetbootmode
+	chown 0:${LVRT_GROUP} ${D}${script_location}/nisetbootmode
 
 	# legacy symlink location
 	install -d ${D}/usr/local/natinst/bin
 	ln -sf ${bindir}/status_led ${D}/usr/local/natinst/bin/status_led
+}
+
+# Create symlinks to the previous location for compatibility
+pkg_postinst_ontarget:${PN} () {
+	if [ -e ${sbindir}/nisetbootmode ]; then
+		ln -sf ${sbindir}/nisetbootmode ${sysconfdir}/init.d/nisetbootmode
+	fi
+}
+
+pkg_prerm_ontarget:${PN} () {
+	if [ -L ${sysconfdir}/init.d/nisetbootmode ]; then
+		rm -f ${sysconfdir}/init.d/nisetbootmode
+	fi
 }


### PR DESCRIPTION
### Summary of Changes

Update ni-utils.bb recipe to support `systemd` init_manager


### Justification

[AB#2573010](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2573010)


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have built the index package feed with this PR in place. (`bitbake package-index`)
* [x] I have built the safemode images with this PR in place. (`bitbake nilrt-safemode-rootfs`)
* [x] Verified ni-utils services are enabled and started.
* [x] I have built the base system image with this PR in place. (`bitbake nilrt-base-system-image`)
* [x] I have applied the systemd nilrt-base-system-image on top of a sysv nilrt-safemode-rootfs
  * [x] Verified ni-utils services are enabled and started.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
