### PR TITLE
dkms: Use main branch instead of master

### DIFF
--- a/recipes-kernel/dkms/dkms.bb
+++ b/recipes-kernel/dkms/dkms.bb
@@ -11,7 +11,7 @@ PV = "3.0.13"
 
 
 SRC_URI = "\
-	git://github.com/dell/dkms.git;protocol=https;branch=master \
+	git://github.com/dell/dkms.git;protocol=https;branch=main \
 	file://0001-autoinstall-all-kernels.patch \
 "
 


### PR DESCRIPTION
dkms repo removed master branch so do_fetch fails. Use main branch instead.

No specific WI for this. Noticed when working on [AB#3039639](https://dev.azure.com/ni/DevCentral/_workitems/edit/3039639).

### Testing

`bitbake -c do_fetch dkms` now passes when download mirror is disabled (it'd fail without this change).

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
