### PR TITLE
Fix error output when provisioning mmc targets

### DIFF
--- a/recipes-core/initrdscripts/files/ni_provisioning.safemode.common
+++ b/recipes-core/initrdscripts/files/ni_provisioning.safemode.common
@@ -409,7 +409,7 @@ sanity_check()
 	print_info "Sanity check TARGET_DISK=$TARGET_DISK..."
 
 	# correct partition table type
-	parted -s --list "$TARGET_DISK" | grep -q "^Partition Table: $PART_STYLE" || die "Wrong partition style reported"
+	parted "$TARGET_DISK" print | grep -q "^Partition Table: $PART_STYLE" || die "Wrong partition style reported"
 
 	attrib_list="NAME KNAME PARTUUID UUID LABEL"
 	if [[ "$PART_STYLE" == "gpt" ]]; then


### PR DESCRIPTION
### Summary of Changes

This change uses a more appropriate parted command when validating the partition type of the target disk during sanity checking.

Provisioning via USB on a target with mmc storage was printing error output similar to:
Error: /dev/mmcblk1boot0: unrecognized disk label
Error: /dev/mmcblk1boot1: unrecognized disk label

### Justification

[AB#3038318](https://dev.azure.com/ni/DevCentral/_workitems/edit/3038318)

### Testing

Built the nilrt-recovery-media-x64.iso locally with these changes. Used the resulting iso on a USB thumbdrive to provision an sbrio-9628 and cRIO-9053. Confirmed the error output was present before the change and was no longer present after the change.

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
