### PR TITLE
busybox: Enable ifplugd networking for systemd

### DIFF
--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -77,6 +77,10 @@ VIRTUAL-RUNTIME_initscripts = "initscripts"
 
 VIRTUAL-RUNTIME_init_manager = "systemd"
 
+# Continue to use ifplugd networking on systemd in order to maintain
+# current NI configurations, scripts, etc...
+PACKAGECONFIG:remove = "networkd"
+
 # For qemu images
 VIRTUAL-RUNTIME_keymaps = ""
 

--- a/recipes-core/busybox/busybox_1.%.bbappend
+++ b/recipes-core/busybox/busybox_1.%.bbappend
@@ -4,11 +4,13 @@ SRC_URI =+ " \
             file://busybox-ifplugd \
             file://ifplugd.action \
             file://ifplugd.conf \
+            file://busybox-ifplugd.service \
             file://zcip.script \
             file://busybox-acpid \
             file://acpid.conf \
             file://acpid_poweroff.sh \
             file://acpid-logrotate.conf \
+            file://busybox-acpid.service \
             file://0001-ifplugd.c-Increase-buffer-size-for-netlink-binding.patch \
             file://zcip-allow-action-script-to-reject-chosen-IP.patch \
             file://login-utilities.cfg \
@@ -30,15 +32,36 @@ PACKAGES =+ " ${PN}-zcip"
 
 DEPENDS =+ " libselinux"
 
-FILES:${PN}-ifplugd = "${sysconfdir}/init.d/busybox-ifplugd ${sysconfdir}/ifplugd/ifplugd.action ${sysconfdir}/ifplugd/ifplugd.conf"
-FILES:${PN}-acpid = "${sysconfdir}/init.d/busybox-acpid ${sysconfdir}/acpid.conf ${sysconfdir}/acpi ${sysconfdir}/acpi/poweroff.sh"
+script_location = "${@bb.utils.contains('INIT_MANAGER','sysvinit','${sysconfdir}/init.d','${base_sbindir}',d)}"
+FILES:${PN}-ifplugd = " \
+	${script_location}/busybox-ifplugd \
+	${sysconfdir}/ifplugd/ifplugd.action \
+	${sysconfdir}/ifplugd/ifplugd.conf \
+	${systemd_system_unitdir}/busybox-acpid.task \
+	${@bb.utils.contains('INIT_MANAGER','systemd','${systemd_unitdir}/system/busybox-ifplugd.service','',d)} \
+"
+FILES:${PN}-acpid = " \
+	${script_location}/busybox-acpid \
+	${sysconfdir}/acpid.conf \
+	${sysconfdir}/acpi \
+	${sysconfdir}/acpi/poweroff.sh \
+	${@bb.utils.contains('INIT_MANAGER','systemd','${systemd_unitdir}/system/busybox-acpid.service','',d)} \
+"
 FILES:${PN}-zcip = "${sysconfdir}/natinst/networking/zcip.script"
 FILES:${PN}-udhcpd =+ "${sysconfdir}/udhcpd.wlan0.conf"
+FILES:${PN}-hwclock =+ "${@bb.utils.contains('INIT_MANAGER','systemd','${base_sbindir}/hwclock.sh','',d)}"
+FILES:${PN}-hwclock:remove = "${@bb.utils.contains('INIT_MANAGER','systemd','${sysconfdir}/init.d/hwclock.sh','',d)}"
 
-INITSCRIPT_PACKAGES =+ " ${PN}-acpid"
-
+INITSCRIPT_PACKAGES =+ "${@bb.utils.contains('INIT_MANAGER','sysvinit',' ${PN}-acpid','',d)}"
 INITSCRIPT_NAME:${PN}-acpid = "busybox-acpid"
 INITSCRIPT_PARAMS:${PN}-acpid = "start 20 2 3 4 5 . stop 20 0 1 6 ."
+SYSTEMD_PACKAGES += "${@bb.utils.contains('INIT_MANAGER','systemd',' ${PN}-acpid','',d)}"
+SYSTEMD_SERVICE:${PN}-acpid = "busybox-acpid.service"
+SYSTEMD_AUTO_ENABLE:${PN}-acpid = "enable"
+
+SYSTEMD_PACKAGES += "${@bb.utils.contains('INIT_MANAGER','systemd',' ${PN}-ifplugd','',d)}"
+SYSTEMD_SERVICE:${PN}-ifplugd = "busybox-ifplugd.service"
+SYSTEMD_AUTO_ENABLE:${PN}-ifplugd = "enable"
 
 # Remove default busybox udhcpd init script; on NILRT images
 # udhcpd is invoked directly from ifplugd action scripts
@@ -47,18 +70,30 @@ INITSCRIPT_PACKAGES:remove = "${PN}-udhcpd"
 
 do_install:append () {
 	if grep "CONFIG_IFPLUGD=y" ${B}/.config; then
+		install -d ${D}${script_location}
+		install -m 0755 ${WORKDIR}/busybox-ifplugd ${D}${script_location}
+
 		install -d ${D}${sysconfdir}/ifplugd/
-		install -m 0755 ${WORKDIR}/busybox-ifplugd ${D}${sysconfdir}/init.d/
 		install -m 0755 ${WORKDIR}/ifplugd.action ${D}${sysconfdir}/ifplugd/
 		install -m 0755 ${WORKDIR}/ifplugd.conf ${D}${sysconfdir}/ifplugd/
+		if ${@bb.utils.contains('INIT_MANAGER','systemd','true','false',d)}; then
+			install -d ${D}${systemd_unitdir}/system
+			install -m 0644 ${WORKDIR}/busybox-ifplugd.service ${D}${systemd_unitdir}/system/
+		fi
 	fi
 	if grep "CONFIG_ACPID=y" ${B}/.config; then
-		install -m 0755 ${WORKDIR}/busybox-acpid ${D}${sysconfdir}/init.d/
-		install -m 0755 ${WORKDIR}/acpid.conf ${D}${sysconfdir}/
+		install -d ${D}${script_location}
+		install -m 0755 ${WORKDIR}/busybox-acpid ${D}${script_location}
+
+		install -m 0755 ${WORKDIR}/acpid.conf ${D}${sysconfdir}/admin
 		install -d ${D}${sysconfdir}/acpi
 		install -m 0755 ${WORKDIR}/acpid_poweroff.sh ${D}${sysconfdir}/acpi/poweroff.sh
 		install -d ${D}${sysconfdir}/logrotate.d
 		install -m 0644 ${WORKDIR}/acpid-logrotate.conf ${D}${sysconfdir}/logrotate.d/acpid.conf
+		if ${@bb.utils.contains('INIT_MANAGER','systemd','true','false',d)}; then
+			install -d ${D}${systemd_unitdir}/system
+			install -m 0644 ${WORKDIR}/busybox-acpid.service ${D}${systemd_unitdir}/system/
+		fi
 	fi
 	if grep "CONFIG_ZCIP=y" ${B}/.config; then
 		install -d ${D}${sysconfdir}/natinst/networking
@@ -69,5 +104,12 @@ do_install:append () {
 
 		# Remove unused default busybox udhcpd init script
 		rm -f ${D}${sysconfdir}/init.d/busybox-udhcpd
+	fi
+	if grep -q "CONFIG_HWCLOCK=y" ${B}/.config; then
+		if ${@bb.utils.contains('INIT_MANAGER', 'systemd','true','false',d)}; then
+			# Remove hwclock.sh from /etc/init.d
+			rm -f ${D}${sysconfdir}/init.d/hwclock.sh
+			install -m 0755 ${WORKDIR}/hwclock.sh ${D}${base_sbindir}
+		fi
 	fi
 }

--- a/recipes-core/busybox/files/busybox-acpid.service
+++ b/recipes-core/busybox/files/busybox-acpid.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Busybox Advanced Configuration and Power Interface Event Daemon
+SourcePath=/usr/sbin/busybox-acpid
+
+[Service]
+Type=forking
+Restart=no
+TimeoutSec=5min
+IgnoreSIGPIPE=no
+KillMode=process
+GuessMainPID=no
+RemainAfterExit=yes
+ExecStart=/usr/sbin/busybox-acpid start
+ExecStop=/usr/sbin/busybox-acpid stop
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-core/busybox/files/busybox-ifplugd.service
+++ b/recipes-core/busybox/files/busybox-ifplugd.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Busybox ifplugd daemon
+SourcePath=/usr/sbin/busybox-ifplugd
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=forking
+Restart=no
+TimeoutSec=5min
+IgnoreSIGPIPE=no
+KillMode=process
+GuessMainPID=no
+RemainAfterExit=yes
+SuccessExitStatus=5 6
+ExecStart=/usr/sbin/busybox-ifplugd start
+ExecStop=/usr/sbin/busybox-ifplugd stop
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
### Summary of Changes

Disable `systemd-networkd` on systemd image
Update `busybox-ifplugd` networking to function on systemd


### Justification

[AB#2573001](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2573001)
RTOS Decision: Continue to use busybox-ifplugd due to the potential of NI products, scripts, etc that relate to ifplugd networking


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have built the index package feed with this PR in place. (`bitbake package-index`)
* [x] I have built the safemode images with this PR in place. (`bitbake nilrt-safemode-rootfs`)
* [x] I have built the base system image with this PR in place. (`bitbake nilrt-base-system-image`)
* [x] I have applied the systemd nilrt-base-system-image on top of a sysv nilrt-safemode-rootfs


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
