### PR TITLE
[recipes-ni] Update recipes to support systemd

### DIFF
--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -15,8 +15,6 @@ DISTRO_FEATURES += "\
         xattr \
         zeroconf \
         pci \
-        systemd \
-        usrmerge \
         pam \
         ptest \
         selinux \
@@ -76,6 +74,11 @@ VIRTUAL-RUNTIME_base-utils-hwclock = "util-linux-hwclock"
 VIRTUAL-RUNTIME_initscripts = "initscripts"
 
 VIRTUAL-RUNTIME_init_manager = "systemd"
+
+DISTRO_FEATURES += " \
+	${@bb.utils.contains('VIRTUAL-RUNTIME_init_manager','systemd','systemd','sysvinit',d)} \
+	${@bb.utils.contains('VIRTUAL-RUNTIME_init_manager','systemd','usrmerge','',d)} \
+"
 
 # Continue to use ifplugd networking on systemd in order to maintain
 # current NI configurations, scripts, etc...

--- a/recipes-ni/crio-support-scripts/crio-support-scripts.bb
+++ b/recipes-ni/crio-support-scripts/crio-support-scripts.bb
@@ -3,23 +3,52 @@ DESCRIPTION = "CompactRIO miscellaneous support files"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 SECTION = "base"
-DEPENDS = "shadow-native pseudo-native niacctbase update-rc.d-native"
+DEPENDS = " \
+	shadow-native \
+	pseudo-native \
+	niacctbase \
+	${@bb.utils.contains('INIT_MANAGER','sysvinit','update-rc.d-native','systemd-systemctl-native',d)} \
+"
 RDEPENDS:${PN} += "niacctbase bash"
 
-SRC_URI:append:x64 = "file://nisetfpgaautoload \
-                      file://nisetconsoleout \
+SRC_URI:append:x64 = " \
+	file://nisetfpgaautoload \
+	file://nisetfpgaautoload.service \
+	file://nisetconsoleout \
+	file://nisetconsoleout.service \
 "
 
 S = "${WORKDIR}"
 
-do_install () {
-     install -d ${D}${sysconfdir}/init.d/
-     if [ "${TARGET_ARCH}" = "x86_64" ]; then
-          install -m 0755   ${S}/nisetfpgaautoload    ${D}${sysconfdir}/init.d
-          install -m 0550   ${S}/nisetconsoleout      ${D}${sysconfdir}/init.d
-          chown 0:${LVRT_GROUP} ${D}${sysconfdir}/init.d/nisetconsoleout
+inherit systemd
+SYSTEMD_SERVICE:${PN} = " \
+	nisetfpgaautoload.service \
+	nisetconsoleout.service \
+"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 
-          update-rc.d -r ${D} nisetfpgaautoload start 81 S . stop 3 0 6 .
-          update-rc.d -r ${D} nisetconsoleout start 15 S . stop 85 0 6 .
-     fi
+script_location = "${@bb.utils.contains('INIT_MANAGER','sysvinit','${sysconfdir}/init.d','${systemd_unitdir}/scripts',d)}"
+FILES:${PN} = " \
+	${script_location}/nisetfpgaautoload \
+	${script_location}/nisetconsoleout \
+	${@bb.utils.contains('INIT_MANAGER','systemd','${systemd_system_unitdir}/nisetfpgaautoload.service','',d)} \
+	${@bb.utils.contains('INIT_MANAGER','systemd','${systemd_system_unitdir}/nisetconsoleout.service','',d)} \
+"
+do_install () {
+	install -d ${D}${script_location}
+	if [ "${TARGET_ARCH}" = "x86_64" ]; then
+		install -m 0755   ${S}/nisetfpgaautoload    ${D}${script_location}
+		install -m 0550   ${S}/nisetconsoleout      ${D}${script_location}
+		chown 0:${LVRT_GROUP} ${D}${script_location}/nisetconsoleout
+
+		if ${@bb.utils.contains('INIT_MANAGER','sysvinit','true','false',d)}; then
+			update-rc.d -r ${D} nisetfpgaautoload start 81 S . stop 3 0 6 .
+			update-rc.d -r ${D} nisetconsoleout start 15 S . stop 85 0 6 .
+		fi
+		if ${@bb.utils.contains('INIT_MANAGER','systemd','true','false',d)}; then
+			install -d ${D}${systemd_system_unitdir}
+			install -m 0644 ${WORKDIR}/nisetfpgaautoload.service ${D}${systemd_system_unitdir}/
+			install -m 0644 ${WORKDIR}/nisetconsoleout.service ${D}${systemd_system_unitdir}/
+		fi
+	fi
 }

--- a/recipes-ni/crio-support-scripts/files/nisetconsoleout.service
+++ b/recipes-ni/crio-support-scripts/files/nisetconsoleout.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=NI Set Console Output
+DefaultDependencies=no
+Before=multi-user.target halt.target reboot.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/systemd/scripts/nisetconsoleout start
+ExecStop=/usr/lib/systemd/scripts/nisetconsoleout stop
+
+[Install]
+WantedBy=multi-user.target rescue.target halt.target reboot.target

--- a/recipes-ni/crio-support-scripts/files/nisetfpgaautoload.service
+++ b/recipes-ni/crio-support-scripts/files/nisetfpgaautoload.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=NI Set FPGA Autoload
+DefaultDependencies=no
+Before=multi-user.target halt.target reboot.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/systemd/scripts/nisetfpgaautoload start
+ExecStop=/usr/lib/systemd/scripts/nisetfpgaautoload stop
+
+[Install]
+WantedBy=multi-user.target rescue.target halt.target reboot.target

--- a/recipes-ni/ni-configpersistentlogs/files/ni-configpersistentlogs
+++ b/recipes-ni/ni-configpersistentlogs/files/ni-configpersistentlogs
@@ -7,9 +7,9 @@ error_and_die() {
     exit 1
 }
 
-FILE_PATH_VOLATILES_CONFIG="/etc/default/volatiles/00_core"
-PERSISTENT_DIR_VAR_LOG_LINE="d root root 0755 /var/log none"
-VOLATILE_SYMLINK_VAR_LOG_LINE="l root root 0755 /var/log /var/volatile/log"
+FILE_PATH_VOLATILES_CONFIG="<PATH_VOLATILES>"
+PERSISTENT_DIR_VAR_LOG_LINE="<PERSISTENT_LINE>"
+VOLATILE_SYMLINK_VAR_LOG_LINE="<VOLATILE_LINE>"
 
 ENABLE_PERSISTENT_LOGS_INI_VAL=$(/usr/local/natinst/bin/nirtcfg --get section=SystemSettings,token=PersistentLogs.enabled,value="false" | tr "[:upper:]" "[:lower:]")
 
@@ -30,6 +30,11 @@ case $ENABLE_PERSISTENT_LOGS_INI_VAL in
         error_and_die "Unexpected value for PersistentLogs.enabled in /etc/natinst/share/ni-rt.ini. Expected True or False."
         ;;
 esac
+
+if [ ! -f "$FILE_PATH_VOLATILES_CONFIG" ]; then
+   [ "${VERBOSE}" != "no" ] && echo "$FILE_PATH_VOLATILES_CONFIG does not exist."
+   exit 0
+fi
 
 # This grep command looks for the exact new line.
 OUTPUT=$(grep "^$NEW_VAR_LOG_LINE$" "$FILE_PATH_VOLATILES_CONFIG" 2>&1)

--- a/recipes-ni/ni-configpersistentlogs/files/ni-configpersistentlogs.service
+++ b/recipes-ni/ni-configpersistentlogs/files/ni-configpersistentlogs.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=NI Persistent Logs Configuration Utility
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/systemd/scripts/ni-configpersistentlogs
+
+[Install]
+WantedBy=multi-user.target rescue.target

--- a/recipes-ni/ni-configpersistentlogs/ni-configpersistentlogs.bb
+++ b/recipes-ni/ni-configpersistentlogs/ni-configpersistentlogs.bb
@@ -8,23 +8,48 @@ PV = "1.0"
 
 SRC_URI = "\
 	file://ni-configpersistentlogs \
+	file://ni-configpersistentlogs.service \
 "
 
 S = "${WORKDIR}"
 
+PATH_VOLATILES_SYSV="/etc/default/volatiles/00_core"
+PERSISTENT_SYSV="d root root 0755 /var/log none"
+VOLATILE_SYSV="l root root 0755 /var/log /var/volatile/log"
+PATH_VOLATILES_SYSD="/usr/lib/tmpfiles.d/00-create-volatile.conf"
+PERSISTENT_SYSD="d		/var/log		-	-	-	-"
+VOLATILE_SYSD="L		/var/log		-	-	-	-	/var/volatile/log"
+
+inherit update-rc.d systemd
 INITSCRIPT_NAME = "ni-configpersistentlogs"
 INITSCRIPT_PARAMS = "start 2 S ."
-
-inherit update-rc.d
+SYSTEMD_SERVICE:${PN} = "ni-configpersistentlogs.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 
 do_install () {
-	install -d ${D}${sysconfdir}/init.d/
-	install -m 0755 ${S}/ni-configpersistentlogs ${D}${sysconfdir}/init.d/
+	install -d ${D}${script_location}
+	install -m 0755 ${S}/ni-configpersistentlogs ${D}${script_location}
+
+	if ${@bb.utils.contains('INIT_MANAGER','systemd','true','false',d)}; then
+		install -d ${D}${systemd_system_unitdir}
+		install -m 0644 ${WORKDIR}/ni-configpersistentlogs.service ${D}${systemd_system_unitdir}/
+		sed -i "s|<PATH_VOLATILES>|${PATH_VOLATILES_SYSD}|g" ${D}${script_location}/ni-configpersistentlogs
+		sed -i "s|<PERSISTENT_LINE>|${PERSISTENT_SYSD}|g" ${D}${script_location}/ni-configpersistentlogs
+		sed -i "s|<VOLATILE_LINE>|${VOLATILE_SYSD}|g" ${D}${script_location}/ni-configpersistentlogs
+	else
+		sed -i "s|<PATH_VOLATILES>|${PATH_VOLATILES_SYSV}|g" ${D}${script_location}/ni-configpersistentlogs
+		sed -i "s|<PERSISTENT_LINE>|${PERSISTENT_SYSV}|g" ${D}${script_location}/ni-configpersistentlogs
+		sed -i "s|<VOLATILE_LINE>|${VOLATILE_SYSV}|g" ${D}${script_location}/ni-configpersistentlogs
+	fi
 }
 
-
+script_location = "${@bb.utils.contains('INIT_MANAGER','sysvinit','${sysconfdir}/init.d','${systemd_unitdir}/scripts',d)}"
 FILES:${PN} += "\
-	${sysconfdir}/init.d/ni-configpersistentlogs \
+	${script_location}/ni-configpersistentlogs \
+	${@bb.utils.contains('INIT_MANAGER','systemd','${systemd_system_unitdir}/ni-configpersistentlogs.service','',d)} \
 "
 
-RDEPENDS:${PN} += "bash initscripts"
+RDEPENDS:${PN} += "\
+	bash \
+	${@bb.utils.contains('INIT_MANAGER','sysvinit',' initscripts',' systemd',d)} \
+"

--- a/recipes-ni/ni-hw-scripts/ni-hw-scripts-common.bb
+++ b/recipes-ni/ni-hw-scripts/ni-hw-scripts-common.bb
@@ -5,55 +5,61 @@ LICENSE = "MIT"
 SECTION = "base"
 
 DEPENDS += "\
-	update-rc.d-native \
+	${@bb.utils.contains('INIT_MANAGER','sysvinit','update-rc.d-native','systemd-systemctl-native',d)} \
 "
 
 SRC_URI += "\
 	file://init.d/ni-rename-ifaces \
 	file://init.d/nisetserialnumber \
+	file://ni-rename-ifaces.service \
+	file://nisetserialnumber.service \
 "
 
 S = "${WORKDIR}"
 
-
-inherit allarch
+inherit allarch systemd
 PACKAGE_ARCH = "all"
 PACKAGES:remove = "${PN}-staticdev ${PN}-dev ${PN}-dbg"
 
 
 do_install () {
-	install -d ${D}${sysconfdir}/init.d/
+	install -d ${D}${script_location}
 
-	install -m 0755 ${S}/init.d/ni-rename-ifaces     ${D}${sysconfdir}/init.d
-	install -m 0755 ${S}/init.d/nisetserialnumber    ${D}${sysconfdir}/init.d
+	install -m 0755 ${S}/init.d/ni-rename-ifaces     ${D}${script_location}
+	install -m 0755 ${S}/init.d/nisetserialnumber    ${D}${script_location}
 }
 
-pkg_postinst:${PN} () {
-	if [ -n "$D" ]; then
-		OPT="-r $D"
-	else
-		OPT="-s"
-	fi
+python __anonymous() {
+    if bb.utils.contains('INIT_MANAGER','sysvinit',True,False,d):
+        d.appendVar('pkg_postinst:${PN}',"""
+if [ -n "$D" ]; then
+    OPT="-r $D"
+else
+    OPT="-s"
+fi
 
-	update-rc.d $OPT ni-rename-ifaces    start 38 S .
-	update-rc.d $OPT nisetserialnumber   start 38 S .
+update-rc.d $OPT ni-rename-ifaces    start 38 S .
+update-rc.d $OPT nisetserialnumber   start 38 S .
+"""
+)
+        d.appendVar('pkg_postrm:${PN}',"""
+if [ -n "$D" ]; then
+    OPT="-f -r $D"
+else
+    OPT="-f"
+fi
+
+update-rc.d $OPT ni-rename-ifaces  remove
+update-rc.d $OPT nisetserialnumber remove
+""")
 }
 
-pkg_postrm:${PN} () {
-	if [ -n "$D" ]; then
-		OPT="-f -r $D"
-	else
-		OPT="-f"
-	fi
-
-	update-rc.d $OPT ni-rename-ifaces  remove
-	update-rc.d $OPT nisetserialnumber remove
-}
-
-
+script_location = "${@bb.utils.contains('INIT_MANAGER','sysvinit','${sysconfdir}/init.d','${systemd_unitdir}/scripts',d)}"
 FILES:${PN} += "\
-	${sysconfdir}/init.d/ni-rename-ifaces \
-	${sysconfdir}/init.d/nisetserialnumber \
+	${script_location}/ni-rename-ifaces \
+	${script_location}/nisetserialnumber \
+	${@bb.utils.contains('INIT_MANAGER','systemd','${systemd_system_unitdir}/ni-rename-ifaces.service','',d)} \
+	${@bb.utils.contains('INIT_MANAGER','systemd','${systemd_system_unitdir}/nisetserialnumber.service','',d)} \
 "
 
 RDEPENDS:${PN} += "\

--- a/recipes-ni/ni-hw-scripts/ni-hw-scripts-common/ni-rename-ifaces.service
+++ b/recipes-ni/ni-hw-scripts/ni-hw-scripts-common/ni-rename-ifaces.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=NI Rename Network Interfaces
+DefaultDependencies=no
+Before=basic.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/systemd/scripts/ni-rename-ifaces start
+
+[Install]
+WantedBy=basic.target

--- a/recipes-ni/ni-hw-scripts/ni-hw-scripts-common/nisetserialnumber.service
+++ b/recipes-ni/ni-hw-scripts/ni-hw-scripts-common/nisetserialnumber.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=NI Set Serial Number
+DefaultDependencies=no
+Before=basic.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/systemd/scripts/nisetserialnumber start
+
+[Install]
+WantedBy=basic.target

--- a/recipes-ni/ni-modules-autoload/files/ni-modules-autoload
+++ b/recipes-ni/ni-modules-autoload/files/ni-modules-autoload
@@ -8,19 +8,21 @@ cd /etc/modules.autoload.d
 
 case "$1" in
     start)
-	for mod in *; do
-	    modprobe -q "$mod"
-	done
-	#autodetection of hardware
-	find /sys/devices -name modalias |
-	    while read -r m; do
-		read -r alias < "$m"
-		modprobe -q "$alias"
-	    done
-	;;
+    for mod in *; do
+        modprobe -q "$mod"
+    done
+    #autodetection of hardware
+    find /sys/devices -name modalias |
+        while read -r m; do
+            read -r alias < "$m"
+            modprobe -q "$alias"
+        done
+    ;;
     stop)
-	for mod in *; do
-	    modprobe -q -r "$mod"
-	done
-	;;
+    for mod in *; do
+        modprobe -q -r "$mod"
+    done
+    ;;
 esac
+
+exit 0

--- a/recipes-ni/ni-modules-autoload/files/ni-modules-autoload.service
+++ b/recipes-ni/ni-modules-autoload/files/ni-modules-autoload.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=NI Modules Autoload Service
+DefaultDependencies=no
+Before=basic.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/systemd/scripts/ni-modules-autoload start
+
+[Install]
+WantedBy=basic.target

--- a/recipes-ni/ni-modules-autoload/ni-modules-autoload.bb
+++ b/recipes-ni/ni-modules-autoload/ni-modules-autoload.bb
@@ -6,23 +6,33 @@ SECTION = "base"
 
 SRC_URI = "\
 	file://ni-modules-autoload \
+	file://ni-modules-autoload.service \
 "
 
-FILES:${PN} = "\
+script_location = "${@bb.utils.contains('INIT_MANAGER','sysvinit','${sysconfdir}/init.d','${systemd_unitdir}/scripts',d)}"
+FILES:${PN} += " \
 	${sysconfdir}/modules.autoload.d \
-	${sysconfdir}/init.d/ni-modules-autoload \
+	${script_location}/ni-modules-autoload \
+	${@bb.utils.contains('INIT_MANAGER','systemd','${systemd_system_unitdir}/ni-modules-autoload.service','',d)} \
 "
 
 RDEPENDS:${PN} += "bash"
 
 INITSCRIPT_NAME = "ni-modules-autoload"
 INITSCRIPT_PARAMS = "start 37 S ."
+SYSTEMD_SERVICE:${PN} = "ni-modules-autoload.service"
+SYSTEMD_AUTO_ENABLE:{PN} = "enable"
 
-inherit update-rc.d
+inherit update-rc.d systemd
 
 do_install () {
 	install -d ${D}${sysconfdir}/modules.autoload.d
 
-	install -d ${D}${sysconfdir}/init.d/
-	install -m 0755 ${WORKDIR}/ni-modules-autoload ${D}${sysconfdir}/init.d/
+	install -d ${D}${script_location}
+	install -m 0755 ${WORKDIR}/ni-modules-autoload ${D}${script_location}
+
+	if ${@bb.utils.contains('INIT_MANAGER','systemd','true','false',d)}; then
+		install -d ${D}${systemd_system_unitdir}
+		install -m 0644 ${WORKDIR}/ni-modules-autoload.service ${D}${systemd_system_unitdir}/
+	fi
 }

--- a/recipes-ni/ni-rtfeatures/files/handle_cpld_ip_reset.service
+++ b/recipes-ni/ni-rtfeatures/files/handle_cpld_ip_reset.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Handle CPLD IP Reset
+DefaultDependencies=no
+Before=multi-user.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/systemd/scripts/handle_cpld_ip_reset start
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-ni/ni-rtfeatures/files/ni-rtfeatures.service
+++ b/recipes-ni/ni-rtfeatures/files/ni-rtfeatures.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=NI RT Features Service
+DefaultDependencies=no
+Before=multi-user.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/systemd/scripts/ni-rtfeatures start
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-ni/ni-rtfeatures/ni-rtfeatures.bb
+++ b/recipes-ni/ni-rtfeatures/ni-rtfeatures.bb
@@ -6,59 +6,79 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 
-DEPENDS += "update-rc.d-native"
+DEPENDS += "\
+	${@bb.utils.contains('INIT_MANAGER','sysvinit','update-rc.d-native','systemd-systemctl-native',d)} \
+"
 
 PV = "2.1"
-
 
 SRC_URI += "\
 	file://handle_cpld_ip_reset.initd \
 	file://ni-rtfeatures.initd \
 	file://rtfeatures.rules \
+	file://handle_cpld_ip_reset.service \
+	file://ni-rtfeatures.service \
 "
 
 S = "${WORKDIR}"
 
-
-inherit allarch
+inherit allarch systemd
 PACKAGE_ARCH = "all"
 PACKAGES:remove = "${PN}-staticdev ${PN}-dev ${PN}-dbg"
 
+SYSTEMD_SERVICE:${PN} = " \
+	handle_cpld_ip_reset.service \
+	ni-rtfeatures.service \
+"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+
+script_location = "${@bb.utils.contains('INIT_MANAGER','sysvinit','${sysconfdir}/init.d','${systemd_unitdir}/scripts',d)}"
+FILES:${PN} += "\
+	${script_location}/handle_cpld_ip_reset \
+	${script_location}/ni-rtfeatures \
+	${sysconfdir}/udev \
+	${@bb.utils.contains('INIT_MANAGER','systemd','${systemd_system_unitdir}/handle_cpld_ip_reset.service','',d)} \
+	${@bb.utils.contains('INIT_MANAGER','systemd','${systemd_system_unitdir}/ni-rtfeatures.service','',d)} \
+"
 
 do_install:append () {
-	install -d ${D}${sysconfdir}/init.d/
-	install -m 0755 ${S}/handle_cpld_ip_reset.initd  ${D}${sysconfdir}/init.d/handle_cpld_ip_reset
-	install -m 0755 ${S}/ni-rtfeatures.initd         ${D}${sysconfdir}/init.d/ni-rtfeatures
+	install -d ${D}${script_location}/
+	install -m 0755 ${S}/handle_cpld_ip_reset.initd  ${D}${script_location}/handle_cpld_ip_reset
+	install -m 0755 ${S}/ni-rtfeatures.initd         ${D}${script_location}/ni-rtfeatures
 
 	install -d ${D}${sysconfdir}/udev/rules.d
 	install -m 0644 ${S}/rtfeatures.rules    ${D}${sysconfdir}/udev/rules.d/rtfeatures.rules
-}
 
-pkg_postinst:${PN} () {
-	if [ -n "$D" ]; then
-		OPT="-r $D"
-	else
-		OPT=""
+	if ${@bb.utils.contains('INIT_MANAGER','systemd','true','false',d)}; then
+		install -d ${D}${systemd_system_unitdir}
+		install -m 0644 ${WORKDIR}/handle_cpld_ip_reset.service ${D}${systemd_system_unitdir}/
+		install -m 0644 ${WORKDIR}/ni-rtfeatures.service ${D}${systemd_system_unitdir}/
 	fi
-	update-rc.d $OPT handle_cpld_ip_reset start 6 1 3 4 5 .
-	update-rc.d $OPT ni-rtfeatures start 20 1 3 4 5 .
 }
 
-pkg_postrm:${PN} () {
-	if [ -n "$D" ]; then
-		OPT="-f -r $D"
-	else
-		OPT="-f"
-	fi
-	update-rc.d $OPT handle_cpld_ip_reset remove
-	update-rc.d $OPT ni-rtfeatures remove
+python __anonymous() {
+    if bb.utils.contains('INIT_MANAGER','sysvinit',True,False,d):
+        d.appendVar('pkg_postinst:${PN}',"""
+if [ -n "$D" ]; then
+    OPT="-r $D"
+else
+    OPT=""
+fi
+update-rc.d $OPT handle_cpld_ip_reset start 6 1 3 4 5 .
+update-rc.d $OPT ni-rtfeatures start 20 1 3 4 5 .
+"""
+)
+        d.appendVar('pkg_postrm:${PN}',"""
+if [ -n "$D" ]; then
+    OPT="-f -r $D"
+else
+    OPT="-f"
+fi
+update-rc.d $OPT handle_cpld_ip_reset remove
+update-rc.d $OPT ni-rtfeatures remove
+"""
+)
 }
-
-
-FILES:${PN} += "\
-	${sysconfdir}/init.d/* \
-	${sysconfdir}/udev \
-"
 
 RDEPENDS:${PN} += "\
 	bash \

--- a/recipes-ni/ni-shutdown-guard/files/holdoff-shutdown.service
+++ b/recipes-ni/ni-shutdown-guard/files/holdoff-shutdown.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Holdoff Shutdown/Reboot Guard
+DefaultDependencies=no
+Before=halt.target reboot.target shutdown.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/systemd/scripts/holdoff-shutdown stop
+
+[Install]
+WantedBy=halt.target reboot.target shutdown.target

--- a/recipes-ni/ni-shutdown-guard/ni-shutdown-guard.bb
+++ b/recipes-ni/ni-shutdown-guard/ni-shutdown-guard.bb
@@ -6,22 +6,25 @@ SECTION = "base"
 
 SRC_URI = "\
 	file://holdoff-shutdown \
+	file://holdoff-shutdown.service \
 	file://nilrt-safemode \
 	file://rguard \
 "
 
+script_location = "${@bb.utils.contains('INIT_MANAGER','sysvinit','${sysconfdir}/init.d','${systemd_unitdir}/scripts',d)}"
 # ni-shutdown-guard package settings
 FILES:${PN} = "\
-	${sysconfdir}/init.d/holdoff-shutdown \
+	${script_location}/holdoff-shutdown \
 	${sbindir}/rguard \
 "
 
 RDEPENDS:${PN} += "bash"
 
+inherit update-rc.d systemd
 INITSCRIPT_NAME = "holdoff-shutdown"
 INITSCRIPT_PARAMS = "stop 00 0 6 ."
-
-inherit update-rc.d
+SYSTEMD_SERVICE:${PN} = "holdoff-shutdown.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 
 # ni-shutdown-guard-safemode package settings
 PACKAGES += "${PN}-safemode"
@@ -37,10 +40,16 @@ RDEPENDS:${PN}-safemode += "${PN}"
 
 do_install () {
 	install -d ${D}${sbindir}
-	install -d ${D}${sysconfdir}/init.d
+	install -d ${D}${script_location}
 	install -d ${D}${sysconfdir}/holdoff-shutdown.d
 
 	install -m 0755   ${WORKDIR}/rguard              ${D}${sbindir}
-	install -m 0755   ${WORKDIR}/holdoff-shutdown    ${D}${sysconfdir}/init.d
+	install -m 0755   ${WORKDIR}/holdoff-shutdown    ${D}${script_location}
 	install -m 0644   ${WORKDIR}/nilrt-safemode      ${D}${sysconfdir}/holdoff-shutdown.d
+
+	if ${@bb.utils.contains('INIT_MANAGER','systemd','true','false',d)}; then
+		install -d ${D}${systemd_system_unitdir}
+		install -m 0644 ${WORKDIR}/holdoff-shutdown.service ${D}${systemd_system_unitdir}/
+	fi
+
 }

--- a/recipes-ni/ni-systemformat/files/nitargetinfo.service
+++ b/recipes-ni/ni-systemformat/files/nitargetinfo.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=NI Target Info Service
+DefaultDependencies=no
+Before=basic.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/systemd/scripts/nitargetinfo start
+
+[Install]
+WantedBy=basic.target

--- a/recipes-ni/ni-systemformat/ni-systemformat.bb
+++ b/recipes-ni/ni-systemformat/ni-systemformat.bb
@@ -7,45 +7,54 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 SECTION = "base"
 
-
 DEPENDS += "niacctbase"
 
 SRC_URI = "\
 	file://nisystemformat \
 	file://nitargetinfo \
+	file://nitargetinfo.service \
 "
 
 S = "${WORKDIR}"
+
+script_location = "${@bb.utils.contains('INIT_MANAGER','sysvinit','${sysconfdir}/init.d','${systemd_unitdir}/scripts',d)}"
+FILES:${PN} += "\
+	${bindir}/nisystemformat \
+	${script_location}/nitargetinfo \
+	/usr/local/natinst/bin/nisystemformat \
+	${@bb.utils.contains('INIT_MANAGER','systemd','${systemd_system_unitdir}/nitargetinfo.service','',d)} \
+"
 
 do_install () {
 	install -d ${D}${bindir}
 	install -m 0550 ${S}/nisystemformat ${D}${bindir}
 	chown 0:${LVRT_GROUP} ${D}${bindir}/nisystemformat
 
-	install -d ${D}${sysconfdir}/init.d
-	install -m 0755 ${S}/nitargetinfo ${D}${sysconfdir}/init.d/
+	install -d ${D}${script_location}
+	install -m 0755 ${S}/nitargetinfo ${D}${script_location}
 
-    # legacy symlink location
-    install -d ${D}/usr/local/natinst/bin
-    ln -sf ${bindir}/nisystemformat ${D}/usr/local/natinst/bin/nisystemformat
+	# legacy symlink location
+	install -d ${D}/usr/local/natinst/bin
+	ln -sf ${bindir}/nisystemformat ${D}/usr/local/natinst/bin/nisystemformat
+
+	if ${@bb.utils.contains('INIT_MANAGER','systemd','true','false',d)}; then
+		install -d ${D}${systemd_system_unitdir}
+		install -m 0644 ${WORKDIR}/nitargetinfo.service ${D}${systemd_system_unitdir}
+	fi
 }
 
-
-FILES:${PN} += "\
-	${bindir}/nisystemformat \
-	${sysconfdir}/init.d/nitargetinfo \
-	/usr/local/natinst/bin/nisystemformat \
-"
-
-inherit update-rc.d
+inherit update-rc.d systemd
 
 INITSCRIPT_NAME = "nitargetinfo"
 INITSCRIPT_PARAMS = "start 20 S ."
+SYSTEMD_SERVICE:${PN} = "nitargetinfo.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 
 RDEPENDS:${PN} += "\
 	bash \
 	niacctbase \
 "
+
 # nisystemformat rdeps
 RDEPENDS:${PN} += "\
 	coreutils \

--- a/recipes-ni/niwatchdogpet/files/niwatchdogpet.service
+++ b/recipes-ni/niwatchdogpet/files/niwatchdogpet.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=NI Target Info Service
+DefaultDependencies=no
+Before=basic.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/systemd/scripts/nitargetinfo
+
+[Install]
+WantedBy=basic.target

--- a/recipes-ni/niwatchdogpet/niwatchdogpet.bb
+++ b/recipes-ni/niwatchdogpet/niwatchdogpet.bb
@@ -3,16 +3,21 @@ SECTION = "base"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-inherit update-rc.d
+inherit update-rc.d systemd
 
 S = "${WORKDIR}"
 
-SRC_URI = "file://LICENSE \
-	   file://niwatchdogpet.c \
-	   file://niwatchdogpet.sh"
+SRC_URI = "\
+	file://LICENSE \
+	file://niwatchdogpet.c \
+	file://niwatchdogpet.sh \
+	file://niwatchdogpet.service \
+"
 
 INITSCRIPT_NAME = "niwatchdogpet"
 INITSCRIPT_PARAMS = "start 05 S ."
+SYSTEMD_SERVICE:${PN} = "niwatchdogpet.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 
 CFLAGS:append = " -std=c89 -Wall -Werror -pedantic"
 
@@ -20,11 +25,22 @@ do_compile() {
 	${CC} -Os ${CFLAGS} ${WORKDIR}/niwatchdogpet.c -o niwatchdogpet ${LDFLAGS}
 }
 
-do_install() {
-	install -m 0755 -d ${D}${sbindir} ${D}${sysconfdir}/init.d
-	install -m 0755 ${S}/niwatchdogpet ${D}${sbindir}
-	install -m 0755 ${S}/niwatchdogpet.sh ${D}${sysconfdir}/init.d/niwatchdogpet
-}
+script_location = "${@bb.utils.contains('INIT_MANAGER','sysvinit','${sysconfdir}/init.d','${systemd_unitdir}/scripts',d)}"
+FILES:${PN} += "\
+	${sbindir}/niwatchdogpet \
+	${script_location}/niwatchdogpet \
+	${@bb.utils.contains('INIT_MANAGER','systemd','${systemd_system_unitdir}/niwatchdogpet.service','',d)} \
+"
 
+do_install() {
+	install -m 0755 -d ${D}${sbindir} ${D}${script_location}
+	install -m 0755 ${S}/niwatchdogpet ${D}${sbindir}
+	install -m 0755 ${S}/niwatchdogpet.sh ${D}${script_location}/niwatchdogpet
+
+	if ${@bb.utils.contains('INIT_MANAGER','systemd','true','false',d)}; then
+		install -d ${D}${systemd_system_unitdir}
+		install -m 0644 ${WORKDIR}/niwatchdogpet.service ${D}${systemd_system_unitdir}/
+	fi
+}
 
 RDEPENDS:${PN} = "fw-printenv"

--- a/recipes-ni/pstore-save/files/pstore-save.service
+++ b/recipes-ni/pstore-save/files/pstore-save.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Pstore State Recovery Utility
+DefaultDependencies=no
+Before=basic.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/systemd/scripts/pstore-save start
+
+[Install]
+WantedBy=basic.target

--- a/recipes-ni/pstore-save/pstore-save.bb
+++ b/recipes-ni/pstore-save/pstore-save.bb
@@ -4,28 +4,41 @@ SECTION = "base"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-inherit update-rc.d
+inherit update-rc.d systemd
 
 S = "${WORKDIR}"
 
 SRC_URI = "\
-    file://pstore-save \
-    file://initscript \
-    file://run-ptest \
-    file://testdata/ \
+	file://pstore-save \
+	file://initscript \
+	file://run-ptest \
+	file://testdata/ \
+	file://pstore-save.service \
 "
 
 INITSCRIPT_NAME = "pstore-save"
 INITSCRIPT_PARAMS = "start 09 S ."
+SYSTEMD_SERVICE:${PN} = "pstore-save.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 
 DEPENDS += "bash"
 RDEPENDS:${PN} += "bash"
 
+script_location = "${@bb.utils.contains('INIT_MANAGER','sysvinit','${sysconfdir}/init.d','${systemd_unitdir}/scripts',d)}"
+FILES:${PN} += "\
+	${script_location}/pstore-save \
+	${sbindir}/pstore-save \
+	${@bb.utils.contains('INIT_MANAGER','systemd','${systemd_system_unitdir}/pstore-save.service','',d)} \
+"
 do_install () {
-    install -d ${D}${sbindir} ${D}${sysconfdir}/init.d
-    install -m 0755 ${S}/pstore-save ${D}${sbindir}/
+	install -d ${D}${sbindir} ${D}${script_location}
+	install -m 0755 ${S}/pstore-save ${D}${sbindir}/
 
-    install -m 0755 ${S}/initscript ${D}${sysconfdir}/init.d/pstore-save
+	install -m 0755 ${S}/initscript ${D}${script_location}/pstore-save
+	if ${@bb.utils.contains('INIT_MANAGER','systemd','true','false',d)}; then
+		install -d ${D}${systemd_system_unitdir}
+		install -m 0644 ${WORKDIR}/pstore-save.service ${D}${systemd_system_unitdir}/
+	fi
 }
 
 inherit ptest
@@ -33,9 +46,9 @@ inherit ptest
 RDEPENDS:${PN}-ptest += "${PN} bash"
 
 do_install_ptest:append () {
-    install -d ${D}${PTEST_PATH}/src
-    install -m 0444 ${S}/testdata/src/* ${D}${PTEST_PATH}/src
+	install -d ${D}${PTEST_PATH}/src
+	install -m 0444 ${S}/testdata/src/* ${D}${PTEST_PATH}/src
 
-    install -d ${D}${PTEST_PATH}/expected
-    install -m 0444 ${S}/testdata/expected/* ${D}${PTEST_PATH}/expected
+	install -d ${D}${PTEST_PATH}/expected
+	install -m 0444 ${S}/testdata/expected/* ${D}${PTEST_PATH}/expected
 }

--- a/recipes-ni/sysconfig-settings/files/nisetembeddeduixml.service
+++ b/recipes-ni/sysconfig-settings/files/nisetembeddeduixml.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=NI Embedded UI XML Service
+DefaultDependencies=no
+Before=graphical.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/systemd/scripts/nisetembeddeduixml start
+
+[Install]
+WantedBy=graphical.target

--- a/recipes-ni/sysconfig-settings/sysconfig-settings.bb
+++ b/recipes-ni/sysconfig-settings/sysconfig-settings.bb
@@ -66,8 +66,12 @@ do_install () {
 	# Create shared systemsettingsdir with appropriate permissions and ownership
 	install -d -m 0775 -o ${LVRT_USER} -g ${LVRT_GROUP} ${D}${systemsettingsdir}
 
-	install -d ${D}${sysconfdir}/init.d/
-	install -m 0755 ${WORKDIR}/nisetembeddeduixml ${D}${sysconfdir}/init.d
+	install -d ${D}${script_location}
+	install -m 0755 ${WORKDIR}/nisetembeddeduixml ${D}${script_location}
+	if ${@bb.utils.contains('INIT_MANAGER','systemd','true','false',d)}; then
+		install -d ${D}${systemd_system_unitdir}
+		install -m 0644 ${WORKDIR}/nisetembeddeduixml.service ${D}${systemd_system_unitdir}/
+	fi
 }
 
 pkg_postinst_ontarget:${PN} () {
@@ -162,6 +166,7 @@ DESCRIPTION:${PN}-ui = "Configuration files to enable UI for the National Instru
 
 SRC_URI:append = "\
 	file://nisetembeddeduixml \
+	file://nisetembeddeduixml.service \
 	file://systemsettings/ui_enable.ini \
 	file://uixml/nilinuxrt.System.binding.xml \
 	file://uixml/nilinuxrt.System.const.de.xml \
@@ -181,18 +186,24 @@ SRC_URI:append = "\
 	file://uixml/nilinuxrt.ui_enable.def.xml \
 "
 
+script_location = "${@bb.utils.contains('INIT_MANAGER','sysvinit','${sysconfdir}/init.d','${systemd_unitdir}/scripts',d)}"
 FILES:${PN}-ui = "\
-	${sysconfdir}/init.d/nisetembeddeduixml \
+	${script_location}/nisetembeddeduixml \
 	${settingsdatadir}/ui_enable.ini \
 	${uixmldir}/nilinuxrt.System.* \
 	${uixmldir}/nilinuxrt.ui_enable.* \
+	${@bb.utils.contains('INIT_MANAGER','systemd','${systemd_system_unitdir}/nisetembeddeduixml.service','',d)} \
 "
 
 RDEPENDS:${PN}-ui += "sysconfig-settings niacctbase"
 
-INITSCRIPT_PACKAGES += "${PN}-ui"
+INITSCRIPT_PACKAGES += "${@bb.utils.contains('INIT_MANAGER','sysvinit','${PN}-ui','',d)}"
 INITSCRIPT_NAME:${PN}-ui = "nisetembeddeduixml"
 INITSCRIPT_PARAMS:${PN}-ui = "start 20 5 ."
+
+inherit systemd
+SYSTEMD_SERVICE:${PN}-ui = "nisetembeddeduixml.service"
+SYSTEMD_AUTO_ENABLE:${PN}-ui = "enable"
 
 pkg_prerm_ontarget:${PN}-ui () {
 	nirtcfg --set "section=systemsettings,token=ui.enabled,value=False"


### PR DESCRIPTION
### Summary of Changes

Updated `recipes-ni` recipes to support both systemd and sysvinit


### Justification

recipes-ni services are required for proper functionality


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have built the index package feed with this PR in place. (`bitbake package-index`)
* [x] I have built the safemode images with this PR in place. (`bitbake nilrt-safemode-rootfs`)
* [x] I have built the base system image with this PR in place. (`bitbake nilrt-base-system-image`)
* [x] I have applied the systemd nilrt-base-system-image on top of a sysv nilrt-safemode-rootfs


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
