### PR TITLE
busybox.bbappend: Correct acpid.conf dest folder

### DIFF
--- a/recipes-core/busybox/busybox_1.%.bbappend
+++ b/recipes-core/busybox/busybox_1.%.bbappend
@@ -85,7 +85,7 @@ do_install:append () {
 		install -d ${D}${script_location}
 		install -m 0755 ${WORKDIR}/busybox-acpid ${D}${script_location}
 
-		install -m 0755 ${WORKDIR}/acpid.conf ${D}${sysconfdir}/admin
+		install -m 0755 ${WORKDIR}/acpid.conf ${D}${sysconfdir}/
 		install -d ${D}${sysconfdir}/acpi
 		install -m 0755 ${WORKDIR}/acpid_poweroff.sh ${D}${sysconfdir}/acpi/poweroff.sh
 		install -d ${D}${sysconfdir}/logrotate.d


### PR DESCRIPTION
### Summary of Changes

Correct acpid.conf destination directory 


### Justification

`admin` folder was incorrectly added


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
