### PR TITLE
Add a systemWebServer workaround for systemd

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -95,6 +95,7 @@ RDEPENDS:${PN} += "\
 	sysconfig-settings \
 	sysconfig-settings-console \
 	syslog-ng \
+	syswebserv-workaround \
 	tar \
 	udev-extraconf \
 	usbutils \

--- a/recipes-ni/ni-sysd-workarounds/files/run_natinst.conf
+++ b/recipes-ni/ni-sysd-workarounds/files/run_natinst.conf
@@ -1,0 +1,1 @@
+d /run/natinst 0777 lvuser ni

--- a/recipes-ni/ni-sysd-workarounds/files/syswebserv_workaround.service
+++ b/recipes-ni/ni-sysd-workarounds/files/syswebserv_workaround.service
@@ -1,0 +1,28 @@
+[Unit]
+SourcePath=/etc/init.d/systemWebServer
+Before=multi-user.target
+Before=graphical.target
+Before=niminionagent.service
+Before=nirtmdnsd.service
+Before=niwifibledd.service
+Before=nisysmgmtmdnspublisher.service
+After=ni-rtfeatures.service
+After=nisvcloc.service
+After=niauth.service
+After=handle_cpld_ip_reset.service
+After=nisdmond.service
+
+[Service]
+Type=forking
+Restart=no
+TimeoutSec=5min
+IgnoreSIGPIPE=no
+KillMode=process
+GuessMainPID=no
+RemainAfterExit=yes
+ExecStart=/etc/init.d/systemWebServer start
+ExecStop=/etc/init.d/systemWebServer stop
+ExecReload=/etc/init.d/systemWebServer reload
+
+[Install]
+WantedBy=default.target

--- a/recipes-ni/ni-sysd-workarounds/syswebserv-workaround.bb
+++ b/recipes-ni/ni-sysd-workarounds/syswebserv-workaround.bb
@@ -1,0 +1,53 @@
+SUMMARY = "systemWebServer systemD workaround files"
+DESCRIPTION = "Workaround for systemWebServer systemD implementation"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+SECTION = "base"
+
+SRC_URI = " \
+	file://syswebserv_workaround.service \
+	file://run_natinst.conf \
+"
+
+DEPENDS += " \
+	update-rc.d-native \
+	shadow-native \
+	pseudo-native \
+"
+
+inherit systemd
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE:${PN} = "syswebserv_workaround.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+
+# Create syswebserv_workaround.service and install to /usr/lib/systemd/system
+FILES:${PN} += " \
+	${systemd_system_unitdir}/syswebserv_workaround.service \
+	${sysconfdir}/tmpfiles.d/run_natinst.conf \
+"
+
+S = "${WORKDIR}"
+
+do_install () {
+	install -d ${D}${systemd_system_unitdir}
+	install -m 0644 ${S}/syswebserv_workaround.service ${D}${systemd_system_unitdir}
+
+	install -d ${D}${sysconfdir}/tmpfiles.d/
+	install -m 0755 ${S}/run_natinst.conf ${D}/etc/tmpfiles.d/
+}
+
+pkg_preinst_on_target:${PN} () {
+	/etc/init.d/systemWebServer stop
+	/sbin/update-rc.d -f systemWebServer remove
+}
+
+pkg_postinst_ontarget:${PN} () {
+	chmod 775 /var/local/natinst
+	chown lvuser:ni /var/local/natinst
+
+	chmod 775 /var/local/natinst/log
+}
+
+RDEPENDS:${PN} += " \
+	bash \
+"


### PR DESCRIPTION
### Summary of Changes

Creates a new systemd workaround recipe for systemWebServer that installs the .service file to /usr/lib/systemd/system. The recipe also creates a .conf file in /etc/tmpfiles.d that updates the permissions of /run/natinst and runs chmod to update the permissions of /var/local/natinst.

[AB#3103453](https://dev.azure.com/ni/DevCentral/_workitems/edit/3103453)

### Justification

These changes are required to get systemWebserver running on systemd machines. The permission changes were required because the /run directory is managed differently by systemd and the updates to /var/local/natinst were required because the default systemd permissions stopped the webserv user from writing there.


### Testing

Built the base image and applied it to a cRIO-9053. I confirmed that the systemWebServer service was running automatically as soon as the device booted and I was able to access it remotely from NI MAX. I also tested this when the device was in safemode.

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
