### PR TITLE
rtctl: Enable support for systemd

### DIFF
--- a/recipes-rt/rtctl/files/rtctl.service
+++ b/recipes-rt/rtctl/files/rtctl.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=RTCTL Daemon
+DefaultDependencies=no
+Before=halt.target reboot.target
+
+[Service]
+Type=forking
+ExecStart=/usr/lib/systemd/scripts/rtctld start
+ExecStop=/usr/lib/systemd/scripts/rtctld stop
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target halt.target reboot.target

--- a/recipes-rt/rtctl/rtctl_1.13.bb
+++ b/recipes-rt/rtctl/rtctl_1.13.bb
@@ -15,6 +15,7 @@ SRC_URI = " \
     file://rtctl-${PV}/rtctld.c \
     file://rtctl-${PV}/init.d/rtctld \
     file://rtgroups \
+    file://rtctl.service \
 "
 SRC_URI[sha256sum] = "33706ea797f99054049c20d709ca0e5c8ae5daccf347b80e8ac2884266439101"
 SRC_URI[md5sum] = "a530ceb797193c54b0d57a05b1e82d24"
@@ -23,10 +24,21 @@ S = "${WORKDIR}/rtctl-${PV}"
 
 RDEPENDS:${PN} += "bash"
 
-inherit update-rc.d
+inherit update-rc.d systemd
 
 INITSCRIPT_NAME = "rtctld"
 INITSCRIPT_PARAMS = "start 99 S . stop 00 0 . stop 00 6 ."
+SYSTEMD_SERVICE:${PN} = "rtctl.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+
+script_location = "${@bb.utils.contains('INIT_MANAGER','sysvinit','${sysconfdir}/init.d','${systemd_unitdir}/scripts',d)}"
+FILES:${PN} += "\
+	${script_location}/rtctld \
+	${sysconfdir}/rtgroups \
+	${sbindir}/rtctl \
+	${sbindir}/rtctld \
+	${@bb.utils.contains('INIT_MANAGER','systemd','${systemd_system_unitdir}/rtctl.service','',d)} \
+"
 
 do_compile() {
     ${CC} -Os ${CFLAGS} rtctld.c -o rtctld ${LDFLAGS}
@@ -36,12 +48,17 @@ do_compile() {
 do_install() {
     install -m 0755 -d ${D}${sbindir}/
     install -m 0755 -d ${D}${sysconfdir}/rtgroups.d/
-    install -m 0755 -d ${D}${sysconfdir}/init.d/
+    install -m 0755 -d ${D}${script_location}/
 
     install -m 0755 ${S}/rtctl ${D}${sbindir}/
     install -m 0755 ${S}/rtctld ${D}${sbindir}/
 
     install -m 0644 ${S}/rtgroups ${D}${sysconfdir}/
 
-    install -m 0755 ${S}/init.d/rtctld ${D}${sysconfdir}/init.d/
+    install -m 0755 ${S}/init.d/rtctld ${D}${script_location}/
+
+    if ${@bb.utils.contains('INIT_MANAGER','systemd','true','false',d)}; then
+        install -d ${D}${systemd_system_unitdir}
+        install -m 0644 ${WORKDIR}/rtctl.service ${D}${systemd_system_unitdir}/
+    fi
 }


### PR DESCRIPTION
### Summary of Changes

Update rtctl service to support systemd

### Justification

Enable rtctl service for systemd


### Testing

TODO: Detail what testing has been done to ensure this submission meets requirements.

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have built the index package feed with this PR in place. (`bitbake package-index`)
* [x] I have built the safemode images with this PR in place. (`bitbake nilrt-safemode-rootfs`)
* [x] I have built the base system image with this PR in place. (`bitbake nilrt-base-system-image`)
* [x] I have applied the systemd nilrt-base-system-image on top of a sysv nilrt-safemode-rootfs


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
