### PR TITLE
linux-nilrt.inc: Add LICENSE to generate SBOM for kernel-modules

### DIFF
--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -41,6 +41,7 @@ SRCREV ?= "${AUTOREV}"
 PV = "${LINUX_VERSION}+git${SRCPV}"
 CVE_VERSION = "${KERNEL_VERSION}+git${SRCPV}"
 
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 LIC_FILES_CHKSUM:xilinx-zynq = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 


### PR DESCRIPTION
### Summary of Changes

The SBOM for safemode image (SPDX for initramfs) was missing numerous kernel-module-* packages. This was because the `LICENSE` was missing from the linux-nilrt recipe, which is now included in linux-nilrt.inc.

### Justification

[AB#2931584](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2931584)


### Testing

I have checked the newly generated SPDX to make sure that the SBOMs have been generated for the kernel-module-* packages. I have also diffed the set of installed package names against the generated SPDX package names.

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
