### PR TITLE
coreutils_9.%.bbappend: Fix priority value of package

### DIFF
--- a/recipes-core/coreutils/coreutils_9.%.bbappend
+++ b/recipes-core/coreutils/coreutils_9.%.bbappend
@@ -19,7 +19,7 @@ RDEPENDS:coreutils:class-target += "\
 	${PN}-timeout \
 "
 
-PRIORITY = "120"
+COREUTILS_PRIORITY = "120"
 
 pkg_postinst:${PN}-hostname () {
 	chmod 4550 $D${base_bindir}/hostname.${BPN}
@@ -33,7 +33,7 @@ pkg_prerm:${PN}-hostname () {
 }
 
 pkg_postinst:${PN}-ls () {
-	update-alternatives --install ${base_bindir}/ls ls ls.${BPN} ${PRIORITY}
+	update-alternatives --install ${base_bindir}/ls ls ls.${BPN} ${COREUTILS_PRIORITY}
 }
 
 pkg_prerm:${PN}-ls () {
@@ -41,7 +41,7 @@ pkg_prerm:${PN}-ls () {
 }
 
 pkg_postinst:${PN}-chcon () {
-	update-alternatives --install ${bindir}/chcon chcon chcon.${BPN} ${PRIORITY}
+	update-alternatives --install ${bindir}/chcon chcon chcon.${BPN} ${COREUTILS_PRIORITY}
 }
 
 pkg_prerm:${PN}-chcon () {
@@ -49,7 +49,7 @@ pkg_prerm:${PN}-chcon () {
 }
 
 pkg_postinst:${PN}-shred () {
-	update-alternatives --install ${bindir}/shred shred shred.${BPN} ${PRIORITY}
+	update-alternatives --install ${bindir}/shred shred shred.${BPN} ${COREUTILS_PRIORITY}
 }
 
 pkg_prerm:${PN}-shred () {
@@ -57,7 +57,7 @@ pkg_prerm:${PN}-shred () {
 }
 
 pkg_postinst:${PN}-timeout () {
-	update-alternatives --install ${bindir}/timeout timeout timeout.${BPN} ${PRIORITY}
+	update-alternatives --install ${bindir}/timeout timeout timeout.${BPN} ${COREUTILS_PRIORITY}
 }
 
 pkg_prerm:${PN}-timeout () {


### PR DESCRIPTION
### Summary of Changes

The priority of the coreutils package had previously been set to a numeric value, instead of the string "optional". This is now being fixed by using a different variable name to set the numeric value of priority.

### Justification

[AB#3079497](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3079497)

### Testing

Checked the priority values of the package before and after the change, as shown in the images below.

| Before change | After change |
|-----|-----|
| ![image](https://github.com/user-attachments/assets/ceafa6c4-0866-49c2-9178-009496d32a33) | ![image](https://github.com/user-attachments/assets/afbe6bfa-cb27-47ec-9990-ca54c35de954) |



* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
