### PR TITLE
ifplugd.action: add support for wired 802.1X

### DIFF
--- a/recipes-core/busybox/files/ifplugd.action
+++ b/recipes-core/busybox/files/ifplugd.action
@@ -12,6 +12,9 @@ export INTERFACE=$1
 
 case "$2" in
    up)
+      if [ -x "/etc/network/if-pre-up.d/wpa-supplicant" ]; then
+         MODE=start IFACE=$INTERFACE IF_WPA_DRIVER=wired IF_WPA_CONF=/etc/natinst/share/wpa_supplicant.wired.$INTERFACE.conf /etc/network/if-pre-up.d/wpa-supplicant
+      fi
       # On link-up, we're not guaranteed to be on the same network as
       # we were before, so we should reprobe for an address if it's
       # automatically configured.
@@ -37,6 +40,9 @@ case "$2" in
       stop_dhcp_server $INTERFACE;
       stop_dhcp_client $INTERFACE;
       stop_linklocal_client $INTERFACE;
+      if [ -x "/etc/network/if-post-down.d/wpa-supplicant" ]; then
+         MODE=stop IFACE=$INTERFACE IF_WPA_DRIVER=wired IF_WPA_CONF=/etc/natinst/share/wpa_supplicant.wired.$INTERFACE.conf /etc/network/if-post-down.d/wpa-supplicant
+      fi
 
       # We clearly aren't going to be able to do DNS on this interface anymore.
       rm -f /etc/resolv.conf.$INTERFACE


### PR DESCRIPTION
### Summary of Changes

update ifplugd.action to call [the wpa-supplicant script][1] in order to support wired 802.1X connections

The wpa-supplicant script will no-op if the .conf file doesn't exist. The location of the .conf file was chosen so that it's available in safe mode. After creating or modifying the .conf file, the user is expected to run `/etc/init.d/networking restart`.

[1]: https://github.com/ni/openembedded-core/blob/7baa3137859915fdbaaea0499b442f5d9df3f17b/meta/recipes-connectivity/wpa-supplicant/wpa-supplicant/wpa-supplicant.sh


### Justification

On a typical linux distribution, the user would access this functionality through `/etc/network/interfaces`, but nilrt ignores that configuration [[reference][2]].

[AB#3044402](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3044402)

[2]: https://github.com/ni/meta-nilrt/blob/beade56ebad058cd77fb2549d65e8ca2a69b9f86/recipes-core/init-ifupdown/files/interfaces#L3


### Testing

I successfully authenticated to a wired 802.1X network using a cRIO-9035, both in run-mode and safe-mode.

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
* This change should be cherry-picked to `nilrt/master/next`.

@ni/rtos @amstewart
