### PR TITLE
nilrt: Change to systemd-compat-units

### DIFF
--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -71,7 +71,7 @@ VIRTUAL-RUNTIME_graphical_init_manager = "xserver-xfce-init"
 
 VIRTUAL-RUNTIME_base-utils-hwclock = "util-linux-hwclock"
 
-VIRTUAL-RUNTIME_initscripts = "initscripts"
+VIRTUAL-RUNTIME_initscripts = "systemd-compat-units"
 
 VIRTUAL-RUNTIME_init_manager = "systemd"
 

--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -26,7 +26,7 @@ RDEPENDS:${PN} += "\
 	${@bb.utils.contains('MACHINE_FEATURES', 'acpi', 'busybox-acpid', '', d)} \
 	${@bb.utils.contains('MACHINE_FEATURES', 'keyboard', 'keymaps', '', d)} \
 	${@bb.utils.contains('INIT_MANAGER', 'systemd', 'systemd', 'sysvinit', d)} \
-	${@bb.utils.contains('INIT_MANAGER', 'systemd', 'systemd-nilrt', '', d)} \
+	${@bb.utils.contains('INIT_MANAGER', 'systemd', 'systemd-nilrt', 'initscripts', d)} \
 	${@bb.utils.contains('INIT_MANAGER', 'systemd', 'services-nilrt', 'initscripts-nilrt', d)} \
 	${@bb.utils.contains('INIT_MANAGER', 'sysvinit', 'eudev', '', d)} \
 	${@bb.utils.contains('INIT_MANAGER', 'systemd', 'niauth-workaround', '', d)} \
@@ -54,7 +54,6 @@ RDEPENDS:${PN} += "\
 	glibc-gconv-utf-16 \
 	gptfdisk \
 	init-ifupdown \
-	initscripts \
 	iproute2 \
 	iptables \
 	kernel-modules \

--- a/recipes-ni/ni-netcfgutil/ni-netcfgutil.bb
+++ b/recipes-ni/ni-netcfgutil/ni-netcfgutil.bb
@@ -41,9 +41,8 @@ FILES:${PN} += "\
 "
 
 RDEPENDS:${PN} += "\
-	${@bb.utils.contains('INIT_MANAGER', 'systemd', 'systemd-nilrt', '', d)} \
+	${@bb.utils.contains('INIT_MANAGER', 'systemd', 'systemd-nilrt', 'initscripts', d)} \
 	${@bb.utils.contains('INIT_MANAGER', 'systemd', 'services-nilrt', 'initscripts-nilrt', d)} \
 	bash \
-	initscripts \
 	ni-utils \
 "


### PR DESCRIPTION
### Summary of Changes

Disable initscripts on systemd 

### Justification

initscripts services are disabled/masked on systemd. Disable initscripts


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have built the base system image with this PR in place ('bitbake nilrt-base-system-image')
* [x] I have installed the base system image on a sysv safemode VM

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
