### PR TITLE
linux-nilrt: Remove System.map from boot dir

### DIFF
--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -73,6 +73,10 @@ DEPENDS:append:armv7a = " dtc-native"
 
 RDEPENDS:kernel-dev += "bash binutils gcc gcc-symlinks"
 
+kernel_do_install:append() {
+	rm ${D}/${KERNEL_IMAGEDEST}/System.map-${KERNEL_VERSION}
+}
+
 do_shared_workdir:append() {
 	cp -rf ./* ${STAGING_KERNEL_BUILDDIR}
 }


### PR DESCRIPTION
The System.map file included in the boot directory takes up 5MB and is able to be safely removed. This commit adds a new bbappend file to remove System.map.

[AB#3112870](https://dev.azure.com/ni/DevCentral/_workitems/edit/3112870)

### Summary of Changes

Adds a new bbappend file for linux-nilrt that removes the System.map file.


### Justification

This file takes up valuable space in the boot partition, can be removed safely,  and is not required for dkms functions. There is also an identical copy of the file that is still included in the /lib/modules directory in case the file is needed for debugging.


### Testing

Built the system image and applied it to a cRIO. I also installed NI driver software, removed it, and verified that I could rebuild the packages from source with dkms.

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
