### PR TITLE
nilrt-logging.bb: Add recipe to install INI file to specify log paths

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -29,6 +29,7 @@ RDEPENDS:${PN} = "\
 	ni-configpersistentlogs \
 	ni-locale-alias \
 	ni-modules-autoload \
+	nilrt-logging \
 	niwatchdogpet \
 	opkg-utils-shell-tools \
 	parted \

--- a/recipes-support/nilrt-logging/files/logging_paths.ini
+++ b/recipes-support/nilrt-logging/files/logging_paths.ini
@@ -1,0 +1,4 @@
+[Dirs]
+Dir1 = /var/log
+Dir2 = /var/local/natinst/log
+Dir3 = /var/lib/pstore

--- a/recipes-support/nilrt-logging/nilrt-logging.bb
+++ b/recipes-support/nilrt-logging/nilrt-logging.bb
@@ -1,0 +1,11 @@
+SUMMARY = "Configuration for NILRT Logging"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+SRC_URI = "file://logging_paths.ini"
+
+FILES:${PN} += "${datadir}/ni-resetniconfig"
+
+do_install() {
+    install -d ${D}${datadir}/ni-resetniconfig
+    install -m 0644 ${WORKDIR}/logging_paths.ini ${D}${datadir}/ni-resetniconfig/logging_paths.ini
+}


### PR DESCRIPTION
### Summary of Changes

An INI file is added at /usr/share/ni-resetniconfig/logging_paths.ini that contains a list of file paths and directory paths. The contents of these paths then get added to the technical report that can be generated through Hardware Config Utility.

### Justification

[AB#3110391](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3110391)


### Testing

I have verified that the INI file is installed at the path /usr/share/ni-resetniconfig/logging_paths.ini upon installing base-system-image. The contents of the file are also present as specified in the file next to the recipe.

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
