### PR TITLE
nilrt-base-system-image.postinst: Enable persistent logging

### DIFF
--- a/recipes-core/images/files/nilrt-base-system-image.postinst
+++ b/recipes-core/images/files/nilrt-base-system-image.postinst
@@ -18,6 +18,10 @@ grub-editenv /boot/grub/grubenv unset enable_initramfs
 # Enable ssh by default when installing SystemLink.
 /usr/local/natinst/bin/nirtcfg -s section=systemsettings,token=sshd.enabled,value=True
 
+# Enable PersistentLogs by default so that technical reports can be generated via
+# Hardware Config Utility.
+/usr/local/natinst/bin/nirtcfg -s section=systemsettings,token=PersistentLogs.enabled,value=True
+
 # Add the memory reservation for Base. We assert that if the section exists,
 # it's already been added.
 if ! grep -q 'RtLinuxMemReserve' /mnt/userfs/etc/natinst/share/ni-rt.ini; then


### PR DESCRIPTION
### Summary of Changes

To include logs from /var/log in the technical report created by Hardware Config Utility, PersistentLogs needs to be enabled since that path is mounted on tmpfs.


### Justification

[AB#3110389](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3110389)


### Testing

Tested that the new installed base system image has PersistentLogs enabled after installation.

| Before | After |
|-----|-----|
| ![image](https://github.com/user-attachments/assets/56a3d24b-7212-4d80-8a14-40833125259a) | ![image](https://github.com/user-attachments/assets/7b508718-0bff-458d-8bf9-8ebaa065a862) |



* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
