### PR TITLE
Enable systemd interface types in busybox-ifplugd

### DIFF
--- a/recipes-core/busybox/files/busybox-ifplugd
+++ b/recipes-core/busybox/files/busybox-ifplugd
@@ -55,7 +55,7 @@ shift
 
 [ "x$*" != "x" ] && INTERFACES="$*"
 
-[ "x$INTERFACES" = "xauto" ] && INTERFACES="`cat /proc/net/dev | awk '{ print $1 }' | egrep '^(eth|wlan|usb)' | cut -d: -f1`"
+[ "x$INTERFACES" = "xauto" ] && INTERFACES="`cat /proc/net/dev | awk '{ print $1 }' | egrep '^(eth|wlan|usb|eno|ens|enp)' | cut -d: -f1`"
 
 case "$VERB" in
     start)

--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -29,6 +29,7 @@ RDEPENDS:${PN} += "\
 	${@bb.utils.contains('INIT_MANAGER', 'systemd', 'systemd-nilrt', 'initscripts', d)} \
 	${@bb.utils.contains('INIT_MANAGER', 'systemd', 'services-nilrt', 'initscripts-nilrt', d)} \
 	${@bb.utils.contains('INIT_MANAGER', 'sysvinit', 'eudev', '', d)} \
+	${@bb.utils.contains('INIT_MANAGER', 'sysvinit', 'modutils-initscripts', '', d)} \
 	${@bb.utils.contains('INIT_MANAGER', 'systemd', 'niauth-workaround', '', d)} \
 	avahi-daemon \
 	base-files \
@@ -69,7 +70,6 @@ RDEPENDS:${PN} += "\
 	linux-firmware-i915 \
 	logrotate \
 	lsbinitscripts \
-	modutils-initscripts \
 	netbase \
 	ni-hw-scripts \
 	ni-rtfeatures \


### PR DESCRIPTION
### Summary of Changes

Enable `ens`, `eno`, and `enp` network interfaces for systemd
Disable `modutils-initscripts` on systemd 


### Justification

Networks are failing to function on systemd 


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have built the nilrt base system image with this PR in place. ('bitbake nilrt-base-system-image`)
* [x] Applied the nilrt-base-system-image on sysv safemode target
* [x] Validated network interfaces are enabled

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
