### PR TITLE
kernel_serial: Account for kernel 6.12 class dir path

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-tests-files/test_kernel_serial_devices.sh
+++ b/recipes-kernel/kernel-tests/kernel-tests-files/test_kernel_serial_devices.sh
@@ -48,6 +48,9 @@ function _commasep { local IFS=","; echo "$*"; }
 
 function _is_isa_bridge () {
 	DEVPATH=$1
+	if [ ! -f "${DEVPATH}/class" ]; then
+		DEVPATH="$(realpath "${DEVPATH}/../..")"
+	fi
 	PCI_CLASS=$(cat ${DEVPATH}/class)
 	# device subclass 06:01 == ISA bridge
 	if [ $(( $PCI_CLASS & 0xFFFF00 )) -eq $(( 0x060100 )) ]; then


### PR DESCRIPTION
### Summary of Changes

Update `test_kernel_serial_devices.sh` script to account for new PCI_CLASS path in kernel 6.12


### Justification

[AB#3122080](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3122080)


### Testing

TODO: Detail what testing has been done to ensure this submission meets requirements.

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have validated the changes function correctly on a failing system

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
