### PR TITLE
kernel_serial: Account for kernel 6.12 class dir path

### DIFF
--- a/recipes-kernel/kernel-tests/kernel-tests-files/test_kernel_serial_devices.sh
+++ b/recipes-kernel/kernel-tests/kernel-tests-files/test_kernel_serial_devices.sh
@@ -48,6 +48,9 @@ function _commasep { local IFS=","; echo "$*"; }
 
 function _is_isa_bridge () {
 	DEVPATH=$1
+	if [ ! -f "${DEVPATH}/class" ]; then
+		DEVPATH="$(realpath "${DEVPATH}/../..")"
+	fi
 	PCI_CLASS=$(cat ${DEVPATH}/class)
 	# device subclass 06:01 == ISA bridge
 	if [ $(( $PCI_CLASS & 0xFFFF00 )) -eq $(( 0x060100 )) ]; then
@@ -142,6 +145,11 @@ function test_serial_devices () {
 		# platform buses (e.g., built into the controller)
 		if _is_onboard_serial $TTY; then
 			PORT=$(cat /sys/class/tty/$TTY/port)
+			if [ "${PORT}" == "0x0" ]; then
+				# If the port is 0x0, it means the device node exists,
+				# but the serial port is not configured, so skip it.
+				continue
+			fi
 			ACTUAL+=("$TTY:$PORT")
 		fi
 	done


### PR DESCRIPTION
### Summary of Changes

Update `test_kernel_serial_devices.sh` script to account for new PCI_CLASS path in kernel 6.12


### Justification

[AB#3122080](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3122080)


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have validated the script on a failing system with configured serial port(s)
* [x] I have validated the script on a failing system with NO configured serial port

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
