### PR TITLE
grub-runmode-bootimage: Add clearcache to cmdline

### DIFF
--- a/recipes-bsp/grub/grub/grub-runmode-bootimage.cfg
+++ b/recipes-bsp/grub/grub/grub-runmode-bootimage.cfg
@@ -3,7 +3,7 @@
 set consoleparam='console=tty0 console=ttyS0,115200n8'
 set kernel_path='/runmode/bzImage'
 
-set otherbootargs="rootwait rw usbcore.usbfs_memory_mb=0 consoleblank=0 rcu_nocbs=all ibt=off "
+set otherbootargs="rootwait rw usbcore.usbfs_memory_mb=0 consoleblank=0 rcu_nocbs=all ibt=off clearcache "
 
 # This file is used to disable CPU vulnerability mitigations for
 # performance reasons. nirtcfg refers to these paths specifically for


### PR DESCRIPTION
populate-volatile.sh initscript is used to create directories/files in common volatile locations such as /var/log, /var/volatile/log, /run, /var/run, etc. When the script is first run, all configuration files are read and /etc/volatile.cache is generated and executed. On subsequent boots, /etc/volatile.cache is executed if it exists.

Packages can add volatile configuration files under /etc/default/volatiles to specify which directories/files need to be created.

But if a package that isn't part of BSI is installed, it's volatile configuration file is never read as /etc/volatile.cache already exists and is not updated by default.

To force /etc/volatile.cache to update on every run, add 'clearcache' kernel commandline param.

----------

We noticed this issue when installing `samba`. postinst fails and samba cannot be started due to absence of `/var/log/samba` and `/run/samba` directories which samba expects to be created by populate-volatile.sh. This issue is present in older releases as well.
With this change, the target can be rebooted (or `/etc/init.d/populate-volatile.sh` can be manually run) to create the dirs after which point `samba` can be started.

The ideal solution would be that `populate-volatile.sh` be invoked in postinst of every package that has volatile configurations so that a target reboot or manually running `populate-volatile.sh` isn't required.

WI: [AB#3153258](https://dev.azure.com/ni/DevCentral/_workitems/edit/3153258)

### Testing

- [x] Manually added `clearcache ` to /boot/runmode/bootimage.cfg on a target and verified `/etc/init.d/populate-volatile.sh` re-evaluates volatile configurations and creates files/dirs on every run.

Did NOT do any OE builds as this is a simple change.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
