### PR TITLE
[25.5/scarthgap] nilrt-snac: staple to v2.1.0

### DIFF
--- a/recipes-ni/nilrt-snac/nilrt-snac_git.bb
+++ b/recipes-ni/nilrt-snac/nilrt-snac_git.bb
@@ -1,6 +1,7 @@
 SUMMARY = "NILRT SNAC Configuration Tool"
 DESCRIPTION = "\
-A utility for admins to put a NILRT system into the SNAC configuration.\
+A utility that helps system administrators place their NI LinuxRT (NILRT) \
+devices into a Secured, Network-Attached Configuration (SNAC).\
 "
 HOMEPAGE = "https://github.com/ni/nilrt-snac"
 SECTION = "base"
@@ -13,8 +14,8 @@ SRC_URI = "\
 	file://run-ptest \
 "
 
-SRCREV = "${AUTOREV}"
-PV = "2.0.0+git${SRCPV}"
+SRCREV = "fba68a59f219b6d3a0b78bb2deb779ac2db41db4"
+PV = "2.1.0"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Service for the NILRT 11.2 release.

Release corresponding to the LV 2025Q3 / NILRT 11.2 release.

* Syslog outbound traffic is now permitted on the firewall's 'work' zone.
* Fixed a bug in the auditd configuration where the service's initscript would not be registered with update-rc.d.
* Fixed a bug in the auditd configuration that would cause an internal python error when trying to verify a system where the `auditd.conf` file does not exist.


### Testing

* [x] Built the `nilrt-snac` recipe with this change. Verified that the IPK looks well-formed.
* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
