### PR TITLE
nilrt-snac: upgrade to v2.1.0

### DIFF
--- a/recipes-ni/nilrt-snac/nilrt-snac_git.bb
+++ b/recipes-ni/nilrt-snac/nilrt-snac_git.bb
@@ -1,6 +1,7 @@
 SUMMARY = "NILRT SNAC Configuration Tool"
 DESCRIPTION = "\
-A utility for admins to put a NILRT system into the SNAC configuration.\
+A utility that helps system administrators place their NI LinuxRT (NILRT) \
+devices into a Secured, Network-Attached Configuration (SNAC).\
 "
 HOMEPAGE = "https://github.com/ni/nilrt-snac"
 SECTION = "base"
@@ -14,7 +15,7 @@ SRC_URI = "\
 "
 
 SRCREV = "${AUTOREV}"
-PV = "2.0.0+git${SRCPV}"
+PV = "2.1.0+git${SRCPV}"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
### Summary of Changes

Release corresponding to the LV 2025Q3 / NILRT 11.2 release.

* Syslog outbound traffic is now permitted on the firewall's 'work' zone.

* Fixed a bug in the auditd configuration where the service's initscript would not be registered with update-rc.d.
* Fixed a bug in the auditd configuration that would cause an internal python error when trying to verify a system where the auditd.conf file does not exist.


### Justification

Regular cyclic upgrade.


### Testing


* [x] Built `nilrt-snac` with this patchset and confirmed that it succeeds.
* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* This patchset should be cherry-picked into the `next` mainline.
* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
