### PR TITLE
niconfiguretracefs: restrict tracefs permissions

### DIFF
--- a/recipes-ni/initscripts-nilrt/files/niconfiguretracefs
+++ b/recipes-ni/initscripts-nilrt/files/niconfiguretracefs
@@ -3,8 +3,15 @@
 # All rights reserved.
 
 debugfs_path="/sys/kernel/debug"
-tracefs_path="/sys/kernel/debug/tracing"
+tracefs_path="$debugfs_path/tracing"
+tracing_on_path="$tracefs_path/tracing_on"
+trace_marker_path="$tracefs_path/trace_marker"
+
+# tracefs is created in a weird state; poke it to make it real
+touch -c $tracefs_path/dummy
 
 # Change the permissions so lvrt user can control ftrace
 chmod a+rx $debugfs_path
-chown -R lvuser $tracefs_path
+chmod a+rx $tracefs_path
+chown lvuser $tracing_on_path
+chown lvuser $trace_marker_path


### PR DESCRIPTION
### Summary of Changes

Rather than provide permissions to lvuser for all tracefs entries, instead only give permissions for the minimal set of entries needed to start/stop tracing and log a custom string.

These operations are low-risk as they do not allow access to the trace contents. It is also important for these operations to have low overhead as they are inserted into the user's program execution. We do not want to incur unnecessary performance burden or pollute the trace contents by requiring admin permissions for these operations.

### Justification

[AB#2958882](https://dev.azure.com/ni/DevCentral/_workitems/edit/2958882)

### Testing

Built package locally and inspected. Built image, installed on a system, inspected and tested.

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)

### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
