### PR TITLE
ni-tracefs-utils: add scripts for limited tracefs access

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -29,6 +29,7 @@ RDEPENDS:${PN} = "\
 	ni-configpersistentlogs \
 	ni-locale-alias \
 	ni-modules-autoload \
+	ni-tracefs-utils \
 	nilrt-logging \
 	niwatchdogpet \
 	opkg-utils-shell-tools \

--- a/recipes-ni/ni-tracefs-utils/files/sudoers
+++ b/recipes-ni/ni-tracefs-utils/files/sudoers
@@ -1,0 +1,3 @@
+# Allow lvuser to have controlled access to kernel tracing mechanism via scripts
+lvuser ALL=(ALL:ALL) NOPASSWD: /sbin/traceextract
+lvuser ALL=(ALL:ALL) NOPASSWD: /sbin/traceconfig

--- a/recipes-ni/ni-tracefs-utils/files/traceconfig
+++ b/recipes-ni/ni-tracefs-utils/files/traceconfig
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+echo 0 > /sys/kernel/debug/tracing/tracing_on
+# Write to trace file in order to clear the trace buffer
+echo > /sys/kernel/debug/tracing/trace
+echo 1 > /sys/kernel/debug/tracing/events/enable
+echo "$1" > /sys/kernel/debug/tracing/buffer_size_kb

--- a/recipes-ni/ni-tracefs-utils/files/traceextract
+++ b/recipes-ni/ni-tracefs-utils/files/traceextract
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+sudo -u lvuser touch "$1"
+chmod 440 "$1"
+chown admin:administrators "$1"
+trace-cmd extract -o "$1"

--- a/recipes-ni/ni-tracefs-utils/ni-tracefs-utils.bb
+++ b/recipes-ni/ni-tracefs-utils/ni-tracefs-utils.bb
@@ -1,0 +1,33 @@
+SUMMARY = "NI tracefs utility scripts"
+DESCRIPTION = "Installs scripts for accessing the kernel tracing mechanism."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+SECTION = "base"
+
+PV = "1.0"
+
+SRC_URI = "\
+	file://traceconfig \
+	file://traceextract \
+	file://sudoers \
+"
+
+FILES:${PN} += "\
+        ${datadir}/ni-tracefs-utils/* \
+        ${sysconfdir}/sudoers.d/* \
+"
+CONFFILES:${PN} = "${sysconfdir}/sudoers.d/*"
+
+RDEPENDS:${PN} += "niacctbase bash sudo-lib"
+
+S = "${WORKDIR}"
+
+do_install () {
+	install -d ${D}${base_sbindir}
+
+	install -m 0550   ${WORKDIR}/traceconfig         ${D}${base_sbindir}
+	install -m 0550   ${WORKDIR}/traceextract         ${D}${base_sbindir}
+
+        install -d ${D}${sysconfdir}/sudoers.d/
+        install --mode=0660 ${S}/sudoers ${D}${sysconfdir}/sudoers.d/${PN}
+}


### PR DESCRIPTION
### Summary of Changes

Add scripts that provide controlled access for lvuser to execute tracing operations. The scripts ensure trace data can only be written to files with admin permissions.

### Justification

[AB#2958882](https://dev.azure.com/ni/DevCentral/_workitems/edit/2958882)

### Testing

Built package locally and inspected. Built image, installed on a system, inspected and tested.

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
