### PR TITLE
Add usbguard to SNAC package group

### DIFF
--- a/recipes-core/packagegroups/packagefeed-ni-extra.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-extra.bb
@@ -328,7 +328,6 @@ RDEPENDS:${PN} += "\
 	can-utils \
 	tcsh \
 	tipcutils \
-	tmux \
 	zram \
 "
 

--- a/recipes-core/packagegroups/packagegroup-ni-snac.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-snac.bb
@@ -13,5 +13,6 @@ RDEPENDS:${PN} = "\
 	nilrt-snac \
 	ntp \
 	tmux \
+	usbguard \
 	wireguard-tools \
 "


### PR DESCRIPTION
### Summary of Changes

This commit adds the `usbguard` package to `packagegroup-ni-snac` package group, ensuring it is included in relevant builds.

In the `packagefeed-ni-extra` group, removed `tmux` - `tmux` is also in `packagegroup-ni-snac` which ends up in core so is not needed in extra.

### Justification

[AB#3093658](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3093658)


### Testing

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [X] I have installed the newly build ipk
* [X] I have verified that both `usbguard` and `usbguard-daemon` run


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
