### PR TITLE
[sumo] nilrt.conf: Bump DISTRO_VERSION, NILRT_FEED_NAME

### DIFF
--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -2,9 +2,9 @@ require nilrt.inc
 
 DISTRO_NAME = "NI Linux Real-Time"
 
-DISTRO_VERSION = "8.24"
+DISTRO_VERSION = "8.25"
 
-NILRT_FEED_NAME ?= "2025Q3"
+NILRT_FEED_NAME ?= "2025Q4"
 
 DISTRO_FEATURES_append_x64 = "\
         x11 \


### PR DESCRIPTION
### Summary of Changes

Update Sumo `DISTRO_VERSION` and `NILRT_FEED_NAME` for 25C3 (2025Q4) cycle

### Justification

[AB#3039656](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3039656)


### Testing

None

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
