### PR TITLE
usbguard.bbappend: Update initscript parameters to remove unnecessary start options

### DIFF
--- a/recipes-security/usbguard/usbguard_1.%.bbappend
+++ b/recipes-security/usbguard/usbguard_1.%.bbappend
@@ -6,7 +6,7 @@ SRC_URI += "file://usbguard.init \
 inherit update-rc.d
 
 INITSCRIPT_NAME = "usbguard"
-INITSCRIPT_PARAMS = "start 20 2 3 4 5 . stop 80 0 1 6 ."
+INITSCRIPT_PARAMS = "stop 80 0 1 6 ."
 
 # Runtime dependencies for proper operation
 RDEPENDS:${PN} += "bash"


### PR DESCRIPTION
### Summary of Changes

`usbguard` will block some but not all USB devices when the `rules.conf` file is empty, such as directly after install. This could potentially block use of the system if critical devices are disallowed. This change will only install a stop link to the service. Manual instructions elsewhere will say how to enable it once configured.


### Justification

[AB#3093670](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3093670)


### Testing

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [X] I have built the package index with this PR in place. (`bitbake package-index`)
* [X] Installed resulting ipk on test system and observed expected install behavior



### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
