### PR TITLE
linux-nilrt*: Update to kernel 6.12

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-debug_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-debug_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NILRT linux kernel debug build"
 NI_RELEASE_VERSION = "master"
-LINUX_VERSION = "6.6"
+LINUX_VERSION = "6.12"
 LINUX_VERSION:xilinx-zynq = "4.14"
 LINUX_KERNEL_TYPE = "debug"
 

--- a/recipes-kernel/linux/linux-nilrt-nohz_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-nohz_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NILRT linux kernel full dynamic ticks (NO_HZ_FULL) build"
 NI_RELEASE_VERSION = "master"
-LINUX_VERSION = "6.6"
+LINUX_VERSION = "6.12"
 LINUX_KERNEL_TYPE = "nohz"
 
 require linux-nilrt-alternate.inc

--- a/recipes-kernel/linux/linux-nilrt_git.bb
+++ b/recipes-kernel/linux/linux-nilrt_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Linux kernel based on nilrt branch"
 NI_RELEASE_VERSION = "master"
-LINUX_VERSION = "6.6"
+LINUX_VERSION = "6.12"
 LINUX_VERSION:xilinx-zynq = "4.14"
 
 require linux-nilrt.inc


### PR DESCRIPTION
### Summary of Changes
Update default, debug and nohz kernels to 6.12.


### Justification

WI: [AB#3144270](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3144270)


### Testing

Tested that the image is working fine with the changed kernels.
"SafeMode"
<img width="1272" height="667" alt="image" src="https://github.com/user-attachments/assets/7ef48e6d-5a10-479b-88a1-7b87c8349abd" />

"Base-System Image"
<img width="1277" height="555" alt="image" src="https://github.com/user-attachments/assets/a7b01730-08c9-49c6-a491-b90c056a42fd" />

"Debug-kernel-6.12"
<img width="1276" height="538" alt="image" src="https://github.com/user-attachments/assets/b94d6b70-db67-428d-bd49-044b6ca6f377" />

"Nohz-kernel-6.12"
<img width="1275" height="588" alt="image" src="https://github.com/user-attachments/assets/d0bac93c-191d-41bc-b7b7-3e1ace090660" />






### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
