### PR TITLE
pkggrp-kernel-mod-essential: remove EOL modules

### DIFF
--- a/recipes-kernel/packagegroups/packagegroup-kernel-modules-essential.bb
+++ b/recipes-kernel/packagegroups/packagegroup-kernel-modules-essential.bb
@@ -325,7 +325,6 @@ RDEPENDS:${PN} = "\
 	kernel-module-nic7018-wdt \
 	kernel-module-nlmon \
 	kernel-module-nls-ucs2-utils \
-	kernel-module-ntfs \
 	kernel-module-ntfs3 \
 	kernel-module-nvme-fabrics \
 	kernel-module-nvme-rdma \
@@ -531,7 +530,6 @@ RDEPENDS:${PN} = "\
 	kernel-module-xt-time \
 	kernel-module-xt-u32 \
 	kernel-module-zaurus \
-	kernel-module-zd1201 \
 	kernel-module-zd1211rw \
 	kernel-module-zstd \
 	kernel-module-zstd-compress \


### PR DESCRIPTION
### Summary of Changes

It is necessary to remove below modules from the meta-package as they have been deprecated or EOLed. If not removed, the BSI would fail to build with kernel 6.12.
1. kernel-module-ntfs: EOL details: [7ffa8f3](https://github.com/ni/linux/commit/7ffa8f3d30236e0ab897c30bdb01224ff1fe1c89) ("fs: Remove NTFS classic")
2. kernel-module-zd1201: EOL details: [757a46c](https://github.com/ni/linux/commit/757a46c2a7a99a4e12f6a267e945c98324c41702) ("wifi: remove orphaned zd1201 driver")

### Justification

[AB#3144269](https://dev.azure.com/ni/DevCentral/_workitems/edit/3144269)


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
