### PR TITLE
nisetupkernelconfig: Disable the fair server

### DIFF
--- a/recipes-ni/initscripts-nilrt/files/nisetupkernelconfig
+++ b/recipes-ni/initscripts-nilrt/files/nisetupkernelconfig
@@ -21,6 +21,17 @@ echo 1 > /proc/sys/fs/suid_dumpable
 #This disables RT scheduler's CPU throttling for National Instruments LabVIEW Real-Time
 echo -1 > /proc/sys/kernel/sched_rt_runtime_us
 
+#Set the runtime for the fair server (in nanoseconds, 0: disabled)
+FAIR_RUNTIME=0
+for cpu_dir in /sys/kernel/debug/sched/fair_server/cpu*; do
+    runtime_file="$cpu_dir/runtime"
+    if [ -w "$runtime_file" ]; then
+        echo "$FAIR_RUNTIME" > "$runtime_file"
+    else
+        echo "error: cannot write to $runtime_file (permission denied or file does not exist)"
+    fi
+done
+
 #This forces CPU affinity of IRQs to Core-0. Some reserved IRQs and specific IRQs
 #such as timer-watch-dog (twd) are per core and their affinity cannot be changed
 #and thus we ignore the errors on those by redirecting error to /dev/null.


### PR DESCRIPTION
Kernel commit 63ba8422f876 ("sched/deadline: Introduce deadlineservers") and associated commits following it introduced the concept of deadline servers.

SCHED_DEADLINE servers can help fix starvation issues of low priority tasks (e.g., SCHED_OTHER) when higher priority tasks monopolize CPU cycles. They do this by reserving a "runtime" slice out of a set "period" for lower priority tasks. Since this is in essence an intentional priority inversion it has the side effect of increased latency in real-time tasks (e.g., SCHED_FIFO).

Disable the "fair server" by setting the
'/sys/kernel/debug/sched/fair_server/cpu*/runtime' value to 0

This restores the previous behavior where real-time tasks always have priority (and matches the existing setup where RT throttling is disabled).

Link: https://lkml.kernel.org/r/4968601859d920335cf85822eb573a5f179f04b8.1699095159.git.bristot@kernel.or

### Justification

Fixes latency regressions in the 6.12 kernel performance benchmarks.
[AB#3121056](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3121056)

### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] Installed `opkg install initscripts-nilrt` on an NILRT target
* [x] Verified the `/etc/init.d/nisetupkernelconfig` functions correctly with kernels which have CONFIG_SCHED_DEBUG enabled and shows an error otherwise

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
