### PR TITLE
Return protoc to the package feeds.

### DIFF
--- a/recipes-devtools/protobuf/protobuf_%.bbappend
+++ b/recipes-devtools/protobuf/protobuf_%.bbappend
@@ -1,0 +1,4 @@
+
+# Setting the 'compiler' PACKAGECONFIG tells the base recipe to build and package the 'protoc' compiler.
+# It is generally useful for NILRT users to have protoc, so that they can compile protobuf projects on-device.
+PACKAGECONFIG:append = " compiler"


### PR DESCRIPTION
### Summary of Changes

The meta-OE protobuf recipe used to (prior to Scarthgap) build and package the `protoc` protobuf compiler binaries into the `libprotobuf-compiler` IPK. Post-Scarthgap, that is no longer the default and the recipe instead packages *only* the `libprotoc` SO library into a `libprotoc` IPK (without the `protoc` binary).

This patchset returns `protoc` to the feeds by asserting the 'compiler' PACKAGECONFIG in `protobuf.bb`.


### Justification

The 'compiler' PACKAGECONFIG option enables compilation and packaging for the protobuf 'protoc' compiler. NILRT users need protoc to compile most protobuf-depending projects on-target.

### Testing

Built `protobuf` recipe IPKs before this change. Notice the `libprotoc` IPK  - which does not contain `protoc`.

```
usr0@rtosams3:~/projects/nilrt/nilrt/build/tmp-glibc/work/core2-64-nilrt-linux/protobuf/4.25.8$ ls deploy-ipks/core2-64/
libprotobuf25.8.0_4.25.8-r0.7_core2-64.ipk       libprotobuf-ptest_4.25.8-r0.7_core2-64.ipk
libprotobuf-dbg_4.25.8-r0.7_core2-64.ipk         libprotobuf-src_4.25.8-r0.7_core2-64.ipk
libprotobuf-dev_4.25.8-r0.7_core2-64.ipk         libprotobuf-staticdev_4.25.8-r0.7_core2-64.ipk
libprotobuf-lic_4.25.8-r0.7_core2-64.ipk         libprotoc25.8.0_4.25.8-r0.7_core2-64.ipk
libprotobuf-lite25.8.0_4.25.8-r0.7_core2-64.ipk
```

Built `protobuf` recipe IPKs after this change. Notice that `libprotoc` has been replaced by `libprotobuf-compiler` - which contains **both** `libprotoc` and the `protoc` binary.

```
usr0@rtosams3:~/projects/nilrt/nilrt/build/tmp-glibc/work/core2-64-nilrt-linux/protobuf/4.25.8$ ls deploy-ipks/core2-64/
libprotobuf25.8.0_4.25.8-r0.8_core2-64.ipk     libprotobuf-lite25.8.0_4.25.8-r0.8_core2-64.ipk
libprotobuf-compiler_4.25.8-r0.8_core2-64.ipk  libprotobuf-ptest_4.25.8-r0.8_core2-64.ipk
libprotobuf-dbg_4.25.8-r0.8_core2-64.ipk       libprotobuf-src_4.25.8-r0.8_core2-64.ipk
libprotobuf-dev_4.25.8-r0.8_core2-64.ipk       libprotobuf-staticdev_4.25.8-r0.8_core2-64.ipk
libprotobuf-lic_4.25.8-r0.8_core2-64.ipk
```

```
./usr/
./usr/bin/
./usr/bin/protoc
./usr/bin/protoc-25.8.0
./usr/lib/
./usr/lib/libprotoc.so.25.8.0
```

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
