### PR TITLE
Revert "protobuf: set 'compiler' PACKAGECONFIG"

### DIFF
--- a/recipes-devtools/protobuf/protobuf_%.bbappend
+++ b/recipes-devtools/protobuf/protobuf_%.bbappend
@@ -1,4 +1,0 @@
-
-# Setting the 'compiler' PACKAGECONFIG tells the base recipe to build and package the 'protoc' compiler.
-# It is generally useful for NILRT users to have protoc, so that they can compile protobuf projects on-device.
-PACKAGECONFIG:append = " compiler"


### PR DESCRIPTION
### Summary of Changes

This reverts commit e887d52184b9d4363a0394e3db9e3988067f123a. (PR #865)

Rationale. When the protobuf recipe is set to build protoc binaries, they are installed into the protobuf sysroot - apparently correctly. But due to complicated reasons that I do not understand, that breaks cmake builds that use protobuf, as in ni-grpc-device and other place (esp QT). Upstream OE ran into this issue as well.

I don't yet know that this issue is unfixable, but it is too disruptive to enter into this release. So revert it for now.


### Justification

[AB#3262975](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3262975)


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
