### PR TITLE
sudo: make sudoers sed resistant to whitespace changes

### DIFF
--- a/recipes-extended/sudo/sudo_1.%.bbappend
+++ b/recipes-extended/sudo/sudo_1.%.bbappend
@@ -1,3 +1,3 @@
 do_install:append() {
-	sed -i 's/^# \(%sudo	ALL=(ALL:ALL) ALL\)$/\1/' ${D}${sysconfdir}/sudoers
+	sed -i 's/^#\s\(%sudo\sALL=(ALL:ALL)\sALL\)$/\1/' ${D}${sysconfdir}/sudoers
 }


### PR DESCRIPTION
### Summary of Changes

The upstream sudoers file [replaced](https://github.com/sudo-project/sudo/commit/7c121ff8340c6fa551ba4997dde9d450cf74e40c) a tab character with a whitespace
character and broke our sudo bbappend's sed command. Replace all the
whitespaces between words in the regex match statement with whitespace
metacharacters to make the regex more resistant to future whitespace
changes.

### Justification

[AB#3261612](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3261612)

### Testing

* [x] Manually compared the value of the `/etc/sudo/sudoers` file in the sudo package before and after this change. Confirmed that the install step now uncomments the config line that gives members of the `sudo` group permissions to run any command.
* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).

This PR is a necessary fix for the 25.8 release. It should be cherry-picked to the scarthgap mainline (and next/).
