### PR TITLE
salt: Staple recipe for 25.8 release

### DIFF
--- a/recipes-support/salt/salt_3000.2.bb
+++ b/recipes-support/salt/salt_3000.2.bb
@@ -18,7 +18,7 @@ PACKAGECONFIG[tcp] = ",,python3-pycryptodome"
 PACKAGECONFIG[zeromq] = ",,python3-pycryptodome python3-pyzmq"
 
 SRC_URI = "\
-    git://github.com/ni/salt.git;protocol=https;branch=ni/master/3000.2 \
+    git://github.com/ni/salt.git;protocol=https;branch=ni/skyline-25.8/3000.2 \
     file://minion \
     file://salt-minion \
     file://salt-common.bash_completion \


### PR DESCRIPTION
### Summary of Changes

salt: Staple recipe for 25.8 release.

**Note**: salt team hasn't yet created a 25.8 release branch but there haven't been any new changes in their master branch since 25.5 release. So pinning to 25.5 release branch. If salt team ends up creating a release branch for 25.8 within the next day, will put up another PR to update.

### Justification

WI: [AB#3126227](https://dev.azure.com/ni/DevCentral/_workitems/edit/3126227)

### Testing

None

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
