### PR TITLE
[25.8] nilrt-snac: staple to v3.0.0

### DIFF
--- a/recipes-ni/nilrt-snac/nilrt-snac_git.bb
+++ b/recipes-ni/nilrt-snac/nilrt-snac_git.bb
@@ -14,8 +14,8 @@ SRC_URI = "\
 	file://run-ptest \
 "
 
-SRCREV = "${AUTOREV}"
-PV = "2.1.0+git${SRCPV}"
+SRCREV = "4f33d3bb23fbca711a6c9a4f9b4f4a073faaffb8"
+PV = "3.0.0"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION

### Summary of Changes

Staple the nilrt-snac recipe to the v3.0.0 release.

https://github.com/ni/nilrt-snac/releases/tag/v3.0.0


### Justification

Service for the NILRT 11.3 release. LV 2025Q4.


### Testing

* [x] Rebuilt the `nilrt-snac` recipe with this staple in place and confirmed that IPKs are now versioned v3.0.0.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
