### PR TITLE
nilrt-bsi.postinst: umask opkg-keyring calls

### DIFF
--- a/recipes-core/images/files/nilrt-base-system-image.postinst
+++ b/recipes-core/images/files/nilrt-base-system-image.postinst
@@ -117,4 +117,4 @@ done
 
 # Upgrade opkg-keyrings so that users can get the latest signing keys
 # OR the command with true since the postinst script shouldn't return an error if the opkg update + upgrade fails.
-opkg -o /mnt/userfs/ update && opkg -o /mnt/userfs/ upgrade opkg-keyrings || true
+umask 022 && opkg -o /mnt/userfs/ update && opkg -o /mnt/userfs/ upgrade opkg-keyrings || true


### PR DESCRIPTION
### Summary of Changes

Update opkg-keyring calls to be `umask 022`


### Justification

[AB#3315103](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3315103)


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have built the base system image with this PR in place. (`bitbake nilrt-base-system-image`)
* [x] I have applied the base system image on a target via MAX and validated the permissions of opkg-keyrings.list

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
