### PR TITLE
[Draft PR] Support cgroups v1 and v2 based on installed LV version

### DIFF
--- a/recipes-ni/initscripts-nilrt/files/lvrt-cgroup.sh
+++ b/recipes-ni/initscripts-nilrt/files/lvrt-cgroup.sh
@@ -7,15 +7,22 @@ identify_lvrt_cgroup_version()
 	# Return early if a version is already set
 	[ -z "$LVRT_CGROUP_VERSION" ] || return 0
 
-	# If lvrt is not installed set version to 0, cgroups not used
+	# If LabVIEW RT is not installed, default to cgroups v2
 	lvrt_installed=$(opkg list-installed ni-labview-realtime)
 	if [ -z "$lvrt_installed" ]; then
-		LVRT_CGROUP_VERSION=0
-		return 1
+		LVRT_CGROUP_VERSION=2
+		return 0
 	fi
 
-	# By default assume LabVIEW RT uses cgroups-v1 (current situation). This
-	# will be amended when LV cgroup-v2 upgrade is implemented.
-	LVRT_CGROUP_VERSION=1
+	# Extract installed LabVIEW RT version
+	lvrt_version=$(awk '{print $3}' <<<"$lvrt_installed")
+	
+	# Get major version
+	major_version=${lvrt_version%%.*}
+	if [ "$major_version" -le 23 ]; then
+		LVRT_CGROUP_VERSION=1
+	else
+		LVRT_CGROUP_VERSION=2
+	fi
 	return 0
 }

--- a/recipes-ni/initscripts-nilrt/files/nicreatecpuacctgroups
+++ b/recipes-ni/initscripts-nilrt/files/nicreatecpuacctgroups
@@ -3,40 +3,59 @@
 # All rights reserved.
 
 # Exit early if LabVIEW RT does not use cgroup-v1
+
+# Source cgroup version detection
 . /usr/share/initscripts-nilrt/lvrt-cgroup.sh
 identify_lvrt_cgroup_version || exit 0
-[ "$LVRT_CGROUP_VERSION" -eq 1 ] || exit 0
 
-#echo -n "Creating cgroups for CPU accounting for National Instruments LabVIEW Real-Time:"
-[ "${VERBOSE}" != "no" ] && echo -n "Starting nicreatecpuacctgroups:"
-mkdir -p /dev/cgroup/cpuacct
-mount -t cgroup -ocpuacct none /dev/cgroup/cpuacct
-cd /dev/cgroup/cpuacct
-mkdir LabVIEW_Timed-Structures_group
-mkdir LabVIEW_Time-Critical_group
-mkdir ISR_group
-mkdir other_group
+if [ "$LVRT_CGROUP_VERSION" -eq 1 ]; then
+	# cgroup v1 logic
+	[ "${VERBOSE}" != "no" ] && echo -n "Starting nicreatecpuacctgroups (cgroup v1):"
+	mkdir -p /dev/cgroup/cpuacct
+	mount -t cgroup -ocpuacct none /dev/cgroup/cpuacct
+	cd /dev/cgroup/cpuacct
+	mkdir LabVIEW_Timed-Structures_group
+	mkdir LabVIEW_Time-Critical_group
+	mkdir ISR_group
+	mkdir other_group
 
-# fast_task_writes was added to 3.2 for performance reasons, but does not exist and is not
-# necessary in the 3.10 kernel. 
-[ -e ./other_group/cgroup.fast_task_writes ] && echo 1 > ./other_group/cgroup.fast_task_writes
-while read TASK
-do
-	echo $TASK > "./other_group/tasks" 2> /dev/null 
-	# cgroup behavior as of 3.10 kernel has been altered 
-	# such that certain tasks cannot be assigned to any cgroup.
-	# Because of this change an error for trying to assign those
-	# tasks can be ignored in this loop and the following loop. 
-done < "tasks"
-[ -e ./other_group/cgroup.fast_task_writes ] && echo 0 > ./other_group/cgroup.fast_task_writes
+	while read TASK; do
+		echo $TASK > "./other_group/tasks" 2> /dev/null
+	done < "tasks"
 
-#If we cannot move a task from the root cpuset, that task is softirq
-# or realted to system timer task
-[ -e ./ISR_group/cgroup.fast_task_writes ] && echo 1 > ./ISR_group/cgroup.fast_task_writes
-while read TASK
-do
-	echo $TASK > "./ISR_group/tasks" 2> /dev/null
-done < "/dev/cgroup/cpuset/tasks"
-[ -e ./ISR_group/cgroup.fast_task_writes ] && echo 0 > ./ISR_group/cgroup.fast_task_writes
-chown -R lvuser:ni /dev/cgroup/cpuacct
-[ "${VERBOSE}" != "no" ] && echo "done"
+	while read TASK; do
+		echo $TASK > "./ISR_group/tasks" 2> /dev/null
+	done < "/dev/cgroup/cpuset/tasks"
+	chown -R lvuser:ni /dev/cgroup/cpuacct
+	[ "${VERBOSE}" != "no" ] && echo "done"
+
+elif [ "$LVRT_CGROUP_VERSION" -eq 2 ]; then
+	# cgroup v2 logic: create /sys/fs/cgroup/ni and subgroups
+	[ "${VERBOSE}" != "no" ] && echo -n "Starting nicreatecpuacctgroups (cgroup v2):"
+	CGROUP2_ROOT="/sys/fs/cgroup"
+	mount -t cgroup2 none "$CGROUP2_ROOT"
+	cd "$CGROUP2_ROOT"
+	# Enable cpuset controller in root
+	echo "+cpuset" > cgroup.subtree_control
+	# Create ni domain
+	mkdir -p ni
+	chown lvuser:ni ni
+	cd ni
+	# Enable cpuset controller in ni
+	echo "+cpuset" > cgroup.subtree_control
+	# Create subgroups
+	for group in irq scanengine system time-critical timed-structures; do
+		mkdir -p "$group"
+		chown lvuser:ni "$group"
+	done
+	# Example: assign tasks to system (if needed)
+	if [ -f "../tasks" ]; then
+		while read TASK; do
+			echo $TASK > system/cgroup.procs 2> /dev/null
+		done < "../tasks"
+	fi
+	[ "${VERBOSE}" != "no" ] && echo "done"
+else
+	[ "${VERBOSE}" != "no" ] && echo "Unknown cgroup version: $LVRT_CGROUP_VERSION. Exiting."
+	exit 0
+fi

--- a/recipes-ni/initscripts-nilrt/files/nicreatecpusets
+++ b/recipes-ni/initscripts-nilrt/files/nicreatecpusets
@@ -3,42 +3,59 @@
 # All rights reserved.
 
 # Exit early if LabVIEW RT does not use cgroup-v1
+
+# Source cgroup version detection
 . /usr/share/initscripts-nilrt/lvrt-cgroup.sh
 identify_lvrt_cgroup_version || exit 0
-[ "$LVRT_CGROUP_VERSION" -eq 1 ] || exit 0
 
-#echo -n "Creating CPU sets for National Instruments LabVIEW Real-Time:"
-[ "${VERBOSE}" != "no" ] && echo -n "Starting nicreatecpusets:"
-mkdir -p /dev/cgroup/cpuset
-mount -t cpuset none /dev/cgroup/cpuset
-cd /dev/cgroup/cpuset
+if [ "$LVRT_CGROUP_VERSION" -eq 1 ]; then
+	# cgroup v1 logic
+	[ "${VERBOSE}" != "no" ] && echo -n "Starting nicreatecpusets (cgroup v1):"
+	mkdir -p /dev/cgroup/cpuset
+	mount -t cpuset none /dev/cgroup/cpuset
+	cd /dev/cgroup/cpuset
 
-mkdir LabVIEW_ScanEngine_set
-mkdir LabVIEW_tl_set
-mkdir system_set
+	for dir in LabVIEW_ScanEngine_set LabVIEW_tl_set system_set; do
+		mkdir -p "$dir"
+		# cpus and mems cannot be empty while tasks are added to tasks file in a cpuset
+		cat cpus > "./$dir/cpus"
+		cat mems > "./$dir/mems"
+	done
 
-#cpus and mems cannot be empty while tasks are added to tasks file
-#in a cpuset
-cat cpus > ./system_set/cpus
-cat mems > ./system_set/mems
-
-cat cpus > ./LabVIEW_tl_set/cpus
-cat mems > ./LabVIEW_tl_set/mems
-
-cat cpus > ./LabVIEW_ScanEngine_set/cpus
-cat mems > ./LabVIEW_ScanEngine_set/mems
-
-# fast_task_writes was added to 3.2 for performance reasons, but does not exist and is not
-# necessary in the 3.10 kernel. 
-[ -e ./system_set/cgroup.fast_task_writes ] && echo 1 > ./system_set/cgroup.fast_task_writes
-while read TASK
-do
-	echo $TASK > "./system_set/tasks" 2> /dev/null
-	# Following system tasks are specifically affined to run on a core
-	# and cannot be moved. So, the above line does thrown
-	# an error for these tasks and those can be ignored.
-	# kworker|ksoftirqd|posixcputmr|migration
-done < "tasks"
-[ -e ./system_set/cgroup.fast_task_writes ] && echo 0 > ./system_set/cgroup.fast_task_writes
-chown -R lvuser:ni /dev/cgroup/cpuset
-[ "${VERBOSE}" != "no" ] && echo "done"
+	while read TASK; do
+		echo $TASK > "./system_set/tasks" 2> /dev/null
+	done < "tasks"
+	chown -R lvuser:ni /dev/cgroup/cpuset
+	[ "${VERBOSE}" != "no" ] && echo "done"
+elif [ "$LVRT_CGROUP_VERSION" -eq 2 ]; then
+	# cgroup v2 logic: create /sys/fs/cgroup/ni and subgroups
+	[ "${VERBOSE}" != "no" ] && echo -n "Starting nicreatecpusets (cgroup v2):"
+	CGROUP2_ROOT="/sys/fs/cgroup"
+	mount -t cgroup2 none "$CGROUP2_ROOT"
+	cd "$CGROUP2_ROOT"
+	# Enable cpuset controller in root
+	echo "+cpuset" > cgroup.subtree_control
+	# Create ni domain
+	mkdir -p ni
+	chown lvuser:ni ni
+	cd ni
+	# Enable cpuset controller in ni
+	echo "+cpuset" > cgroup.subtree_control
+	# Create subgroups and assign cpuset.cpus/mems if available
+	for group in irq scanengine system time-critical timed-structures; do
+		mkdir -p "$group"
+		chown lvuser:ni "$group"
+		[ -f "../cpuset.cpus" ] && cat ../cpuset.cpus > "$group/cpuset.cpus"
+		[ -f "../cpuset.mems" ] && cat ../cpuset.mems > "$group/cpuset.mems"
+	done
+	# Assign tasks (v2: use cgroup.procs)
+	if [ -f "../tasks" ]; then
+		while read TASK; do
+			echo $TASK > system/cgroup.procs 2> /dev/null
+		done < "../tasks"
+	fi
+	[ "${VERBOSE}" != "no" ] && echo "done"
+else
+	[ "${VERBOSE}" != "no" ] && echo "Unknown cgroup version: $LVRT_CGROUP_VERSION. Exiting."
+	exit 0
+fi


### PR DESCRIPTION
### Summary of Changes

This pull request addresses the handling of cgroups v1 and v2 on NILRT targets, and the version is chosen based on the version of LabVIEW Real Time installed on it. If the LV version is 2023 and below, we choose cgroups v1, if not, we use cgroups v2.

This requires a change to the docker-moby recipe, where I need to remove dependency to cgroup-lite. This is because cgroup-lite is specific to cgroups v1, and installing docker on a machine with LabVIEW Real Time 2025 results in mounting both v1 and v2 paths. Eliminating this dependency from docker enables running simple test containers on NILRT.

### Justification

[AB#3271314](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3271314)


### Testing

I have tested the following
1. cgroup v2 paths are mounted when LabVIEW is not installed
2. cgroup v1 paths are mounted when LabVIEW 2023 is installed
3. cgroup v2 paths are mounted when LabVIEW 2025 is installed
4. I was able to run `docker run hello-world` with cgroups v2 - I had to remove cgroups-lite as a dependency of docker-moby because that's for cgroups v1 specificially

This will be followed up by more testing as specified in the [spec](https://dev.azure.com/ni/DevCentral/_git/labview?path=%2Fdocs%2FLabVIEW-wiki%2FSpecifications%2FDeveloping-Features%2FUse-cgroups-v2-in-LabVIEW-RT%2FUse-cgroups-v2-in-LabVIEW-RT.md&_a=preview).

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
