### PR TITLE
Build scarthgap BSI for ARM with 4.14 kernel.

### DIFF
--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -13,6 +13,9 @@ KBUILD_FRAGMENTS_LOCATION ?= "nilrt"
 
 LINUX_VERSION_EXTENSION = "$([ "${LINUX_KERNEL_TYPE}" != "standard" ] && echo '-${LINUX_KERNEL_TYPE}')"
 
+# Only required for 4.14 kernels
+EXTRA_OEMAKE:append:xilinx-zynq = ' CFLAGS="${TOOLCHAIN_OPTIONS}" '
+
 # Kbuild intenionally clobbers CFLAGS/LDFLAGS for some binaries we ship in nilrt,
 # particularly in the tools/ dir (fixdep, genksyms etc), and OE has this insanity check
 # to see if binaries were built using the OE-supplied *FLAGS, so skip this sanity check to

--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -42,6 +42,7 @@ PV = "${LINUX_VERSION}+git${SRCPV}"
 CVE_VERSION = "${KERNEL_VERSION}+git${SRCPV}"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+LIC_FILES_CHKSUM:xilinx-zynq = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 
 # This checks ${PV} == version from kernel sources which our PV/AUTOREV breaks, so skip it.
 KERNEL_VERSION_SANITY_SKIP="1"

--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -14,7 +14,7 @@ KBUILD_FRAGMENTS_LOCATION ?= "nilrt"
 LINUX_VERSION_EXTENSION = "$([ "${LINUX_KERNEL_TYPE}" != "standard" ] && echo '-${LINUX_KERNEL_TYPE}')"
 
 # Only required for 4.14 kernels
-EXTRA_OEMAKE:append:xilinx-zynq = ' CFLAGS="${TOOLCHAIN_OPTIONS}" '
+EXTRA_OEMAKE:append:xilinx-zynq = ' CFLAGS="${TOOLCHAIN_OPTIONS} -Wno-array-bounds" '
 
 # Kbuild intenionally clobbers CFLAGS/LDFLAGS for some binaries we ship in nilrt,
 # particularly in the tools/ dir (fixdep, genksyms etc), and OE has this insanity check

--- a/recipes-kernel/linux/linux-nilrt_git.bb
+++ b/recipes-kernel/linux/linux-nilrt_git.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Linux kernel based on nilrt branch"
 NI_RELEASE_VERSION = "master"
 LINUX_VERSION = "6.12"
-LINUX_VERSION:xilinx-zynq = "6.12"
+LINUX_VERSION:xilinx-zynq = "4.14"
 
 require linux-nilrt.inc
 

--- a/recipes-kernel/make-mod-scripts/make-mod-scripts_%.bbappend
+++ b/recipes-kernel/make-mod-scripts/make-mod-scripts_%.bbappend
@@ -1,0 +1,2 @@
+# Only required for 4.14 kernel
+EXTRA_OEMAKE:append:xilinx-zynq = ' CFLAGS="${TOOLCHAIN_OPTIONS}" '


### PR DESCRIPTION
### Summary of Changes

Build scarthgap BSI for ARM with 4.14 kernel.

### Justification

WI: [AB#3217123](https://dev.azure.com/ni/DevCentral/_workitems/edit/3217123)

### Testing

Tested following with changes in https://github.com/ni/linux/pull/258

- [x] `bitbake packagefeed-ni-core` on ARM scarthgap
- [x] `bitbake packagegroup-ni-desirable` on ARM scarthgap
- [x] `bitbake nilrt-base-system-image` on ARM scarthgap
- [x] `bitbake packagefeed-ni-core` on x64
- [x] `bitbake nilrt-base-system-image` on x64
- [x] `bitbake packagegroup-ni-desirable` on x64

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).

### Note
This PR shouldn't be merge until https://github.com/ni/linux/pull/258 is merged.