### PR TITLE
Build scarthgap BSI FIT image for ARM

### DIFF
--- a/conf/machine/xilinx-zynq.conf
+++ b/conf/machine/xilinx-zynq.conf
@@ -4,7 +4,9 @@
 
 TARGET_ARCH = "arm"
 DEFAULTTUNE = "cortexa9-vfpv3"
-KERNEL_IMAGETYPE = "Image"
+
+KERNEL_CLASSES += "kernel-fitimage"
+KERNEL_IMAGETYPE = "fitImage"
 
 KERNEL_FEATURES:remove = "cfg/fs/vfat.scc"
 
@@ -17,7 +19,24 @@ SERIAL_CONSOLES = "115200;ttyS0"
 
 INITRAMFS_FSTYPES = "cpio.gz.u-boot"
 
+# To generate bootscript section in FIT image, u-boot needs to be built.
 UBOOT_ARCH = "arm"
+UBOOT_LOADADDRESS ?= "0x8000"
+UBOOT_ENTRYPOINT ?= "${UBOOT_LOADADDRESS}"
+UBOOT_ENV = "bootscript"
+UBOOT_ENV_BINARY ?= "bootscript.txt"
+# Since we don't actually use u-boot built here, use a random machine config.
+UBOOT_MACHINE ?= "qemu_arm_defconfig"
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-nilrt"
-IMAGE_FSTYPES += "tar.bz2"
+
+KERNEL_EXTRA_ARGS += "LOADADDR=0x8000"
+FIT_HASH_ALG = "crc32"
+
+NILRT_ARM_DEVICE_CODES = "\
+        762F 76D3 76D6 76F2 7740 7741 7742 7743 7744 774C \
+        774E 775E 77AC 77B1 77B2 77D4 77D5 77D6 7885 7AAE \
+        793C \
+"
+
+KERNEL_DEVICETREE = "${@' '.join(["ni-%s.dtb" % x for x in "${NILRT_ARM_DEVICE_CODES}".split()])}"

--- a/recipes-bsp/u-boot/files/bootscript.txt
+++ b/recipes-bsp/u-boot/files/bootscript.txt
@@ -1,0 +1,45 @@
+if test ${DeviceCode} -eq 0x7AAE; then
+  setenv set_args 'setenv bootargs ${consoleparam} root=/dev/mmcblk0p3 rw ${usb_gadget_args} rcu_nocbs=all rootdelay=1 $othbootargs'
+else
+  setenv set_args 'setenv bootargs ${consoleparam} $mtdparts ubi.mtd=boot-config ubi.mtd=root root=ubi1:rootfs rw rootfstype=ubifs ${usb_gadget_args} rcu_nocbs=all $othbootargs'
+fi
+
+# usb host or device mode switching
+if test -n ${otg_usb_en} && test ${otg_usb_en} -eq 1; then
+  fdt addr ${loadaddr} && fdt get value fdtname /configurations/conf-ni-${DeviceCode}.dtb fdt && fdt get addr fdtaddr /images/${fdtname} data && fdt addr ${fdtaddr} && if itest.l ${usb_otgsc_id:-ffffffff} == 0; then
+    fdt set /amba@0/usb@${otg_usb_base_addr} dr_mode host;
+  elif itest.l ${usb_otgsc_id:-ffffffff} == 100; then
+    fdt set /amba@0/usb@${otg_usb_base_addr} dr_mode peripheral;
+  fi;
+fi
+
+# wireless region switching
+if test -n ${wirelessRegionFactory} && test -n ${wireless_board_id} && test -n ${wlan_sdio_base_addr}; then
+  fdt addr ${loadaddr} && fdt get value fdtname /configurations/conf-ni-${DeviceCode}.dtb fdt && fdt get addr fdtaddr /images/${fdtname} data && fdt addr ${fdtaddr} && fdt set /amba@0/sdhci@${wlan_sdio_base_addr}/wlan@0 atheros,board-id ${wireless_board_id} && fdt set /amba@0/sdhci@${wlan_sdio_base_addr}/wlan@0 atheros,region-code ${wirelessRegionFactory};
+fi
+
+# cRIO-9068 doesn't have USB gadget, so skip it on that device
+if test ${DeviceCode} != 0x76D6; then
+  # myRIO should use ethaddr for the USB gadget to ensure a persistent address
+  if test ${DeviceCode} == 0x762F || test ${DeviceCode} == 0x76D3; then
+    usb_gadget_addr=${ethaddr}
+  else
+    usb_gadget_addr=${usbgadgetethaddr}
+  fi
+  usb_gadget_args="g_ether.idVendor=${USBVendorID} g_ether.idProduct=${USBProductID} g_ether.iProduct=\"${USBProduct} [${hostname}]\" g_ether.iSerialNumber=${serial#} g_ether.dev_addr=${usb_gadget_addr} g_ether.bcdDevice=${USBDevice}"
+fi
+
+if test -n \"$bootscriptenvrun\" ; then run bootscriptenvrun; fi
+
+silent_tmp=${silent}
+setenv silent
+echo "Booting LabVIEW RT..."
+setenv silent ${silent_tmp}
+
+test -n "$manufacturer" ||
+    setenv manufacturer National Instruments &&
+    setenv .flags manufacturer:so &&
+    saveenv;
+
+run set_args
+bootm ${loadaddr}#conf-ni-${DeviceCode}.dtb

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI:append:xilinx-zynq = " file://${UBOOT_ENV_BINARY} "


### PR DESCRIPTION
### Summary of Changes

Added changes to build ARM BSI FIT image.

### Justification

WI: [AB#3217134](https://dev.azure.com/ni/DevCentral/_workitems/edit/3217134)

### Testing

With changes in https://github.com/ni/openembedded-core/pull/169

- [x] `bitbake packagefeed-ni-core` on ARM scarthgap
- [x] `bitbake packagegroup-ni-desirable` on ARM scarthgap
- [x] `bitbake nilrt-base-system-image` on ARM scarthgap
- [x] Installed BSI and FIT image on a cRIO-9068 (with some manual fixups) and verified device boots.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).


### Note
https://github.com/ni/openembedded-core/pull/169 needs to be merged first.