### PR TITLE
Make scarthgap BSI bootable on ARM

### DIFF
--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -20,9 +20,10 @@ VIRTUAL-RUNTIME_mountpoint ?= "busybox"
 
 SKIP_META_SECURITY_SANITY_CHECK = "1"
 
+KERNEL_IMAGEDEST:xilinx-zynq = "boot"
 # on older NILRT distro flavors the kernel is installed in non-standard paths
 # for backward compatibility
-KERNEL_IMAGEDEST = "boot/runmode"
+KERNEL_IMAGEDEST:x64 = "boot/runmode"
 
 # Needs to change thanks to NIAuth
 # - cf oe-core base-files/base-files/profile

--- a/conf/machine/xilinx-zynq.conf
+++ b/conf/machine/xilinx-zynq.conf
@@ -25,6 +25,8 @@ UBOOT_LOADADDRESS ?= "0x8000"
 UBOOT_ENTRYPOINT ?= "${UBOOT_LOADADDRESS}"
 UBOOT_ENV = "bootscript"
 UBOOT_ENV_BINARY ?= "bootscript.txt"
+# Set to "" to not generate unnecessary /etc/${UBOOT_INITIAL_ENV}* files.
+UBOOT_INITIAL_ENV = ""
 # Since we don't actually use u-boot built here, use a random machine config.
 UBOOT_MACHINE ?= "qemu_arm_defconfig"
 

--- a/recipes-bsp/u-boot/files/fw_env.config
+++ b/recipes-bsp/u-boot/files/fw_env.config
@@ -1,0 +1,7 @@
+# Configuration file for fw_(printenv/saveenv) utility.
+# Up to two entries are valid, in this case the redundand
+# environment sector is assumed present.
+
+# Device name		Device offset	Env. size	Flash sector size
+/dev/ubi0:u-boot-env1	0x0000		0x20000		0x20000
+/dev/ubi0:u-boot-env2	0x0000		0x20000		0x20000

--- a/recipes-bsp/u-boot/libubootenv_%.bbappend
+++ b/recipes-bsp/u-boot/libubootenv_%.bbappend
@@ -2,3 +2,15 @@ COMPATIBLE_MACHINE = "xilinx-zynq"
 PROVIDES += "fw-printenv"
 RPROVIDES:${PN}-bin += "fw-printenv"
 RDEPENDS:${PN}-bin += "u-boot-env"
+
+do_install:append() {
+	install -d ${D}${base_sbindir}
+
+	ln -s ${bindir}/fw_printenv ${D}${base_sbindir}/fw_printenv
+	ln -s ${bindir}/fw_setenv ${D}${base_sbindir}/fw_setenv
+}
+
+FILES:${PN}-bin += "\
+	${base_sbindir}/fw_printenv \
+	${base_sbindir}/fw_setenv \
+"

--- a/recipes-bsp/u-boot/libubootenv_%.bbappend
+++ b/recipes-bsp/u-boot/libubootenv_%.bbappend
@@ -1,3 +1,4 @@
 COMPATIBLE_MACHINE = "xilinx-zynq"
 PROVIDES += "fw-printenv"
 RPROVIDES:${PN}-bin += "fw-printenv"
+RDEPENDS:${PN}-bin += "u-boot-env"

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,2 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
-SRC_URI:append:xilinx-zynq = " file://${UBOOT_ENV_BINARY} "
+
+SRC_URI:append:xilinx-zynq = "\
+    file://${UBOOT_ENV_BINARY} \
+    file://fw_env.config \
+"

--- a/recipes-core/images/files/nilrt-base-system-image.postinst
+++ b/recipes-core/images/files/nilrt-base-system-image.postinst
@@ -45,8 +45,8 @@ if grep -qs artemis /sys/firmware/devicetree/base/compatible ; then
     mkdir -p /etc/natinst/share
 
     # configure the path for fw_printenv to read environmental variables from u-boot
-    # replace /dev/mtd4 and /dev/mtd5 with /boot/uboot/uboot.env
-    sed -i '/mtd/d' /mnt/userfs/etc/fw_env.config
+    # replace /dev/ubi* with /boot/uboot/uboot.env
+    sed -i '/ubi/d' /mnt/userfs/etc/fw_env.config
     echo /boot/uboot/uboot.env         0x0000         0x20000 >> /mnt/userfs/etc/fw_env.config
 
 fi

--- a/recipes-core/images/files/nilrt-base-system-image.postinst
+++ b/recipes-core/images/files/nilrt-base-system-image.postinst
@@ -63,28 +63,22 @@ if [ "$arch" = "x86_64" ]; then
     echo LABEL=niconfig         /etc/natinst/share   ext4       sync           0  0 >> /mnt/userfs/etc/fstab
 fi
 
-if [ "$arch" = "armv7l" ]; then
-	kernel="/mnt/userfs/boot/tmp/linux_runmode.itb"
-elif [ "$arch" = "x86_64" ]; then
-	kernel="/mnt/userfs/boot/tmp/runmode"
-else
-	echo >&2 "ERROR: Unsupported platform"
-	exit 1
-fi
-
 # in normal operation, /boot better exist
 awk '{print $2;}' < /proc/mounts | grep -q /boot || exit 1
 
 # Give hwclock CAP_SYS_TIME capabilties
 /usr/sbin/setcap CAP_SYS_TIME+ep /mnt/userfs/sbin/hwclock.util-linux
 
-# install the kernel
-[ "$arch" = "x86_64" ] && rm -rf /boot/runmode
-if mv "$kernel" "$mount_point"; then
-	# Remove the tmp path from the rootfs
-	rmdir "`dirname "$kernel"`"
-else
-	exit 1
+if [ "$arch" = "x86_64" ]; then
+	kernel="/mnt/userfs/boot/tmp/runmode"
+	# install the kernel
+	rm -rf /boot/runmode
+	if mv "$kernel" "$mount_point"; then
+		# Remove the tmp path from the rootfs
+		rmdir "`dirname "$kernel"`"
+	else
+		exit 1
+	fi
 fi
 
 # Use persistent names on PXI, not on any other targets

--- a/recipes-core/images/files/nilrt-base-system-image.postinst
+++ b/recipes-core/images/files/nilrt-base-system-image.postinst
@@ -9,11 +9,13 @@
 # itself, regardless of if some other component ultimately will too.
 mkdir -p -m 755 /mnt/userfs/etc/natinst/share/uninstall
 
-# Delete the enable_initramfs variable so the target will no longer try to boot
-# using an initramfs in runmode.  This also disables the usage of an initramfs on
-# older runmodes and safemode combinations.  The enable_initramfs variable is
-# only set during provisioning, so it should remain unset for this target.
-grub-editenv /boot/grub/grubenv unset enable_initramfs
+if [ "$arch" = "x86_64" ]; then
+	# Delete the enable_initramfs variable so the target will no longer try to boot
+	# using an initramfs in runmode.  This also disables the usage of an initramfs on
+	# older runmodes and safemode combinations.  The enable_initramfs variable is
+	# only set during provisioning, so it should remain unset for this target.
+	grub-editenv /boot/grub/grubenv unset enable_initramfs
+fi
 
 # Enable ssh by default when installing SystemLink.
 /usr/local/natinst/bin/nirtcfg -s section=systemsettings,token=sshd.enabled,value=True

--- a/recipes-core/images/nilrt-runmode-rootfs.bb
+++ b/recipes-core/images/nilrt-runmode-rootfs.bb
@@ -28,9 +28,9 @@ PACKAGE_EXCLUDE += "rauc rauc-mark-good"
 
 # on older NILRT distro flavors the kernel is installed in non-standard paths
 # for backward compatibility
-CUSTOM_KERNEL_PATH ?= "/boot/tmp/runmode"
+CUSTOM_KERNEL_PATH:x64 ?= "/boot/tmp/runmode"
 
-bootimg_fixup() {
+bootimg_fixup_x64() {
 	install -m 0644 "${THISDIR}/files/bootimage.ini" "${IMAGE_ROOTFS}/boot/runmode/bootimage.ini"
 	sed -i "s/%component_version%/${BUILDNAME}/" "${IMAGE_ROOTFS}/boot/runmode/bootimage.ini"
 
@@ -39,6 +39,11 @@ bootimg_fixup() {
 	mv "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}" "${IMAGE_ROOTFS}/${CUSTOM_KERNEL_PATH}"
 }
 
-IMAGE_PREPROCESS_COMMAND += " bootimg_fixup; "
+bootimg_fixup_arm() {
+	mv "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/fitImage" "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/linux_runmode.itb"
+}
+
+IMAGE_PREPROCESS_COMMAND:append:x64 = " bootimg_fixup_x64; "
+IMAGE_PREPROCESS_COMMAND:append:xilinx-zynq = " bootimg_fixup_arm; "
 
 IMAGE_FSTYPES += "squashfs tar.gz"

--- a/recipes-ni/initscripts-nilrt/files/mountutils
+++ b/recipes-ni/initscripts-nilrt/files/mountutils
@@ -1,0 +1,337 @@
+#!/bin/sh
+# Copyright (c) 2025 Emerson Electric Co.
+# All rights reserved.
+
+# find_mtd_device_number - returns a mtd device number based on a partition label
+# usage: <variable>=$(find_mtd_device "partition_label")
+find_mtd_device_number()
+{
+	local line
+	local number
+
+	while read line; do {
+		case "$line" in
+		*"\"$1\""*)
+			IFS=":"
+			set $line
+			number=${1##mtd}
+			unset IFS
+			break
+			;;
+		esac
+	} done </proc/mtd
+
+	echo $number
+}
+
+# find_mtd_device - returns a mtd device name based on a partition label
+# usage: <variable>=$(find_mtd_device "partition_label")
+find_mtd_device()
+{
+	local device_number
+	local device_prefix
+
+	device_prefix="/dev/mtd"
+	if [ -d "$device_prefix" ]; then
+		device_prefix="$device_prefix/"
+	fi
+
+	device_number=$(find_mtd_device_number "$1")
+	if [ ! -z device_number ]; then
+		echo "${device_number:+$device_prefix$device_number}"
+	fi
+}
+
+# find_mtd_block_device - returns a mtd block device name based on a partition label
+# usage: <variable>=$(find_mtd_block_device "partition_label")
+find_mtd_block_device()
+{
+
+	local device_number
+	local device_prefix
+
+	device_prefix="/dev/mtdblock"
+	if [ -d "$device_prefix" ]; then
+		device_prefix="$device_prefix/"
+	fi
+
+	device_number=$(find_mtd_device_number "$1")
+	if [ ! -z device_number ]; then
+		echo "${device_number:+$device_prefix$device_number}"
+	fi
+}
+
+# delete_partition() - erases the partition referenced by a partition label
+#		       input argument
+# usage: delete_partition "partition_label"
+# WARNING: Do not use for UBI partitions - it will destroy the erase counters
+# used for NAND wear leveling
+delete_partition()
+{
+	local device
+
+	device=$(find_mtd_device "$1")
+	if [ -z $device ]; then
+		echo "could not find a mtd partition named '$1'" >&2
+		exit 1
+	fi
+
+	flash_eraseall "$device"
+}
+
+# find_ubi_mount_point - finds the ubi mount point for a device
+# usage: <variable>=$(find_ubi_mount_point "device_name")
+find_ubi_mount_point()
+{
+	local device_name=$1
+	grep "ubifs" /proc/mounts | grep -m 1 $device_name | awk '{print $2}'
+}
+
+# find_current_mount_point - finds the mount point for a device
+# usage: <variable>=$(find_current_mount_point "device_name")
+find_current_mount_point()
+{
+	local device_name=$1
+	grep -m 1 $device_name /proc/mounts | awk '{print $2}'
+}
+
+# find_mount_fs_type - finds the filesystem type for a device
+# usage: <variable>=$(find_mount_fs_type "device_name")
+find_mount_fs_type()
+{
+	local device_name=$1
+	grep -m 1 $device_name /proc/mounts | awk '{print $3}'
+}
+
+# map_mtd_name_to_ubi_dev - returns the ubi device number corresponding to a
+#			    given mtd partition label
+# usage <ubi_device_number>=$(map_mtd_name_to_ubi_dev "partition_label")
+map_mtd_name_to_ubi_dev()
+{
+	local device_number
+	local ubidev
+
+	device_number=$(find_mtd_device_number "$1")
+
+	for ubidev in /sys/class/ubi/*
+	do
+		if [ -d "${ubidev}" ]; then
+			if [ -f "${ubidev}/mtd_num" ]; then
+				if [ "$(cat "${ubidev}/mtd_num")" = "${device_number}" ]; then
+					echo "${ubidev}" | grep -oE "[0-9]+$"
+				fi
+			fi
+		fi
+	done
+}
+
+# get_ubi_volumes_count - returns the number of volumes contained in a given
+#			  ubi device (identified by the device number)
+# usage <volumes_count>=$(get_ubi_volumes_count <ubi_device_number>)
+get_ubi_volumes_count()
+{
+	cat "/sys/class/ubi/ubi$1/volumes_count"
+}
+
+# find_ubi_volume - for a given ubi device $1 finds the volume corresponding
+#                   to name $2
+# usage: <variable>=$(find_ubi_volume "ubi_device" "volume_name")
+find_ubi_volume()
+{
+	local ubi_volume
+
+	for ubi_volume in /sys/class/ubi/ubi$1_*
+	do
+		if [ -d "${ubi_volume}" ]; then
+			if [ -f "${ubi_volume}/name" ]; then
+				if [ "$(cat "${ubi_volume}/name")" = "$2" ]; then
+					echo "${ubi_volume}" | grep -oE "[0-9]+$"
+				fi
+			fi
+		fi
+	done
+}
+
+# find_ubi_volume_name - for a given ubi device $1 finds the volume corresponding
+#                   to volume number $2
+# usage: <variable>=$(find_ubi_volume_name "ubi_device" "volume_number")
+find_ubi_volume_name()
+{
+	cat /sys/class/ubi/ubi$1_$2/name
+}
+
+ubi_attach_error()
+{
+	echo "could not find an ubi device attached to mtd partition '$1'" >&2
+	exit 1
+}
+
+# format_ubi_partition() - erases the ubi/mtd partition referenced by a
+#			   partition label input argument
+# usage: format_ubi_partition "partition_label"
+format_ubi_partition()
+{
+	local device
+	local ubidev
+
+	device=$(find_mtd_device "$1")
+	if [ -z $device ]; then
+		echo "could not find a mtd partition named '$1'" >&2
+		exit 1
+	fi
+
+	ubidev=$(map_mtd_name_to_ubi_dev "$1")
+	if [ ! -z $ubidev ]; then
+		ubidetach -p "$device"
+	fi
+	ubiformat -y "$device"
+	ubiattach -p "$device"
+
+	ubidev=$(map_mtd_name_to_ubi_dev "$1")
+	if [ -z $ubidev ]; then
+		ubi_attach_error "$1"
+	fi
+}
+
+# format_ubi_volume() - erases the ubi/mtd partition referenced by a
+#			   partition label input argument and rewrites an empty
+#			   ubifs file system
+# usage: format_ubi_volume "partition_label" "volume_number" "volume_label"
+format_ubi_volume()
+{
+	local device
+	local ubidev
+
+	if [ `id -u` != 0 ]; then
+		echo "must be root!" >&2
+		exit 1;
+	fi
+
+	device=$(find_mtd_device "$1")
+	if [ -z $device ]; then
+		echo "could not find a mtd partition named '$1'" >&2
+		exit 1
+	fi
+
+	ubidev=$(map_mtd_name_to_ubi_dev "$1")
+	if [ -z $ubidev ]; then
+		ubi_attach_error "$1"
+	fi
+
+	# truncate (wipe out) the volume
+	/usr/sbin/ubiupdatevol -t /dev/ubi${ubidev}_$2
+
+	# Make sure the name is correct
+	current_name=$(find_ubi_volume_name $ubidev $2)
+	if [ $current_name != $3 ]; then
+		ubirename /dev/ubi${ubidev} $current_name $3
+	fi
+
+	# Create an empty ubifs (write version 4) so that kernel doesn't
+	# make a newer version of ubifs on mount. Linux 4.14 makes ubifs v5
+	# on empty volumes. Previous versions of Linux make ubifs v4.
+	mkfs.ubifs /dev/ubi${ubidev}_$2
+}
+
+# mount_ubi_volume() - mounts an ubi volume
+#			If the volume does not exist or cannot be mounted,
+#			it is formatted and mount is reattempted
+# usage: mount_ubi_volume "partition_label" "volume_label" "volume_number" "mount_point" "extra_arguments"
+mount_ubi_volume()
+{
+	local partition_label=$1
+	local volume_label=$2
+	local volume_number=$3
+	local mount_point=$4
+	local extra_arguments=$5
+
+	if [ `id -u` != 0 ]; then
+		# 1. find the ubi device corresponding to the user fs partition
+		ubi_device=$(map_mtd_name_to_ubi_dev "$partition_label")
+		if [ -z $ubi_device ]; then
+			echo "$partition_label does not exist!" >&2
+			exit 1
+		fi
+
+		# 2. find out if it's already mounted
+		current_mount_point=$(find_ubi_mount_point "$volume_label")
+		if [ "$current_mount_point" = "$mount_point" ]; then
+			return 0
+		elif [ -n "$current_mount_point" -a "$current_mount_point" != "$mount_point" ]; then
+			echo "Cannot mount at $mount_point.  Already mounted at $current_mount_point!" >&2
+			exit 1
+		fi
+
+		# 3. mount the partition
+		mount $extra_arguments ubi$ubi_device:$volume_label
+
+		# 4. make sure the mount point agrees with what we want
+		current_mount_point=$(find_ubi_mount_point "$volume_label")
+		if [ "$current_mount_point" != "$mount_point" ]; then
+			echo "fstab mount point disagrees with $mount_point. Cannot mount!" >&2
+			umount $current_mount_point
+			exit 1
+		fi
+
+		return 0
+	fi
+
+	# 1. find the ubi device corresponding to the user fs partition
+	ubi_device=$(map_mtd_name_to_ubi_dev "$partition_label")
+	if [ -z $ubi_device ]; then
+		# it doesn't exist, so we may as well ubiformat it
+		format_ubi_partition "$partition_label"
+		ubi_device=$(map_mtd_name_to_ubi_dev "$partition_label")
+		if [ -z ubi_device ]; then
+			ubi_attach_error $partition_label
+		fi
+	fi
+
+	# 2. find out if it's already mounted
+	current_mount_point=$(find_ubi_mount_point "$volume_label")
+	if [ "$current_mount_point" != "$mount_point" ]; then
+		if [ -n "$current_mount_point" ]; then
+			#echo "unmounting 'ubi$ubi_device:$volume_label' from '$current_mount_point'"
+			umount "$current_mount_point"
+		fi
+
+		# 3. if there are no volumes defined, create one now
+		ubi_volumes=$(get_ubi_volumes_count "$ubi_device")
+		if [ $ubi_volumes -eq 0 ]; then
+			#echo "creating '$volume_label' volume on /dev/ubi$ubi_device" >&2
+			ubimkvol /dev/ubi$ubi_device -N $volume_label -m
+		else
+			ubi_volume_number=$(find_ubi_volume "$ubi_device" "$volume_label")
+			if [ -z $ubi_volume_number ]; then
+				echo "could not find '$volume_label' volume on /dev/ubi$ubi_device'" >&2
+				exit 1
+			fi
+		fi
+
+		# 4. mount
+		mkdir -p $mount_point
+		mount -t ubifs $extra_arguments ubi$ubi_device:$volume_label $mount_point
+
+		# 5. check if the mount operation succeeded
+		current_mount_point=$(find_ubi_mount_point "$volume_label")
+		if [ -z $current_mount_point ]; then
+			#echo "failed to mount 'ubi$ubi_device:$volume_label' at '$mount_point'" >&2
+
+			# attempt to re-format
+			#echo "re-formatting rootfs volume" >&2
+			format_ubi_volume $partition_label $volume_number $volume_label
+
+			# retry mount
+			mount -t ubifs ubi$ubi_device:$volume_label $mount_point
+
+			current_mount_point=$(find_ubi_mount_point "$volume_label")
+			if [ -z $current_mount_point ]; then
+				echo "failed again to mount 'ubi$ubi_device:$volume_label' at '$mount_point'" >&2
+				exit 1
+			fi
+		fi
+		#echo "mounted 'ubi$ubi_device:$volume_label' at '$mount_point'" >&2
+	#else
+		#echo "'ubi$ubi_device:$volume_label' already mounted at '$current_mount_point'" >&2
+	fi
+}

--- a/recipes-ni/initscripts-nilrt/initscripts-nilrt.bb
+++ b/recipes-ni/initscripts-nilrt/initscripts-nilrt.bb
@@ -35,6 +35,10 @@ SRC_URI = "\
 	file://wirelesssetdomain \
 "
 
+SRC_URI:append:xilinx-zynq = "\
+	file://mountutils \
+"
+
 S = "${WORKDIR}"
 
 do_install () {
@@ -87,6 +91,10 @@ do_install () {
 
 	install -d ${D}${datadir}/${BPN}
 	install -m 0755 lvrt-cgroup.sh ${D}${datadir}/${BPN}/lvrt-cgroup.sh
+}
+
+do_install:append:xilinx-zynq () {
+	install -m 0755 ${WORKDIR}/mountutils            ${D}${sysconfdir}/init.d
 }
 
 pkg_postinst_ontarget:${PN} () {


### PR DESCRIPTION
### Summary of Changes

Make scarthgap BSI bootable on ARM.

### Justification

WI: [AB#3217144](https://dev.azure.com/ni/DevCentral/_workitems/edit/3217144)

### Testing

- [x] `bitbake packagefeed-ni-core` on ARM.
- [x] `bitbake packagegroup-ni-desirable` on ARM.
- [x] `bitbake nilrt-base-system-image` on ARM.
- [x] Installed BSI by running `tar xf nilrt-base-system-image-xilinx-zynq.tar`, `tar xf data.tar.gz -C /mnt/userfs`, `./postinst` on a cRIO-9068 and verified it boots into runmode.
- [x] `bitbake packagefeed-ni-core` on x64.
- [x] `bitbake packagegroup-ni-desirable` on x64.
- [x] `bitbake nilrt-base-system-image` on x64.
- [x] `bitbake packagegroup-ni-desirable` on x64.
- [x] Installed BSI on a VM through MAX and verified it boots into runmode.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
