### PR TITLE
passwd/group: define static ID for 'audio' to fix pulseaudio dependency

### DIFF
--- a/files/group
+++ b/files/group
@@ -71,3 +71,4 @@ mosquitto:x:340:
 radiusd:x:301:
 postgres:x:28:
 mail:x:8:
+audio:x:29:


### PR DESCRIPTION
### Summary of Changes

Define a static ID for the audio group in files/group to fix pulseaudio dependency resolution.


### Justification

Pulseaudio is a dependency for multiple packages (libcanberra, onboard, etc.) that are part of the NI Linux RT distribution.
This change ensures pulseaudio and its dependents can be built successfully by defining the audio group in meta-nilrt/files/group.

The pulseaudio change from oe-core was not merged in the [last upstream merge PR](https://github.com/ni/openembedded-core/pull/168) to avoid introducing meta-nilrt changes at that time. This PR addresses the gap.


### Testing

- [x] bitbake packagefeed-ni-core
- [x] bitbake packagegroup-ni-desirable
- [x] bitbake package-index && bitbake nilrt-base-system-image
- [x] Installed BSI on a VM and verified it boots

@chaitu236 
