### PR TITLE
Re-add ARM specific changes in OE repos

### DIFF
--- a/recipes-core/udev/udev-extraconf.bb
+++ b/recipes-core/udev/udev-extraconf.bb
@@ -13,6 +13,8 @@ SRC_URI = " \
 	file://scripts \
 "
 
+SRC_URI:append:xilinx-zynq = "file://fpga.rules"
+
 S = "${WORKDIR}"
 
 
@@ -35,6 +37,9 @@ do_install() {
 	install -m 0755 ${S}/scripts/* ${D}${sysconfdir}/udev/scripts
 }
 
+do_install:append:xilinx-zynq() {
+	install -m 0644 ${WORKDIR}/fpga.rules          ${D}${sysconfdir}/udev/rules.d/fpga.rules
+}
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 

--- a/recipes-core/udev/udev-extraconf/fpga.rules
+++ b/recipes-core/udev/udev-extraconf/fpga.rules
@@ -1,0 +1,2 @@
+# /dev/fpgaperipheral should be read/write to ni (0660 permissions are default)
+KERNEL=="fpgaperipheral", GROUP="ni"


### PR DESCRIPTION
### Summary of Changes

Re-add ARM specific changes that were previously removed from OE repos


### Justification

[AB#3218279](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3218279)


### Testing

* [X] I have built the core package feed, on x64, with this PR in place. (`bitbake packagefeed-ni-core`)
* [X] I have built the core package feed, on ARM, with this PR in place. (`bitbak packagefeed-ni-core`)
* [X] I have built the core base system image, on x64, with this PR in place. (`bitbake nilrt-base-system-image`)
* [X] I have built the core base system image, on ARM, with this PR in place. (`bitbake nilrt-base-system-image`)
* [X] I have installed the x64 BSI on a PXIe Target and verified device boots

### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
