### PR TITLE
passwd/group: Move 'audio' to correct position

### DIFF
--- a/files/group
+++ b/files/group
@@ -69,6 +69,6 @@ tracing:x:341:
 mosquitto:x:340:
 # free space
 radiusd:x:301:
+audio:x:29:
 postgres:x:28:
 mail:x:8:
-audio:x:29:


### PR DESCRIPTION
### Summary of Changes

'bitbake -c do_check_useradd_staticids shadow' fails with following error

"ERROR: shadow-4.14.2-r0 do_check_useradd_staticids: entries out of
order: Entry 'mail' (8) has smaller ID than 'audio' (29)"

So move 'audio' to correct position.

Fixes: f32bfb9d6 ("passwd/group: define static ID for 'audio' to fix pulseaudio dependency")

### Justification

WI: [AB#3420074](https://ni.visualstudio.com/DevCentral/_workitems/edit/3420074/)

### Testing

- [x] `bitbake -c do_check_useradd_staticids shadow` passes on local build

### Procedure

- [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
