### PR TITLE
docker-moby: Shorten PV to limit path length

### DIFF
--- a/recipes-containers/docker/docker-moby_%.bbappend
+++ b/recipes-containers/docker/docker-moby_%.bbappend
@@ -1,0 +1,4 @@
+# Original recipe's PV is too long causing feed exports to exceed path limits.
+# So use a shortened SRCREV_moby in PV.
+SRCREV_moby_short = "${@d.getVar('SRCREV_moby')[:10]}"
+PV = "${DOCKER_VERSION}+git${SRCREV_moby_short}"


### PR DESCRIPTION
### Summary of Changes

Original recipe's PV is too long causing feed exports to exceed path limits.
So use a shortened SRCREV_moby in PV.


### Justification

WI: [AB#3410213](https://dev.azure.com/ni/DevCentral/_workitems/edit/3410213)

### Testing

- [x] `bitbake docker-moby`
- [x] Package names are now shorter
       <img width="1258" height="225" alt="image" src="https://github.com/user-attachments/assets/558e54e3-ce1e-4803-b39c-839f4da9afe4" />

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
