### PR TITLE
Cherry-pick fixes for build failure from nilrt/master/scarthgap 

### DIFF
--- a/files/group
+++ b/files/group
@@ -74,3 +74,4 @@ mosquitto:x:340:
 radiusd:x:301:
 postgres:x:28:
 mail:x:8:
+audio:x:29:

--- a/files/group
+++ b/files/group
@@ -72,6 +72,6 @@ tracing:x:341:
 mosquitto:x:340:
 # free space
 radiusd:x:301:
+audio:x:29:
 postgres:x:28:
 mail:x:8:
-audio:x:29:


### PR DESCRIPTION
### Summary of Changes

Cherry-pick fixes for build failure from nilrt/master/scarthgap 

### Justification

systemd build is failing with following error as `nilrt/systemd/scarghgap` doesn't have `audio` group.

> pulseaudio was skipped: Recipe pulseaudio, package pulseaudio-server: system groupname "audio" does not have a static ID defined. Add audio to one of these files: ...


### Testing

None (We already know this fixed the issue on nilrt/master/scarthgap. Also, build is broken and this is a hot fix).

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).

Ideally we should merge `nilrt/master/scarthgap` to `nilrt/master/systemd` but there was a merge conflict and we also need to ensure systemd specific changes are placed in correct location after arm/x64 split in several recipes/packagegroups.