### PR TITLE
nilrt-base-system-image: Update CDF for ARM

### DIFF
--- a/recipes-core/images/files/nilrt-base-system-image.cdf
+++ b/recipes-core/images/files/nilrt-base-system-image.cdf
@@ -4,7 +4,7 @@
   <SOFTPKG NAME="%guid%" VERSION="%version%" OLDESTCOMPATIBLEVERSION="%version%" PROVIDESOS="YES" TYPE="HIDDEN">
     <TITLE>SystemLink Base Image</TITLE>
     <IMPLEMENTATION>
-      <OS VALUE="NI-Linux x64"><OSVERSION VALUE="7.0"/></OS>
+      <OS VALUE="%osvalue%"><OSVERSION VALUE="7.0"/></OS>
       <CODEBASE FILENAME="%filename%" TYPE="TAR" />
     </IMPLEMENTATION>
   </SOFTPKG>

--- a/recipes-core/images/nilrt-base-system-image.bb
+++ b/recipes-core/images/nilrt-base-system-image.bb
@@ -33,10 +33,6 @@ bootimg_fixup() {
 		-delete
 }
 
-# TODO: We're doing CDF generation here. The CDF encodes the filename of the
-#       .tar. However, we're not generating it with the same name that we
-#       used to ("systemlink-linux-x64-dkms.tar"); is having these artifacts
-#       with a new name fine?
 create_cdf() {
 	CDFOUT="${DEPLOY_DIR_IMAGE}/${IMAGE_BASENAME}-${MACHINE}${IMAGE_NAME_SUFFIX}.cdf"
 	install -m 0644 "${THISDIR}/files/${BPN}.cdf" $CDFOUT

--- a/recipes-core/images/nilrt-base-system-image.bb
+++ b/recipes-core/images/nilrt-base-system-image.bb
@@ -12,7 +12,12 @@ SRC_URI += " \
 
 PV = "${DISTRO_VERSION}"
 
-CDFGUID = "4C0005F7-54D1-492B-A7E7-C1E58BD9B972"
+CDFGUID:x64 = "4C0005F7-54D1-492B-A7E7-C1E58BD9B972"
+# TODO: Update GUID to E40D0BD6-F888-4BDB-AFB9-EF97A34107B3 when ARM scarthgap is ready to ship
+CDFGUID:xilinx-zynq = "8E3EACD0-B36E-462B-A500-88AE644AB3B0"
+
+OSVALUE:x64 = "NI-Linux x64"
+OSVALUE:xilinx-zynq = "Linux-ARMv7-A"
 
 ROOTFS_IMAGE = "nilrt-runmode-rootfs"
 do_rootfs[depends] += "${ROOTFS_IMAGE}:do_image_complete"
@@ -40,7 +45,7 @@ create_cdf() {
 	SHORTVER=$(echo ${BUILDNAME} | sed 's/^\([0-9.]*\).*/\1/;')
 	TARFILE="${IMAGE_BASENAME}-${MACHINE}${IMAGE_NAME_SUFFIX}.tar"
 
-	sed -i "s/%guid%/$GUID/g; s/%version%/$SHORTVER/g; s/%filename%/$TARFILE/g;" $CDFOUT
+	sed -i "s/%guid%/$GUID/g; s/%version%/$SHORTVER/g; s/%osvalue%/${OSVALUE}/g; s/%filename%/$TARFILE/g;" $CDFOUT
 }
 
 IMAGE_PREPROCESS_COMMAND += "bootimg_fixup;"


### PR DESCRIPTION
### Summary of Changes

Use different `GUID` and `OS VALUE` on ARM.

### Justification

WI: [AB#3218167](https://dev.azure.com/ni/DevCentral/_workitems/edit/3218167)

### Testing

- [x] Verified `bitbake -e nilrt-base-system-image` on ARM and x64 shows expected values for `CDFGUID` and `OSVALUE`.
- [x] `bitbake packagefeed-ni-core` on ARM.
- [x] `bitbake nilrt-base-system-image` on ARM.
- [x] Verified generated CDF on ARM contains expected values.

### Procedure

- [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
