### PR TITLE
libubootenv: Fix ownership, perms for fw_printenv

### DIFF
--- a/recipes-bsp/u-boot/libubootenv_%.bbappend
+++ b/recipes-bsp/u-boot/libubootenv_%.bbappend
@@ -1,9 +1,14 @@
 COMPATIBLE_MACHINE = "xilinx-zynq"
 PROVIDES += "fw-printenv"
+DEPENDS += "niacctbase"
 RPROVIDES:${PN}-bin += "fw-printenv"
 RDEPENDS:${PN}-bin += "u-boot-env"
 
 do_install:append() {
+	# Setup ownership, perms so webserv user can execute fw_printenv
+	chmod 4550 ${D}${bindir}/fw_printenv
+	chown 0:${LVRT_GROUP} ${D}${bindir}/fw_printenv
+
 	install -d ${D}${base_sbindir}
 
 	ln -s ${bindir}/fw_printenv ${D}${base_sbindir}/fw_printenv


### PR DESCRIPTION
### Summary of Changes

webserv user needs to be able to execute fw_printenv for sysapi to work.
So setup ownership, permissions for fw_printenv accordingly.
Permissions are now same as in sumo.

### Justification

WI: [AB#3219691](https://dev.azure.com/ni/DevCentral/_workitems/edit/3219691)

### Testing

- [x] `bitbake packagefeed-ni-core` on scarthgap ARM.
- [x] `bitbake nilrt-base-system-image` on scarthgap ARM.
- [x] Installed BSI on cRIO-9068 and verified sysapi can read `ModeNumber`, `SerialNumber`.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
