### PR TITLE
Enable ti-wifi-utils recipe for ARM scarthgap

### DIFF
--- a/recipes-connectivity/ti-wifi-utils/files/0001-fix-efuse_param_type_enm.patch
+++ b/recipes-connectivity/ti-wifi-utils/files/0001-fix-efuse_param_type_enm.patch
@@ -1,0 +1,25 @@
+From c4d382a73a1c96c4c1568d4b33363d3ce91c42ba Mon Sep 17 00:00:00 2001
+From: Can Wong <can.wong@emerson.com>
+Date: Wed, 22 Oct 2025 14:55:52 -0500
+Subject: [PATCH] fix efuse_param_type_enm
+
+---
+ plt.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/plt.h b/plt.h
+index 8b534a9..43d5dbc 100644
+--- a/plt.h
++++ b/plt.h
+@@ -399,7 +399,7 @@ enum EFUSE_PARAMETER_TYPE_ENMT {
+ 	TX_BIP_PD_BUFFER_VBIAS_ERROR_E,
+ 	EFUSE_NUMBER_OF_PARAMETERS_E,
+ 	EFUSE_LAST_PARAMETER_E = (EFUSE_NUMBER_OF_PARAMETERS_E - 1)
+-} EFUSE_PARAMETER_TYPE_ENM;
++};
+ 
+ int get_mac_addr(int ifc_num, unsigned char *mac_addr);
+ 
+-- 
+2.43.0
+

--- a/recipes-connectivity/ti-wifi-utils/files/0001-fix-packed-member-warning.patch
+++ b/recipes-connectivity/ti-wifi-utils/files/0001-fix-packed-member-warning.patch
@@ -1,0 +1,282 @@
+From 868075373104c403bc96f061c3117d762a8dae69 Mon Sep 17 00:00:00 2001
+From: Can Wong <can.wong@emerson.com>
+Date: Wed, 22 Oct 2025 14:48:10 -0500
+Subject: [PATCH] fix packed member warning
+
+---
+ ini.c | 112 +++++++++++++++++++++++++++++++++++++++++-----------------
+ nvs.c |  16 +++++++--
+ 2 files changed, 93 insertions(+), 35 deletions(-)
+
+diff --git a/ini.c b/ini.c
+index 46cd8c7..e53b395 100644
+--- a/ini.c
++++ b/ini.c
+@@ -391,8 +391,11 @@ static int parse_fem0_band2_prms(char *l, struct wl12xx_ini *p)
+ 	if (split_line(l, &name, &val))
+ 		return 1;
+ 
+-	COMPARE_N_ADD2("FEM0_TXBiPReferencePDvoltage_2_4G", l, val,
+-		&gp->tx_bip_ref_pd_voltage);
++	{
++		__le16 aligned_val;
++		memcpy(&aligned_val, &gp->tx_bip_ref_pd_voltage, sizeof(aligned_val));
++		COMPARE_N_ADD2("FEM0_TXBiPReferencePDvoltage_2_4G", l, val, &aligned_val);
++	}
+ 
+ 	COMPARE_N_ADD("FEM0_TxBiPReferencePower_2_4G", l, val,
+ 		&gp->tx_bip_ref_power);
+@@ -444,8 +447,11 @@ static int parse_fem0_band2_prms_128x(char *l, struct wl12xx_ini *p)
+ 	if (split_line(l, &name, &val))
+ 		return 1;
+ 
+-	COMPARE_N_ADD2("FEM0_TxBiPReferencePDvoltage_2_4G", l, val,
+-		&gp->tx_bip_ref_pd_voltage);
++	{
++		__le16 aligned_val;
++		memcpy(&aligned_val, &gp->tx_bip_ref_pd_voltage, sizeof(aligned_val));
++		COMPARE_N_ADD2("FEM0_TXBiPReferencePDvoltage_2_4G", l, val, &aligned_val);
++	}
+ 
+ 	COMPARE_N_ADD("FEM0_TxBiPReferencePower_2_4G", l, val,
+ 		&gp->tx_bip_ref_power);
+@@ -503,8 +509,11 @@ static int parse_fem1_band2_prms(char *l, struct wl12xx_ini *p)
+ 	if (split_line(l, &name, &val))
+ 		return 1;
+ 
+-	COMPARE_N_ADD2("FEM1_TXBiPReferencePDvoltage_2_4G", l, val,
+-		&gp->tx_bip_ref_pd_voltage);
++	{
++		__le16 aligned_val;
++		memcpy(&aligned_val, &gp->tx_bip_ref_pd_voltage, sizeof(aligned_val));
++		COMPARE_N_ADD2("FEM1_TXBiPReferencePDvoltage_2_4G", l, val, &aligned_val);
++	}
+ 
+ 	COMPARE_N_ADD("FEM1_TxBiPReferencePower_2_4G", l, val,
+ 		&gp->tx_bip_ref_power);
+@@ -556,8 +565,11 @@ static int parse_fem1_band2_prms_128x(char *l, struct wl12xx_ini *p)
+ 	if (split_line(l, &name, &val))
+ 		return 1;
+ 
+-	COMPARE_N_ADD2("FEM1_TxBiPReferencePDvoltage_2_4G", l, val,
+-		&gp->tx_bip_ref_pd_voltage);
++	{
++		__le16 aligned_val;
++		memcpy(&aligned_val, &gp->tx_bip_ref_pd_voltage, sizeof(aligned_val));
++		COMPARE_N_ADD2("FEM1_TXBiPReferencePDvoltage_2_4G", l, val, &aligned_val);
++	}
+ 
+ 	COMPARE_N_ADD("FEM1_TxBiPReferencePower_2_4G", l, val,
+ 		&gp->tx_bip_ref_power);
+@@ -615,8 +627,11 @@ static int parse_fem2_band2_prms(char *l, struct wl12xx_ini *p)
+ 	if (split_line(l, &name, &val))
+ 		return 1;
+ 
+-	COMPARE_N_ADD2("FEM2_TXBiPReferencePDvoltage_2_4G", l, val,
+-		&gp->tx_bip_ref_pd_voltage);
++	{
++		__le16 aligned_val;
++		memcpy(&aligned_val, &gp->tx_bip_ref_pd_voltage, sizeof(aligned_val));
++		COMPARE_N_ADD2("FEM2_TXBiPReferencePDvoltage_2_4G", l, val, &aligned_val);
++	}
+ 
+ 	COMPARE_N_ADD("FEM2_TxBiPReferencePower_2_4G", l, val,
+ 		&gp->tx_bip_ref_power);
+@@ -668,8 +683,11 @@ static int parse_fem2_band2_prms_128x(char *l, struct wl12xx_ini *p)
+ 	if (split_line(l, &name, &val))
+ 		return 1;
+ 
+-	COMPARE_N_ADD2("FEM2_TxBiPReferencePDvoltage_2_4G", l, val,
+-		&gp->tx_bip_ref_pd_voltage);
++	{
++		__le16 aligned_val;
++		memcpy(&aligned_val, &gp->tx_bip_ref_pd_voltage, sizeof(aligned_val));
++		COMPARE_N_ADD2("FEM2_TxBiPReferencePDvoltage_2_4G", l, val, &aligned_val);
++	}
+ 
+ 	COMPARE_N_ADD("FEM2_TxBiPReferencePower_2_4G", l, val,
+ 		&gp->tx_bip_ref_power);
+@@ -727,8 +745,11 @@ static int parse_fem3_band2_prms(char *l, struct wl12xx_ini *p)
+ 	if (split_line(l, &name, &val))
+ 		return 1;
+ 
+-	COMPARE_N_ADD2("FEM3_TXBiPReferencePDvoltage_2_4G", l, val,
+-		&gp->tx_bip_ref_pd_voltage);
++	{
++		__le16 aligned_val;
++		memcpy(&aligned_val, &gp->tx_bip_ref_pd_voltage, sizeof(aligned_val));
++		COMPARE_N_ADD2("FEM3_TXBiPReferencePDvoltage_2_4G", l, val, &aligned_val);
++	}
+ 
+ 	COMPARE_N_ADD("FEM3_TxBiPReferencePower_2_4G", l, val,
+ 		&gp->tx_bip_ref_power);
+@@ -780,8 +801,11 @@ static int parse_fem3_band2_prms_128x(char *l, struct wl12xx_ini *p)
+ 	if (split_line(l, &name, &val))
+ 		return 1;
+ 
+-	COMPARE_N_ADD2("FEM3_TxBiPReferencePDvoltage_2_4G", l, val,
+-		&gp->tx_bip_ref_pd_voltage);
++	{
++		__le16 aligned_val;
++		memcpy(&aligned_val, &gp->tx_bip_ref_pd_voltage, sizeof(aligned_val));
++		COMPARE_N_ADD2("FEM3_TxBiPReferencePDvoltage_2_4G", l, val, &aligned_val);
++	}
+ 
+ 	COMPARE_N_ADD("FEM3_TxBiPReferencePower_2_4G", l, val,
+ 		&gp->tx_bip_ref_power);
+@@ -839,8 +863,11 @@ static int parse_fem0_band5_prms(char *l, struct wl12xx_ini *p)
+ 	if (split_line(l, &name, &val))
+ 		return 1;
+ 
+-	COMPARE_N_ADD2("FEM0_TXBiPReferencePDvoltage_5G", l, val,
+-		&gp->tx_bip_ref_pd_voltage);
++	{
++		__le16 aligned_val;
++		memcpy(&aligned_val, &gp->tx_bip_ref_pd_voltage, sizeof(aligned_val));
++		COMPARE_N_ADD2("FEM0_TXBiPReferencePDvoltage_5G", l, val, &aligned_val);
++	}
+ 
+ 	COMPARE_N_ADD("FEM0_TxBiPReferencePower_5G", l, val,
+ 		&gp->tx_bip_ref_power);
+@@ -889,8 +916,11 @@ static int parse_fem0_band5_prms_128x(char *l, struct wl12xx_ini *p)
+ 	if (split_line(l, &name, &val))
+ 		return 1;
+ 
+-	COMPARE_N_ADD2("FEM0_TxBiPReferencePDvoltage_5G", l, val,
+-		&gp->tx_bip_ref_pd_voltage);
++	{
++		__le16 aligned_val;
++		memcpy(&aligned_val, &gp->tx_bip_ref_pd_voltage, sizeof(aligned_val));
++		COMPARE_N_ADD2("FEM0_TXBiPReferencePDvoltage_5G", l, val, &aligned_val);
++	}
+ 
+ 	COMPARE_N_ADD("FEM0_TxBiPReferencePower_5G", l, val,
+ 		&gp->tx_bip_ref_power);
+@@ -945,8 +975,11 @@ static int parse_fem1_band5_prms(char *l, struct wl12xx_ini *p)
+ 	if (split_line(l, &name, &val))
+ 		return 1;
+ 
+-	COMPARE_N_ADD2("FEM1_TXBiPReferencePDvoltage_5G", l, val,
+-		&gp->tx_bip_ref_pd_voltage);
++	{
++		__le16 aligned_val;
++		memcpy(&aligned_val, &gp->tx_bip_ref_pd_voltage, sizeof(aligned_val));
++		COMPARE_N_ADD2("FEM1_TXBiPReferencePDvoltage_5G", l, val, &aligned_val);
++	}
+ 
+ 	COMPARE_N_ADD("FEM1_TxBiPReferencePower_5G", l, val,
+ 		&gp->tx_bip_ref_power);
+@@ -995,8 +1028,11 @@ static int parse_fem1_band5_prms_128x(char *l, struct wl12xx_ini *p)
+ 	if (split_line(l, &name, &val))
+ 		return 1;
+ 
+-	COMPARE_N_ADD2("FEM1_TxBiPReferencePDvoltage_5G", l, val,
+-		&gp->tx_bip_ref_pd_voltage);
++	{
++		__le16 aligned_val;
++		memcpy(&aligned_val, &gp->tx_bip_ref_pd_voltage, sizeof(aligned_val));
++		COMPARE_N_ADD2("FEM1_TXBiPReferencePDvoltage_5G", l, val, &aligned_val);
++	}
+ 
+ 	COMPARE_N_ADD("FEM1_TxBiPReferencePower_5G", l, val,
+ 		&gp->tx_bip_ref_power);
+@@ -1051,8 +1087,11 @@ static int parse_fem2_band5_prms(char *l, struct wl12xx_ini *p)
+ 	if (split_line(l, &name, &val))
+ 		return 1;
+ 
+-	COMPARE_N_ADD2("FEM2_TXBiPReferencePDvoltage_5G", l, val,
+-		&gp->tx_bip_ref_pd_voltage);
++	{
++		__le16 aligned_val;
++		memcpy(&aligned_val, &gp->tx_bip_ref_pd_voltage, sizeof(aligned_val));
++		COMPARE_N_ADD2("FEM2_TXBiPReferencePDvoltage_5G", l, val, &aligned_val);
++	}
+ 
+ 	COMPARE_N_ADD("FEM2_TxBiPReferencePower_5G", l, val,
+ 		&gp->tx_bip_ref_power);
+@@ -1101,8 +1140,11 @@ static int parse_fem2_band5_prms_128x(char *l, struct wl12xx_ini *p)
+ 	if (split_line(l, &name, &val))
+ 		return 1;
+ 
+-	COMPARE_N_ADD2("FEM2_TxBiPReferencePDvoltage_5G", l, val,
+-		&gp->tx_bip_ref_pd_voltage);
++	{
++		__le16 aligned_val;
++		memcpy(&aligned_val, &gp->tx_bip_ref_pd_voltage, sizeof(aligned_val));
++		COMPARE_N_ADD2("FEM2_TXBiPReferencePDvoltage_5G", l, val, &aligned_val);
++	}
+ 
+ 	COMPARE_N_ADD("FEM2_TxBiPReferencePower_5G", l, val,
+ 		&gp->tx_bip_ref_power);
+@@ -1157,8 +1199,11 @@ static int parse_fem3_band5_prms(char *l, struct wl12xx_ini *p)
+ 	if (split_line(l, &name, &val))
+ 		return 1;
+ 
+-	COMPARE_N_ADD2("FEM3_TXBiPReferencePDvoltage_5G", l, val,
+-		&gp->tx_bip_ref_pd_voltage);
++	{
++		__le16 aligned_val;
++		memcpy(&aligned_val, &gp->tx_bip_ref_pd_voltage, sizeof(aligned_val));
++		COMPARE_N_ADD2("FEM3_TXBiPReferencePDvoltage_5G", l, val, &aligned_val);
++	}
+ 
+ 	COMPARE_N_ADD("FEM3_TxBiPReferencePower_5G", l, val,
+ 		&gp->tx_bip_ref_power);
+@@ -1207,8 +1252,11 @@ static int parse_fem3_band5_prms_128x(char *l, struct wl12xx_ini *p)
+ 	if (split_line(l, &name, &val))
+ 		return 1;
+ 
+-	COMPARE_N_ADD2("FEM3_TxBiPReferencePDvoltage_5G", l, val,
+-		&gp->tx_bip_ref_pd_voltage);
++	{
++		__le16 aligned_val;
++		memcpy(&aligned_val, &gp->tx_bip_ref_pd_voltage, sizeof(aligned_val));
++		COMPARE_N_ADD2("FEM3_TXBiPReferencePDvoltage_5G", l, val, &aligned_val);
++	}
+ 
+ 	COMPARE_N_ADD("FEM3_TxBiPReferencePower_5G", l, val,
+ 		&gp->tx_bip_ref_power);
+diff --git a/nvs.c b/nvs.c
+index 2e9e146..52cd148 100644
+--- a/nvs.c
++++ b/nvs.c
+@@ -741,7 +741,9 @@ int prepare_nvs_file(void *arg, char *file_name)
+ 	}
+ 
+ 	/* fill NVS version */
+-	if (nvs_fill_version(new_nvs, &pdata->ver))
++	unsigned int aligned_ver;
++	memcpy(&aligned_ver, &pdata->ver, sizeof(aligned_ver));
++	if (nvs_fill_version(new_nvs, &aligned_ver))
+ 		fprintf(stderr, "Fail to fill version\n");
+ 
+ 	/* fill end of NVS */
+@@ -1123,7 +1125,11 @@ static void print_127x_fem_param5(int femnr, struct wl1271_ini_fem_params_5 *p)
+ 
+ 	printf("# SECTION 2.1.2: 5G parameters\n");
+ 
+-	print_femle16a(fem, "TxBiPReferencePDvoltage_5G", p->tx_bip_ref_pd_voltage);
++	{
++		__le16 aligned_pd_voltage[sizeof(p->tx_bip_ref_pd_voltage)/sizeof(__le16)];
++		memcpy(aligned_pd_voltage, p->tx_bip_ref_pd_voltage, sizeof(aligned_pd_voltage));
++		print_femle16a(fem, "TxBiPReferencePDvoltage_5G", aligned_pd_voltage);
++	}
+ 
+ 	print_femhexa(fem, "TxBiPReferencePower_5G", p->tx_bip_ref_power);
+ 	print_femhexa(fem, "TxBiPOffsetdB_5G", p->tx_bip_ref_offset);
+@@ -1148,7 +1154,11 @@ static void print_128x_fem_param5(int femnr, struct wl128x_ini_fem_params_5 *p)
+ 
+ 	printf("# SECTION 2.1.2: 5G parameters\n");
+ 
+-	print_femle16a(fem, "TxBiPReferencePDvoltage_5G", p->tx_bip_ref_pd_voltage);
++{
++    __le16 aligned_pd_voltage[sizeof(p->tx_bip_ref_pd_voltage)/sizeof(__le16)];
++    memcpy(aligned_pd_voltage, p->tx_bip_ref_pd_voltage, sizeof(aligned_pd_voltage));
++    print_femle16a(fem, "TxBiPReferencePDvoltage_5G", aligned_pd_voltage);
++}
+ 
+ 	print_femhexa(fem, "TxBiPReferencePower_5G", p->tx_bip_ref_power);
+ 	print_femhexa(fem, "TxBiPOffsetdB_5G", p->tx_bip_ref_offset);
+-- 
+2.43.0
+

--- a/recipes-connectivity/ti-wifi-utils/ti-wifi-utils_git.bb
+++ b/recipes-connectivity/ti-wifi-utils/ti-wifi-utils_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "The calibrator and other useful utilities for TI wireless solution based on wl12xx driver"
-LICENSE = "BSD"
+LICENSE = "0BSD"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4725015cb0be7be389cf06deeae3683d"
 
 DEPENDS = "libnl"
@@ -9,6 +9,8 @@ PV = "R8.6+git${SRCPV}"
 #Tag: R8.6
 SRCREV = "cf8965aad73764022669647fa33852558a657930"
 SRC_URI = "git://git.ti.com/wilink8-wlan/18xx-ti-utils.git \
+           file://0001-fix-packed-member-warning.patch \
+           file://0001-fix-efuse_param_type_enm.patch \
 "
 
 S = "${WORKDIR}/git"

--- a/recipes-connectivity/ti-wifi-utils/ti-wifi-utils_git.bb
+++ b/recipes-connectivity/ti-wifi-utils/ti-wifi-utils_git.bb
@@ -1,0 +1,26 @@
+DESCRIPTION = "The calibrator and other useful utilities for TI wireless solution based on wl12xx driver"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://COPYING;md5=4725015cb0be7be389cf06deeae3683d"
+
+DEPENDS = "libnl"
+
+PV = "R8.6+git${SRCPV}"
+
+#Tag: R8.6
+SRCREV = "cf8965aad73764022669647fa33852558a657930"
+SRC_URI = "git://git.ti.com/wilink8-wlan/18xx-ti-utils.git \
+"
+
+S = "${WORKDIR}/git"
+
+export CROSS_COMPILE = "${TARGET_PREFIX}"
+
+EXTRA_OEMAKE = 'CFLAGS="${CFLAGS} -I${STAGING_INCDIR}/libnl3/ -DCONFIG_LIBNL32 " \
+		LDFLAGS="${LDFLAGS} -L${STAGING_LIBDIR}" \
+		CC="${CC}" \
+		NLVER=3'
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 calibrator ${D}${bindir}/
+}

--- a/recipes-core/packagegroups/packagefeed-ni-extra.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-extra.bb
@@ -240,6 +240,7 @@ RDEPENDS:${PN} += "\
 	rfkill \
 	samba \
 	ser2net \
+	ti-wifi-utils \
 	tiptop \
 	usbmuxd \
 	zeromq \

--- a/recipes-core/packagegroups/packagefeed-ni-extra.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-extra.bb
@@ -245,10 +245,6 @@ RDEPENDS:${PN} += "\
 	zeromq \
 "
 
-RDEPENDS:${PN}:append:xilinx-zynq = " \
-	ti-wifi-utils \
-"
-
 # meta-openembedded/meta-oe/recipes-core
 RDEPENDS:${PN} += "\
 	usleep \

--- a/recipes-core/packagegroups/packagefeed-ni-extra.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-extra.bb
@@ -240,10 +240,13 @@ RDEPENDS:${PN} += "\
 	rfkill \
 	samba \
 	ser2net \
-	ti-wifi-utils \
 	tiptop \
 	usbmuxd \
 	zeromq \
+"
+
+RDEPENDS:${PN}:append:xilinx-zynq = " \
+	ti-wifi-utils \
 "
 
 # meta-openembedded/meta-oe/recipes-core

--- a/recipes-core/packagegroups/packagegroup-ni-wifi.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-wifi.bb
@@ -15,6 +15,9 @@ RDEPENDS:${PN} = "\
 	libnl \
 	openssl \
 	rfkill \
-	ti-wifi-utils \
 	wpa-supplicant \
 	wireless-regdb"
+
+RDEPENDS:${PN}:append:xilinx-zynq = " \
+	ti-wifi-utils \
+"

--- a/recipes-core/packagegroups/packagegroup-ni-wifi.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-wifi.bb
@@ -15,5 +15,6 @@ RDEPENDS:${PN} = "\
 	libnl \
 	openssl \
 	rfkill \
+	ti-wifi-utils \
 	wpa-supplicant \
 	wireless-regdb"


### PR DESCRIPTION
### Summary of Changes

Enable `ti-wifi-utils` to build and compile for ARM scarthgap


### Justification

[AB#3429871](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3429871)


### Testing

* [x] I have built the core package feed (x64) with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have built the base system image (x64) with this PR in place. (`bitbake nilrt-base-system-image`)
* [x] I have deployed the base system image (x64) to a PXIe-8881 target.
* [x] I have built the core package feed (xilinx-zynq) with this PR in place (`bitbake packagefeed-ni-core`)
* [x] I have built the base system image (xilinx-zynq) with this PR in place (`bitbake nilrt-base-system-image`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
