### PR TITLE
docker-moby: Remove cgroup-lite as a dependency

### DIFF
--- a/recipes-containers/docker/docker-moby_%.bbappend
+++ b/recipes-containers/docker/docker-moby_%.bbappend
@@ -2,3 +2,7 @@
 # So use a shortened SRCREV_moby in PV.
 SRCREV_moby_short = "${@d.getVar('SRCREV_moby')[:10]}"
 PV = "${DOCKER_VERSION}+git${SRCREV_moby_short}"
+
+# Remove cgroup-lite dependency so that docker can work on systems with cgroup v2 paths.
+RDEPENDS:${PN}:remove = "cgroup-lite"
+RDEPENDS:${PN}:append = " ni-cgroups"


### PR DESCRIPTION
### Summary of Changes

cgroups v1 paths will soon be deprecated, we need docker containers to be runnable on cgroup v2 paths. The
meta-virtualization recipe adds the dependency cgroup-lite for SysVInit images. Since that is specific to cgroup v1 paths, it needs to be removed from the docker-moby pacakge dependencies.

The docker-moby package is now capable of using cgroup v2 paths by adding the new recipe `ni-cgroups` as a dpeendency.

### Justification

[AB#3441396](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3441396)


### Testing

This change has been tested locally by building and installing the docker-moby package on a SysVInit target. The docker-functional-tests have also been run on the target to make sure nothing is broken.

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
