### PR TITLE
nisetbootmode.functions: Add ARM support

### DIFF
--- a/recipes-ni/ni-utils/files/nisetbootmode.functions
+++ b/recipes-ni/ni-utils/files/nisetbootmode.functions
@@ -3,22 +3,22 @@ arch=`uname -m`
 BOOT_CONFIG_LOCATION="/boot/bootmode"
 
 write_config() {
-   echo "set BOOT_MODE=$1" > $BOOT_CONFIG_LOCATION
+	echo "set BOOT_MODE=$1" > $BOOT_CONFIG_LOCATION
 }
 
 read_config() {
-   read tmp_cfg < $BOOT_CONFIG_LOCATION
-   echo $tmp_cfg | awk -F '=' '{print $2}';
+	read tmp_cfg < $BOOT_CONFIG_LOCATION
+	echo $tmp_cfg | awk -F '=' '{print $2}';
 }
 
 # if the bootmode file doesn't exist, this is the first run of this
 # script for this boot, so set it to the current mode
 if [ ! -f "$BOOT_CONFIG_LOCATION" ]; then
-   if [ -f "/etc/natinst/safemode" ]; then
-      write_config safemode
-   else
-      write_config runtime
-   fi
+	if [ -f "/etc/natinst/safemode" ]; then
+		write_config safemode
+	else
+		write_config runtime
+	fi
 fi
 
 BOOT_MODE_INPUT=/tmp/ni_boot_mode_input

--- a/recipes-ni/ni-utils/files/nisetbootmode.functions
+++ b/recipes-ni/ni-utils/files/nisetbootmode.functions
@@ -1,23 +1,34 @@
 arch=`uname -m`
 
-BOOT_CONFIG_LOCATION="/boot/bootmode"
+if [ "$arch" = "armv7l" ]; then
+	BOOT_CONFIG_LOCATION=/sys/bus/i2c/devices/0-0040/bootmode
+	write_config() {
+		echo -n $1 > $BOOT_CONFIG_LOCATION
+	}
+	read_config() {
+		read tmp_cfg < $BOOT_CONFIG_LOCATION
+		echo $tmp_cfg
+	}
+elif [ "$arch" = "x86_64" ]; then
+	BOOT_CONFIG_LOCATION="/boot/bootmode"
 
-write_config() {
-	echo "set BOOT_MODE=$1" > $BOOT_CONFIG_LOCATION
-}
+	write_config() {
+		echo "set BOOT_MODE=$1" > $BOOT_CONFIG_LOCATION
+	}
 
-read_config() {
-	read tmp_cfg < $BOOT_CONFIG_LOCATION
-	echo $tmp_cfg | awk -F '=' '{print $2}';
-}
+	read_config() {
+		read tmp_cfg < $BOOT_CONFIG_LOCATION
+		echo $tmp_cfg | awk -F '=' '{print $2}';
+	}
 
-# if the bootmode file doesn't exist, this is the first run of this
-# script for this boot, so set it to the current mode
-if [ ! -f "$BOOT_CONFIG_LOCATION" ]; then
-	if [ -f "/etc/natinst/safemode" ]; then
-		write_config safemode
-	else
-		write_config runtime
+	# if the bootmode file doesn't exist, this is the first run of this
+	# script for this boot, so set it to the current mode
+	if [ ! -f "$BOOT_CONFIG_LOCATION" ]; then
+		if [ -f "/etc/natinst/safemode" ]; then
+			write_config safemode
+		else
+			write_config runtime
+		fi
 	fi
 fi
 


### PR DESCRIPTION
### Summary of Changes

Add ARM support to nisetbootmode.functions which enables setting next bootmode.

### Justification

WI: [AB#3219691](https://dev.azure.com/ni/DevCentral/_workitems/edit/3219691)

### Testing

- [x] Replace the corresponding file on an ARM target with scarthgap BSI. Could set next boot to safemode from MAX and boot into safemode.
- [x] Replace the corresponding file on an x64 target. Could set next boot to safemode from MAX and boot into safemode.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
