### PR TITLE
[ARM] Enable nisafemodeversion and lvrt

### DIFF
--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -127,6 +127,8 @@ LICENSE_CREATE_PACKAGE ?= "1"
 
 # Use 32-bit time on ARM32 to keep compatibility with pre-compiled binaries
 GLIBC_64BIT_TIME_FLAGS:xilinx-zynq = ""
+# Skip the 32bit-time QA check to avoid build time warnings. We know we're using 32-bit time.
+INSANE_SKIP:append:xilinx-zynq = "32bit-time"
 
 ## OPKG SOURCE FEEDS ##
 

--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -125,6 +125,8 @@ NILRT_GIT ?= "git://github.com/ni"
 # Creates ``*-lic`` subpackages for all OE recipes if enabled
 LICENSE_CREATE_PACKAGE ?= "1"
 
+# Use 32-bit time on ARM32 to keep compatibility with pre-compiled binaries
+GLIBC_64BIT_TIME_FLAGS:xilinx-zynq = ""
 
 ## OPKG SOURCE FEEDS ##
 

--- a/recipes-ni/ni-safemode-utils/files/nisafemodeversion
+++ b/recipes-ni/ni-safemode-utils/files/nisafemodeversion
@@ -30,8 +30,8 @@ unknown_ver_string=unknown
 
 get_version_itb()
 {
-	if [ -x /sbin/fdtview ]; then
-		version_string=`/sbin/fdtview -l / version $1 | awk -F = '{print $2}'`
+	if [ -x /usr/bin/uboot-dumpimage ]; then
+		version_string=`/usr/bin/uboot-dumpimage -l $1 2>/dev/null | grep "FIT description" | awk -F ' - ' '{print $2}'`
 		if [ $? -ne 0 ]; then
 			version_string=""
 		fi

--- a/recipes-ni/ni-safemode-utils/files/nisafemodeversion
+++ b/recipes-ni/ni-safemode-utils/files/nisafemodeversion
@@ -3,7 +3,7 @@
 # Copyright (c) 2013 National Instruments
 #
 # Script used to get the current version of safemode on the system, the version of safemode
-# for the specified cfg file, or the comparision of the safemode version on the system with
+# for the specified cfg file, or the comparison of the safemode version on the system with
 # the version of the safemode on the cfg file.
 #
 # returns:
@@ -12,7 +12,7 @@
 #    2 if the version for comparison is older
 #    3 if the version for comparison is the same
 #    4 if the version for comparison is newer
-#    5 if the comparison is invalid due to an unkown version for either the current or given safemode
+#    5 if the comparison is invalid due to an unknown version for either the current or given safemode
 
 usage()
 {

--- a/recipes-ni/ni-safemode-utils/files/nisafemodeversion
+++ b/recipes-ni/ni-safemode-utils/files/nisafemodeversion
@@ -28,6 +28,20 @@ cleanup()
 
 unknown_ver_string=unknown
 
+get_version_itb()
+{
+	if [ -x /sbin/fdtview ]; then
+		version_string=`/sbin/fdtview -l / version $1 | awk -F = '{print $2}'`
+		if [ $? -ne 0 ]; then
+			version_string=""
+		fi
+	fi
+	if [ -z "$version_string" ]; then
+		version_string=$unknown_ver_string
+	fi
+	echo ${version_string//\"/}
+}
+
 get_version_grub()
 {
 	version_string=`grep ^component_version= $1`
@@ -39,9 +53,13 @@ get_version_grub()
 }
 
 mount_point="/boot"
-
-bootimage_data="bootimage.ini"
-get_version=get_version_grub
+if [ -f $mount_point/.safe/linux_safemode.itb ]; then
+	bootimage_data="linux_safemode.itb"
+	get_version=get_version_itb
+else
+	bootimage_data="bootimage.ini"
+	get_version=get_version_grub
+fi
 
 current_version_source=$mount_point/.safe/$bootimage_data
 version_source=$current_version_source

--- a/recipes-ni/ni-safemode-utils/ni-safemode-utils.bb
+++ b/recipes-ni/ni-safemode-utils/ni-safemode-utils.bb
@@ -21,6 +21,7 @@ FILES:${PN} += "\
 DEPENDS += "shadow-native pseudo-native niacctbase update-rc.d-native"
 
 RDEPENDS:${PN} += "niacctbase bash fw-printenv"
+RDEPENDS:${PN}:append:xilinx-zynq = " u-boot-tools-mkimage "
 
 do_install () {
 	install -d ${D}${natinstbin}


### PR DESCRIPTION
### Summary of Changes

Changes to get `nisafemodeversion` and `lvrt` working.

### Justification

WI: [AB#3219691](https://dev.azure.com/ni/DevCentral/_workitems/edit/3219691)

### Testing

- [x] `bitbake packagefeed-ni-core` on scarthgap ARM.
- [x] `bitbake packagegroup-ni-desirable` on scarthgap ARM.
- [x] `bitbake nilrt-base-system-image` on scarthgap ARM
- [x] scarthgap ARM BSI boots on cRIO-9068.
- [x] Verified `nisafemodeversion` works and MAX shows safemode firmware version.
- [x] Verified a simple LabVIEW VI works.
- [x] `bitbake -e nilrt-base-system-image` on scarthgap x64 and verified `GLIBC_64BIT_TIME_FLAGS` and `INSANE_SKIP` changes made for ARM don't apply to x64 builds.
- [x] Verified `nisafemodeversion` still works on an x64 VM.


### Procedure

- [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
