### PR TITLE
nilrt-bsi.postinst: Fix BSI install on old safemodes

### DIFF
--- a/recipes-core/images/files/nilrt-base-system-image.postinst
+++ b/recipes-core/images/files/nilrt-base-system-image.postinst
@@ -69,7 +69,13 @@ awk '{print $2;}' < /proc/mounts | grep -q /boot || exit 1
 # Give hwclock CAP_SYS_TIME capabilties
 /usr/sbin/setcap CAP_SYS_TIME+ep /mnt/userfs/sbin/hwclock.util-linux
 
-if [ "$arch" = "x86_64" ]; then
+if [ "$arch" = "armv7l" ]; then
+   # safemodes older than 8.0 don't bind mount bootfs to /mnt/userfs/bootfs.
+   # So files that get extracted into /mnt/userfs/boot have to be moved into /boot.
+	if [ ! -f "$mount_point/linux_runmode.itb" ]; then
+		mv /mnt/userfs/boot/* "$mount_point"
+	fi
+elif [ "$arch" = "x86_64" ]; then
 	kernel="/mnt/userfs/boot/tmp/runmode"
 	# install the kernel
 	rm -rf /boot/runmode


### PR DESCRIPTION
### Summary of Changes

Safemodes older than 8.0 don't bind mount `/boot` to `/mnt/userfs/boot`. So uboot can't find the `linux_runmode.itb` after BSI install and boots into safemode.

Fix this by moving `/mnt/userfs/boot/*` files to `/boot` if `/boot/linux_runmode.itb` isn't present.

### Justification

WI: [AB#3217166](https://dev.azure.com/ni/DevCentral/_workitems/edit/3217166)

### Testing

* [x] Built and installed ARM BSI on cRIO-9067 with a 7.0 safemode. Target can now boot into runmode.
* [x] Built and installed x64 BSI on a VM. VM can boot into runmode.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
