### PR TITLE
Add xorgxrdp and xrdp package builds to nilrt extra feed

### DIFF
--- a/files/group
+++ b/files/group
@@ -6,6 +6,7 @@ ni:x:500:
 openvpn:x:499:
 niwscerts:x:498:
 # free space
+xrdp:x:403:
 arpwatch:x:402:
 ptest:x:401:
 ossec:x:400:

--- a/files/passwd
+++ b/files/passwd
@@ -6,6 +6,7 @@ webserv:x:501::::
 lvuser:x:500::::
 openvpn:x:499::::
 # free space
+xrdp:x:403::::
 arpwatch:x:402::::
 ptest:x:401::::
 ossec:x:400::::

--- a/recipes-core/packagegroups/packagefeed-ni-extra.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-extra.bb
@@ -4,7 +4,7 @@ LICENSE = "MIT"
 inherit packagegroup
 
 # Graphical extra packages
-RDEPENDS:${PN}:append = "\
+RDEPENDS:${PN}:append:x64 = "\
 	packagegroup-self-hosted \
 	packagegroup-xfce-extended \
 	consolekit \
@@ -37,7 +37,9 @@ RDEPENDS:${PN}:append = "\
 	xfontsel \
 	xlsfonts \
 	xmag \
+	xorgxrdp \
 	xrdb \
+	xrdp \
 	xterm \
 	xwd \
 "

--- a/recipes-support/xorg-xrdp/xorgxrdp/0001-xorg.conf-Make-sure-the-glamor-module-is-loaded.patch
+++ b/recipes-support/xorg-xrdp/xorgxrdp/0001-xorg.conf-Make-sure-the-glamor-module-is-loaded.patch
@@ -1,0 +1,25 @@
+From b8f1e5ca910b06202a046e676c44293e08eaeb1a Mon Sep 17 00:00:00 2001
+From: Joe Hershberger <joe.hershberger@ni.com>
+Date: Fri, 31 Oct 2025 18:37:17 +0000
+Subject: [PATCH] xorg.conf: Make sure the glamor module is loaded
+
+Signed-off-by: Joe Hershberger <joe.hershberger@ni.com>
+---
+ xrdpdev/xorg.conf | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/xrdpdev/xorg.conf b/xrdpdev/xorg.conf
+index 2ca8bd5..838698a 100644
+--- a/xrdpdev/xorg.conf
++++ b/xrdpdev/xorg.conf
+@@ -23,6 +23,7 @@ Section "Module"
+     Load "int10"
+     Load "record"
+     Load "vbe"
++    Load "glamoregl"
+     Load "xorgxrdp"
+     Load "fb"
+ EndSection
+-- 
+2.44.1
+

--- a/recipes-support/xorg-xrdp/xorgxrdp_%.bbappend
+++ b/recipes-support/xorg-xrdp/xorgxrdp_%.bbappend
@@ -1,0 +1,15 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-xorg.conf-Make-sure-the-glamor-module-is-loaded.patch"
+
+DEPENDS += "libdrm"
+
+FILES:${PN}:remove = "${libdir}/xorg/modules/*"
+FILES:${PN} += "${libdir}/xorg/modules/*.so"
+FILES:${PN} += "${libdir}/xorg/modules/*/*.so"
+FILES:${PN}-staticdev += "${libdir}/xorg/modules/*.a"
+FILES:${PN}-staticdev += "${libdir}/xorg/modules/*/*.a"
+
+CFLAGS:prepend = "-I${STAGING_INCDIR}/libdrm "
+EXTRA_OECONF =+ "--enable-glamor"
+

--- a/recipes-support/xrdp/xrdp/0001-xrdp-Make-init.d-script-compatible-with-nilrt.patch
+++ b/recipes-support/xrdp/xrdp/0001-xrdp-Make-init.d-script-compatible-with-nilrt.patch
@@ -1,0 +1,51 @@
+From aa73fb0f27d7ae660b005b363508410b93e50753 Mon Sep 17 00:00:00 2001
+From: Joe Hershberger <joe.hershberger@ni.com>
+Date: Fri, 31 Oct 2025 17:07:34 +0000
+Subject: [PATCH 1/2] xrdp: Make init.d script compatible with nilrt
+
+Point at the shared init functions in the correct path and implement the
+missing expected function.
+
+Signed-off-by: Joe Hershberger <joe.hershberger@ni.com>
+---
+ instfiles/init.d/xrdp | 24 +++++++++++++++++++++++-
+ 1 file changed, 23 insertions(+), 1 deletion(-)
+
+diff --git a/instfiles/init.d/xrdp b/instfiles/init.d/xrdp
+index cbf2bc70..d4f51987 100644
+--- a/instfiles/init.d/xrdp
++++ b/instfiles/init.d/xrdp
+@@ -28,7 +28,29 @@ DESC="Remote Desktop Protocol server"
+ 
+ test -x $DAEMON || exit 0
+ 
+-. /lib/lsb/init-functions
++. /etc/init.d/functions
++
++# If not using LSB init-functions, provide local versions.
++log_daemon_msg() {
++    echo "$*"
++}
++log_end_msg() {
++    if [ "$1" -eq 0 ]; then
++        echo "Done."
++    else
++        echo "Failed."
++    fi
++}
++log_progress_msg() {
++    echo "$*"
++}
++log_success_msg() {
++    echo "$*"
++}
++log_failure_msg() {
++    echo "$*"
++}
++
+ 
+ check_root()  {
+     if [ "$(id -u)" != "0" ]; then
+-- 
+2.44.1
+

--- a/recipes-support/xrdp/xrdp/0002-sesman-Add-xfce4-and-custom-window-manager-support.patch
+++ b/recipes-support/xrdp/xrdp/0002-sesman-Add-xfce4-and-custom-window-manager-support.patch
@@ -1,0 +1,53 @@
+From 75ebbb07e8d6bb75a0293e9f1bb0eb164750e1e7 Mon Sep 17 00:00:00 2001
+From: Joe Hershberger <joe.hershberger@ni.com>
+Date: Fri, 31 Oct 2025 18:09:41 +0000
+Subject: [PATCH 2/2] sesman: Add xfce4 and custom window manager support
+
+Signed-off-by: Joe Hershberger <joe.hershberger@ni.com>
+---
+ sesman/sesman.ini    |  1 +
+ sesman/startwm.sh    | 16 ++++++++++++++++
+ 2 files changed, 17 insertions(+)
+
+diff --git a/sesman/sesman.ini b/sesman/sesman.ini
+index 8c5f173f..e7f9acce 100644
+--- a/sesman/sesman.ini
++++ b/sesman/sesman.ini
+@@ -117,6 +117,7 @@ param=xrdp/xorg.conf
+ param=-noreset
+ param=-nolisten
+ param=tcp
++param=-keeptty
+ param=-logfile
+ param=.xorgxrdp.%s.log
+ 
+diff --git a/sesman/startwm.sh b/sesman/startwm.sh
+index b3befe88..bc8afe96 100755
+--- a/sesman/startwm.sh
++++ b/sesman/startwm.sh
+@@ -63,6 +63,22 @@ wm_start()
+     export LANG LANGUAGE
+   fi
+ 
++  # custom session
++  if [ -x "$HOME/.xsession" ]; then
++    pre_start
++    exec "$HOME/.xsession"
++    post_start
++    exit 0
++  fi
++
++  # xfce4
++  if [ -x "/usr/bin/startxfce4" ]; then
++    pre_start
++    exec startxfce4
++    post_start
++    exit 0
++  fi
++
+   # debian
+   if [ -r /etc/X11/Xsession ]; then
+     pre_start
+-- 
+2.44.1
+

--- a/recipes-support/xrdp/xrdp_%.bbappend
+++ b/recipes-support/xrdp/xrdp_%.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI =+ " \
+            file://0001-xrdp-Make-init.d-script-compatible-with-nilrt.patch \
+            file://0002-sesman-Add-xfce4-and-custom-window-manager-support.patch \
+            "
+
+inherit update-rc.d
+INITSCRIPT_NAME = "xrdp"
+INITSCRIPT_PARAMS = "defaults 25"


### PR DESCRIPTION
### Summary of Changes

Fix a few things for our context and make sure the build will support hardware acceleration of the RDP session on our controllers.

### Justification

This is generally a useful thing to be able to use for accessing your nilrt targets.

### Testing

Installed on a 9042 and verified that the RDP was functional and that the Intel GPU was accelerating the RDP session.

* [ X ] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [ X ] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
