### PR TITLE
cpe: Specify vendor for zlib and lz4

### DIFF
--- a/recipes-core/cpe/lz4_1.9.4.bbappend
+++ b/recipes-core/cpe/lz4_1.9.4.bbappend
@@ -1,0 +1,1 @@
+CVE_PRODUCT ?= "lz4_project:lz4"

--- a/recipes-core/cpe/zlib_1.3.1.bbappend
+++ b/recipes-core/cpe/zlib_1.3.1.bbappend
@@ -1,0 +1,1 @@
+CVE_PRODUCT ?= "zlib:zlib"


### PR DESCRIPTION
### Summary of Changes

Set CVE_PRODUCT for `lz4` and `zlib`, such that Vendor is provided to the CPE String


### Justification

[AB#3352706](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3352706)


### Testing

TODO: Detail what testing has been done to ensure this submission meets requirements.

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have built zlib and lz4 and verified the cpe string contains "vendor"


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
