### PR TITLE
nilrt-base-system-image.cdf: Set OSVERSION for ARM to 26.0

### DIFF
--- a/recipes-core/images/files/nilrt-base-system-image.cdf
+++ b/recipes-core/images/files/nilrt-base-system-image.cdf
@@ -4,7 +4,7 @@
   <SOFTPKG NAME="%guid%" VERSION="%version%" OLDESTCOMPATIBLEVERSION="%version%" PROVIDESOS="YES" TYPE="HIDDEN">
     <TITLE>SystemLink Base Image</TITLE>
     <IMPLEMENTATION>
-      <OS VALUE="%osvalue%"><OSVERSION VALUE="7.0"/></OS>
+      <OS VALUE="%osvalue%"><OSVERSION VALUE="%osversion%"/></OS>
       <CODEBASE FILENAME="%filename%" TYPE="TAR" />
     </IMPLEMENTATION>
   </SOFTPKG>

--- a/recipes-core/images/nilrt-base-system-image.bb
+++ b/recipes-core/images/nilrt-base-system-image.bb
@@ -19,6 +19,11 @@ CDFGUID:xilinx-zynq = "8E3EACD0-B36E-462B-A500-88AE644AB3B0"
 OSVALUE:x64 = "NI-Linux x64"
 OSVALUE:xilinx-zynq = "Linux-ARMv7-A"
 
+OSVERSION:x64 = "7.0"
+# For BSI to fit on smaller ARM targets, safemode needs zlib compression and other space saving measures.
+# So set minimum compatible safemode version to 26.0 which has them.
+OSVERSION:xilinx-zynq = "26.0"
+
 ROOTFS_IMAGE = "nilrt-runmode-rootfs"
 do_rootfs[depends] += "${ROOTFS_IMAGE}:do_image_complete"
 
@@ -41,7 +46,7 @@ create_cdf() {
 	SHORTVER=$(echo ${BUILDNAME} | sed 's/^\([0-9.]*\).*/\1/;')
 	TARFILE="${IMAGE_BASENAME}-${MACHINE}${IMAGE_NAME_SUFFIX}.tar"
 
-	sed -i "s/%guid%/$GUID/g; s/%version%/$SHORTVER/g; s/%osvalue%/${OSVALUE}/g; s/%filename%/$TARFILE/g;" $CDFOUT
+	sed -i "s/%guid%/$GUID/g; s/%version%/$SHORTVER/g; s/%osvalue%/${OSVALUE}/g; s/%osversion%/${OSVERSION}/g; s/%filename%/$TARFILE/g;" $CDFOUT
 }
 
 IMAGE_PREPROCESS_COMMAND += "bootimg_fixup;"


### PR DESCRIPTION
scarthgap based ARM images are bigger in size and so safemode needs to have zlib compression and other space saving measures to be able to apply the BSI.

So set minimum safemode compatible version to 26.0 which has the support.

WI: [AB#3475811](https://dev.azure.com/ni/DevCentral/_workitems/edit/3475811)

### Testing

- [x] `bitbake -e nilrt-base-system-image` for ARM build shows `OSVERSION` set to 26.0.
- [x] `bitbake -e nilrt-base-system-image` for x64 build shows `OSVERSION` set to 7.0.
- [x] `bitbake nilrt-base-system-image` on ARM and verified that cdf contains `26.0`.
- [x] Verified that with OSVERSION set to 26.0, an NI-9147 target with 25.0 firmware is unable to install scarthgap based ARM BSI.
        <img width="364" height="198" alt="image" src="https://github.com/user-attachments/assets/80b09b93-cf57-421c-b36f-162641bbad62" />
- [x] Verified that NI-9147 target with 26.0 firmware is able to install scarthgap based ARM BSI.


### Procedure

- [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
