### PR TITLE
ti-wifi: Set branch in SRC_URI

### DIFF
--- a/recipes-connectivity/ti-wifi-utils/ti-wifi-utils_git.bb
+++ b/recipes-connectivity/ti-wifi-utils/ti-wifi-utils_git.bb
@@ -8,7 +8,7 @@ PV = "R8.6+git${SRCPV}"
 
 #Tag: R8.6
 SRCREV = "cf8965aad73764022669647fa33852558a657930"
-SRC_URI = "git://git.ti.com/wilink8-wlan/18xx-ti-utils.git \
+SRC_URI = "git://git.ti.com/wilink8-wlan/18xx-ti-utils.git;branch=master;tag=${SRCREV} \
            file://0001-fix-packed-member-warning.patch \
            file://0001-fix-efuse_param_type_enm.patch \
 "


### PR DESCRIPTION
### Summary of Changes
Set branch in `ti-wifi-utils` SRC_URI 


### Justification
[AB#3517588](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3517588)


### Testing
* [X] I have built the ti-wifi-utils package with this PR in place. (`bitbake ti-wifi-utils`)
  * Verified no warnings produced for ti-wifi-utils 


### Procedure
* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
