### PR TITLE
clamav: Add memory-aware scan wrapper for NILRT systems

### DIFF
--- a/recipes-scanners/clamav/clamav_1.%.bbappend
+++ b/recipes-scanners/clamav/clamav_1.%.bbappend
@@ -1,0 +1,52 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://clamav-scan"
+
+do_install:append() {
+    # Install clamav-scan wrapper script for memory-constrained NILRT systems
+    install -m 0755 ${WORKDIR}/clamav-scan ${D}${bindir}/clamav-scan
+}
+
+FILES:${PN} += "${bindir}/clamav-scan"
+
+# NILRT-specific: Backup DNS configuration before installation
+pkg_preinst:${PN}-freshclam:append() {
+    if [ -n "$D" ]; then
+        return 0
+    fi
+    
+    # Backup from /etc/resolv.conf (primary source) if it exists and has content
+    if [ -f /etc/resolv.conf ] && [ -s /etc/resolv.conf ]; then
+        cp /etc/resolv.conf /tmp/resolv.conf.clamav-backup
+    elif [ -f /var/run/resolv.conf ] && [ -s /var/run/resolv.conf ]; then
+        cp /var/run/resolv.conf /tmp/resolv.conf.clamav-backup
+    fi
+}
+
+# NILRT-specific: Add clamav user to adm group for /var/log access
+# NILRT systems have ACLs on /var/log that only allow root and adm group
+pkg_postinst:${PN}-freshclam:append() {
+    if [ -n "$D" ]; then
+        return 0
+    fi
+    
+    # Add clamav user to adm group if not already a member
+    if ! groups ${CLAMAV_USER} | grep -q adm; then
+        usermod -a -G adm ${CLAMAV_USER}
+    fi
+    
+    # Restore DNS configuration if needed (NILRT uses /var/run/resolv.conf)
+    if [ ! -s /var/run/resolv.conf ]; then
+        if [ -f /tmp/resolv.conf.clamav-backup ] && [ -s /tmp/resolv.conf.clamav-backup ]; then
+            cp /tmp/resolv.conf.clamav-backup /var/run/resolv.conf
+            chmod 644 /var/run/resolv.conf
+        else
+            echo "WARNING: DNS is not configured on this system."
+            echo "ClamAV's freshclam requires DNS to download virus signature updates."
+            echo "Please configure DNS by adding nameserver entries to /var/run/resolv.conf"
+        fi
+    fi
+    
+    # Clean up backup file
+    rm -f /tmp/resolv.conf.clamav-backup
+}

--- a/recipes-scanners/clamav/files/clamav-scan
+++ b/recipes-scanners/clamav/files/clamav-scan
@@ -1,0 +1,109 @@
+#!/bin/sh
+#
+# ClamAV scan wrapper
+# Automatically manages swap memory for systems with limited RAM
+#
+
+# Check for root privileges
+if [ "$(id -u)" -ne 0 ]; then
+  echo "Error: This script must be run as root." >&2
+  exit 1
+fi
+
+# Configuration
+MIN_MEMORY_MB=3072
+SWAP_SIZE_MB=1024
+# Use /var/cache which should be on root filesystem
+# Avoid /tmp and /var/volatile which are tmpfs (RAM-based)
+TEMP_SWAP="/var/cache/clamav_swap"
+
+# Parse wrapper-specific options
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --swap-size)
+      SWAP_SIZE_MB="$2"
+      shift 2
+      ;;
+    -h|--help)
+      echo "ClamAV Scan Wrapper"
+      echo ""
+      echo "Usage: clamav-scan [--swap-size MB] [clamscan options...]"
+      echo ""
+      echo "Wrapper Options:"
+      echo "  --swap-size MB    Set swap file size in MB (default: 1024)"
+      echo "  -h, --help        Show this help"
+      echo ""
+      echo "All other options are passed to clamscan."
+      exit 0
+      ;;
+    *)
+      # Not a wrapper option, pass to clamscan
+      break
+      ;;
+  esac
+done
+
+# Memory and swap management
+check_and_create_swap() {
+  # Check total memory in KB and convert to MB
+  total_mem_kb=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+  total_mem_mb=$((total_mem_kb / 1024))
+  
+  # Check if any swap is currently active
+  swap_active=$(swapon --show 2>/dev/null | wc -l)
+  
+  # Create and enable swap file only if memory < threshold and no swap is active
+  if [ "$total_mem_mb" -lt "$MIN_MEMORY_MB" ] && [ "$swap_active" -eq 0 ]; then
+    
+    # Clean up any existing swap file
+    if [ -f "$TEMP_SWAP" ]; then
+      swapoff "$TEMP_SWAP" 2>/dev/null || true
+      rm -f "$TEMP_SWAP"
+    fi
+    
+    # Create swap file using dd (works on all filesystems and architectures)
+    if ! dd if=/dev/zero of="$TEMP_SWAP" bs=1M count=$SWAP_SIZE_MB 2>&1; then
+      echo "Warning: Failed to create ${SWAP_SIZE_MB}MB swap file. Continuing without swap." >&2
+      echo "         ClamAV may fail or produce errors due to insufficient memory." >&2
+      rm -f "$TEMP_SWAP" 
+      return 0
+    fi
+    
+    chmod 600 "$TEMP_SWAP"
+    if ! mkswap "$TEMP_SWAP" >/dev/null 2>&1; then
+      echo "Warning: Failed to format swap file. Continuing without swap." >&2
+      rm -f "$TEMP_SWAP"
+      return 0
+    fi
+    
+    if ! swapon "$TEMP_SWAP" 2>/dev/null; then
+      echo "Warning: Failed to enable swap. Continuing without swap." >&2
+      rm -f "$TEMP_SWAP"
+      return 0
+    fi
+    
+    return 0
+  fi
+  
+  return 0
+}
+
+cleanup_swap() {
+  if [ -f "$TEMP_SWAP" ]; then
+    swapoff "$TEMP_SWAP" 2>/dev/null || true
+    rm -f "$TEMP_SWAP"
+  fi
+}
+
+# Trap to ensure cleanup on exit
+trap cleanup_swap EXIT INT TERM
+
+# Create swap if needed
+check_and_create_swap
+
+# Run ClamAV scan - pass all arguments directly to clamscan
+clamscan "$@"
+scan_result=$?
+
+# Cleanup is handled by trap
+exit $scan_result


### PR DESCRIPTION
### Summary of Changes
Add clamav-scan wrapper script and bbappend for NILRT-specific memory management when scanning on resource-constrained embedded systems.

Added DNS backup and restore logic for SNAC Mode.

The wrapper script:
- Automatically creates swap space when system RAM is below 3GB
- Configurable swap size (default 1024MB) via --swap-size option

Added tech debt [AB#3560775](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3560775) to track the DNS backup and restore workaround.

### Justification

This addresses memory exhaustion issues on devices with limited RAM when running virus database updates and scans.
[AB#3286105](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3286105)

### Testing
Tested on NI cRIO-9038 when combined with meta-nilrt changes
- ClamAV installs without errors without SNAC mode too
- freshclam successfully downloads virus databases without any human intervention
- clamscan and clamav-scan scans for malware
- Swap wrapper manages memory automatically

Tested following scenarios
1. install clamAV - Run freshclam and clamscan
2. install clamAV - Configure Snac Mode - Run freshclam and clamscan (DNS backup restore is required)
3. Configure Snac Mode - install clamAV - Run freshclam and clamscan (DNS backup restore is required)

* [ ] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
