### PR TITLE
clamav: Fix volatile directory creation 

### DIFF
--- a/recipes-scanners/clamav/clamav_1.%.bbappend
+++ b/recipes-scanners/clamav/clamav_1.%.bbappend
@@ -30,6 +30,11 @@ pkg_postinst:${PN}-freshclam:append() {
         return 0
     fi
     
+    # Create volatile directories using populate-volatile.sh
+    if [ -e ${sysconfdir}/init.d/populate-volatile.sh ]; then
+        ${sysconfdir}/init.d/populate-volatile.sh update
+    fi
+    
     # Add clamav user to adm group if not already a member
     if ! groups ${CLAMAV_USER} | grep -q adm; then
         usermod -a -G adm ${CLAMAV_USER}


### PR DESCRIPTION
### Summary of Changes

- Ensure volatile directories (/var/log/clamav) are created properly using populate-volatile.sh

### Justification

[AB#3286109](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3286109) Issue identified during SNAC test development
`Failed to open log file /var/log/clamav/freshclam.log: No such file or directory`

### Testing

TODO: Detail what testing has been done to ensure this submission meets requirements.

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
