### PR TITLE
BSI: Limit systemlink dependencies to x64

### DIFF
--- a/recipes-core/images/includes/nilrt-proprietary.inc
+++ b/recipes-core/images/includes/nilrt-proprietary.inc
@@ -41,8 +41,12 @@ NI_PROPRIETARY_COMMON_PACKAGES:append:x64 = "\
 
 NI_PROPRIETARY_RUNMODE_PACKAGES = "\
         ni-arch-gen \
+        python3-ni-asset-discovery \
+"
+
+# SystemLink dependencies
+NI_PROPRIETARY_RUNMODE_PACKAGES:append = "\
         ni-sysmgmt-salt-minion-support \
         ni-sysmgmt-sysapi-expert \
-        python3-ni-asset-discovery \
         python3-ni-systemlink-sdk \
 "

--- a/recipes-core/images/includes/nilrt-proprietary.inc
+++ b/recipes-core/images/includes/nilrt-proprietary.inc
@@ -45,7 +45,7 @@ NI_PROPRIETARY_RUNMODE_PACKAGES = "\
 "
 
 # SystemLink dependencies
-NI_PROPRIETARY_RUNMODE_PACKAGES:append = "\
+NI_PROPRIETARY_RUNMODE_PACKAGES:append:x64 = "\
         ni-sysmgmt-salt-minion-support \
         ni-sysmgmt-sysapi-expert \
         python3-ni-systemlink-sdk \

--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -113,8 +113,6 @@ RDEPENDS:${PN} = "\
 	python3-xmlrpc \
 	python3-yarl \
 	rtctl \
-	salt-common \
-	salt-minion \
 	sysconfig-settings \
 	systemimageupdateinfo \
 	trace-cmd \
@@ -125,6 +123,8 @@ RDEPENDS:${PN} = "\
 
 RDEPENDS:${PN}:append:x64 = "\
 	linux-firmware-radeon \
+	salt-common \
+	salt-minion \
 "
 
 # Required components for Veristand.


### PR DESCRIPTION
### Summary of Changes

salt upgrade https://github.com/ni/meta-nilrt/pull/906 caused BSI size to increase causing installation failure on
smaller ARM32 targets.

Temporarily remove salt and SystemLink dependencies until SL team
optimizes install size to work on ARM.

### Testing

* [x] Built feeds, BSI for ARM with changes in https://github.com/ni/meta-nilrt/pull/906
* [x] salt is not present in BSI and verified that BSI is installable on cRIO-9066 and HWCU, LV work.
* [x] `bitbake -e nilrt-runmode-rootfs` on x64 and verified `NI_PROPRIETARY_RUNMODE_PACKAGES` contains salt packages.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
