### PR TITLE
files: define uid/gid for krill

### DIFF
--- a/files/group
+++ b/files/group
@@ -6,6 +6,7 @@ ni:x:500:
 openvpn:x:499:
 niwscerts:x:498:
 # free space
+krill:x:404:
 xrdp:x:403:
 arpwatch:x:402:
 ptest:x:401:

--- a/files/passwd
+++ b/files/passwd
@@ -6,6 +6,7 @@ webserv:x:501::::
 lvuser:x:500::::
 openvpn:x:499::::
 # free space
+krill:x:404::::
 xrdp:x:403::::
 arpwatch:x:402::::
 ptest:x:401::::


### PR DESCRIPTION
### Summary of Changes

Define a 'krill' uid/gid.


### Justification

The meta-security packagegroup [depends](https://github.com/ni/meta-security/blob/nilrt/master/scarthgap/recipes-core/packagegroup/packagegroup-core-security.bb#L52) upon the `krill` package for distributions that use PAM - such as NILRT. Because NILRT also uses staticids, the security packagegroup (and therefore the extras feed build) errors due to the 'krill' user not having a defined uid/gid.

Without this patchset, running `bitbake -g packagefeed-ni-extra` throws the following error and fails to build the whole meta-security packagegroup chain.

```
...
ERROR: Nothing RPROVIDES 'krill' (but /home/usr0/projects/nilrt/nilrt/sources/meta-security/recipes-core/packagegroup/packagegroup-core-security.bb RDEPENDS on or otherwise requires it)
krill was skipped: Recipe krill, package krill: system username "krill" does not have a static ID defined. Add krill to one of these files: /home/usr0/projects/nilrt/nilrt/sources/meta-nilrt/files/passwd
NOTE: Runtime target 'krill' is unbuildable, removing...
Missing or unbuildable dependency chain was: ['krill']
NOTE: Runtime target 'packagegroup-security-scanners' is unbuildable, removing...
Missing or unbuildable dependency chain was: ['packagegroup-security-scanners', 'krill']
...
```

### Testing

* [x] Repeating the graphing command from the Justification no longer produces an error.
* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
