### PR TITLE
[26.0] nilrt-snac: staple recipe to v3.1.0

### DIFF
--- a/recipes-ni/nilrt-snac/nilrt-snac_git.bb
+++ b/recipes-ni/nilrt-snac/nilrt-snac_git.bb
@@ -14,8 +14,8 @@ SRC_URI = "\
 	file://run-ptest \
 "
 
-SRCREV = "${AUTOREV}"
-PV = "2.1.0+git${SRCPV}"
+SRCREV = "68f5ab078871e5bbdf98f9804381024481688414"
+PV = "3.1.0"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
### Summary of Changes
* Staple the nilrt-snac recipe to v3.1.0.


### Justification

Service for NI 2026Q1 release.


### Testing

* [x] Built `nilrt-snac` and confirmed that the sources look correct.
* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
