### PR TITLE
Use cgroupsv1 on ARM

### DIFF
--- a/recipes-ni/ni-cgroups/files/ni-cgroups
+++ b/recipes-ni/ni-cgroups/files/ni-cgroups
@@ -10,6 +10,16 @@
 
 identify_lvrt_cgroup_version()
 {
+	# We only support cgroups v1 on ARM for now
+	local cpu_arch
+	cpu_arch="$(uname -m)"
+	case "$cpu_arch" in
+		arm*|aarch64)
+			echo 1
+			return
+			;;
+	esac
+
 	local lvrt_installed
 	lvrt_installed=$(opkg list-installed ni-labview-realtime 2>/dev/null)
 


### PR DESCRIPTION
### Summary of Changes

Introduce CPU architecture detection in the ni-cgroups init script to explicitly enforce cgroups v1 on ARM and AArch64 platforms. The script now evaluates the system architecture before determining the cgroup version, ensuring that ARM-based systems consistently use cgroups v1, independent of the installed LabVIEW RT version.


### Justification

[AB#3591813](https://dev.azure.com/ni/DevCentral/_workitems/edit/3591813).

### Testing
Cgroup version selection was validated on ARM targets before and after applying the changes.

Before current changes:

ARM target with no LVRT → v2
ARM target with LVRT version 2023 → v1
ARM target with LVRT version 2026 → v2

After current changes:

ARM target with no LVRT → v1
ARM target with LVRT version 2023 → v1
ARM target with LVRT version 2026 → v1

These results confirm consistent enforcement of cgroups v1 on all ARM-based systems.



@ni/rtos 
