### PR TITLE
nilrt: Enable various tpm2 packages

### DIFF
--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -22,6 +22,11 @@ DISTRO_FEATURES += "\
         virtualization \
 "
 
+# Enable TPM
+DISTRO_FEATURES:append = "\
+    tpm2 \
+"
+
 # Because NIRLT uses opkg so intimately, assert that the rootfs should always
 # be made of IPKs.
 PACKAGE_CLASSES =+ "package_ipk"

--- a/conf/templates/default/bblayers.conf.sample
+++ b/conf/templates/default/bblayers.conf.sample
@@ -25,6 +25,7 @@ BBLAYERS ?= " \
 	${GIT_REPODIR}/meta-rauc \
 	${GIT_REPODIR}/meta-sdr \
 	${GIT_REPODIR}/meta-security \
+	${GIT_REPODIR}/meta-security/meta-tpm \
 	${GIT_REPODIR}/meta-selinux \
 	${GIT_REPODIR}/meta-virtualization \
 	${GIT_REPODIR}/openembedded-core/meta \

--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -121,6 +121,11 @@ RDEPENDS:${PN} = "\
 	zip \
 "
 
+RDEPENDS:${PN}:append = "\
+	packagegroup-security-tpm2 \
+	libtss2-tcti-device \
+"
+
 RDEPENDS:${PN}:append:x64 = "\
 	linux-firmware-radeon \
 	salt-common \


### PR DESCRIPTION
### Summary of Changes

Enable `tpm2-tools`, `tpm2-tss` and other tpm utilities on nilrt runmode


### Justification

TODO: Justify why this contribution should be part of the project. Link to an AZDO work item with `AB#${AZDO ID}`.


### Testing

TODO: Detail what testing has been done to ensure this submission meets requirements.

* [ ] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [ ] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
