### PR TITLE
ni-cgroups: change LV RT 2026 to use cgroups v1

### DIFF
--- a/recipes-ni/ni-cgroups/files/ni-cgroups
+++ b/recipes-ni/ni-cgroups/files/ni-cgroups
@@ -30,8 +30,8 @@ identify_lvrt_cgroup_version()
 	lvrt_version=$(awk '{print $3}' <<<"$lvrt_installed")
 	major_version=${lvrt_version%%.*}
 
-	# LabVIEW RT 2025 and prior versions only support cgroups v1
-	[ -n "$major_version" ] && [ "$major_version" -le 25 ] && echo 1 || echo 2
+	# LabVIEW RT 2026 and prior versions only support cgroups v1
+	[ -n "$major_version" ] && [ "$major_version" -le 26 ] && echo 1 || echo 2
 }
 
 LVRT_CGROUP_VERSION=$(identify_lvrt_cgroup_version)


### PR DESCRIPTION
### Summary of Changes

Adding cgroups v2 support to LabVIEW RT 2026 caused some test failures in LabVIEW RT. Hence, restrict it to use cgroups v1 instead of v2 for now.

### Justification

[AB#3515413](https://dev.azure.com/ni/DevCentral/_workitems/edit/3515413)
This commit also needs to be cherry-picked into nilrt/26.0/scarthgap branch.

### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] `bitbake nilrt-base-system-image`
* [x] Built the BSI and installed it on the PXI-8881 target along with LVRT 2026. Ran all the tests under "C:\sync\penguin\2023\test\trunk\tests_auto\functionality\Utility\CPU and  Memory" and all of them passed.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
