### PR TITLE
pkgfeed-ni-core: Enable TPM2 Tools

### DIFF
--- a/conf/distro/nilrt.inc
+++ b/conf/distro/nilrt.inc
@@ -22,6 +22,11 @@ DISTRO_FEATURES += "\
         virtualization \
 "
 
+# Enable TPM2 features for x64 architectures
+DISTRO_FEATURES:append:x64 = "\
+        tpm2 \
+"
+
 # Because NIRLT uses opkg so intimately, assert that the rootfs should always
 # be made of IPKs.
 PACKAGE_CLASSES =+ "package_ipk"

--- a/conf/templates/default/bblayers.conf.sample
+++ b/conf/templates/default/bblayers.conf.sample
@@ -25,6 +25,7 @@ BBLAYERS ?= " \
 	${GIT_REPODIR}/meta-rauc \
 	${GIT_REPODIR}/meta-sdr \
 	${GIT_REPODIR}/meta-security \
+	${GIT_REPODIR}/meta-security/meta-tpm \
 	${GIT_REPODIR}/meta-selinux \
 	${GIT_REPODIR}/meta-virtualization \
 	${GIT_REPODIR}/openembedded-core/meta \

--- a/recipes-core/packagegroups/packagefeed-ni-core.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-core.bb
@@ -34,6 +34,7 @@ RDEPENDS:${PN}:append:x64 = "\
 	packagegroup-ni-graphical \
 	packagegroup-ni-nohz-kernel \
 	packagegroup-ni-snac \
+	packagegroup-ni-tpm \
 	bolt \
 	onboard \
 "

--- a/recipes-core/packagegroups/packagegroup-ni-tpm.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-tpm.bb
@@ -1,0 +1,15 @@
+# (C) Copyright 2026,
+#  National Instruments Corporation.
+#  All rights reserved.
+
+SUMMARY = "TPM packages for NI Linux Realtime distribution"
+LICENSE = "MIT"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
+
+RDEPENDS:${PN} = "\
+	packagegroup-security-tpm2 \
+	libtss2-tcti-device \
+"


### PR DESCRIPTION
### Summary of Changes
Enable TPM2 user-space tools in packagefeed-ni-core
TPM2 CONFIG modules enabled in nati_x86_64_defconfig: https://github.com/ni/linux/pull/265

### Justification
[AB#3643436](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3643436)


### Testing
* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have built the base system image with this PR in place. (`bitbake nilrt-base-system-image`)
* [x] I have installed the built base system image onto a target machine
* [x] I have created a python server of the core package feed with this PR in place
* [x] I have installed libtss2-tcti-device onto a target machine
* [x] I have installed tpm2-tools onto a target machine
* [x] I have executed tpm2 commands


### Procedure
* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
