### PR TITLE
Start ni-cgroups init script earlier in the boot order

### DIFF
--- a/recipes-ni/ni-cgroups/files/ni-cgroups
+++ b/recipes-ni/ni-cgroups/files/ni-cgroups
@@ -3,7 +3,7 @@
 # Provides:          ni-cgroups
 # Required-Start:    $local_fs
 # Required-Stop:
-# Default-Start:     4 5
+# Default-Start:     S
 # Default-Stop:      0 6
 # Short-Description: Setup cgroups LabVIEW RT & assign tasks
 ### END INIT INFO

--- a/recipes-ni/ni-cgroups/files/ni-cgroups-v2
+++ b/recipes-ni/ni-cgroups/files/ni-cgroups-v2
@@ -22,8 +22,6 @@ setup_cpuset()
 	for group in $SUBGROUPS; do
 		mkdir -p "$group"
 		echo "threaded" > "$group/cgroup.type"
-		cp cpuset.cpus "$group/"
-		cp cpuset.mems "$group/"
 	done
 
 	# Assign tasks to the "ni/system" set by default

--- a/recipes-ni/ni-cgroups/ni-cgroups_1.0.bb
+++ b/recipes-ni/ni-cgroups/ni-cgroups_1.0.bb
@@ -12,7 +12,7 @@ SRC_URI = "file://ni-cgroups \
     "
 
 INITSCRIPT_NAME = "ni-cgroups"
-INITSCRIPT_PARAMS = "start 01 4 5 . stop 04 0 6 ."
+INITSCRIPT_PARAMS = "start 04 S . stop 04 0 6 ."
 
 S = "${WORKDIR}"
 


### PR DESCRIPTION
### Summary of Changes

Move the ni-cgroups init script to start earlier in the boot. Also remove unnecessary 'cp' calls from v2 script.

### Justification

Currently the 'ni-cgroups' init script is started at rc5/S04 run level. This is fairly late in the boot process and it creates unnecessary cgroup migration work for the kernel. Move it earlier in the boot process to avoid this and make sure everything is migrated by the time lvrt starts. Note that any processes started after this script runs will automatically inherit the cgroup setup from their parent (which is the desired behavior). Also clean-up redundant 'cp' calls.

[AB#3515413](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3515413)

### Testing

* [x] `bitbake ni-cgroups`
* [x] Installed `ni-cgroups` from local feed on a cRIO-9037 system
* [x] Validated that the cgroups v1 code path works as expected and the LV ATS test for CPU pool assignments passes
* [x] Validated the cgroups v2 mount point, folder hierarchy, and cgroup assignment for a timed loop is correct. Note that the cgroups v2 LV ATS test is still in work on the LV side.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
