### PR TITLE
meta-nilrt: Fix util-linux SDK deps and add meta-erlang layer

### DIFF
--- a/conf/templates/default/bblayers.conf.sample
+++ b/conf/templates/default/bblayers.conf.sample
@@ -8,6 +8,7 @@ BBFILES ?= ""
 BBLAYERS ?= " \
 	${GIT_REPODIR}/meta-cloud-services \
 	${GIT_REPODIR}/meta-cloud-services/meta-openstack \
+	${GIT_REPODIR}/meta-erlang \
 	${GIT_REPODIR}/meta-mingw \
 	${GIT_REPODIR}/meta-nilrt \
 	${GIT_REPODIR}/meta-openembedded/meta-filesystems \

--- a/recipes-core/util-linux/util-linux_2.%.bbappend
+++ b/recipes-core/util-linux/util-linux_2.%.bbappend
@@ -2,7 +2,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 DEPENDS:append:class-target = " shadow-native pseudo-native busybox"
 
-RDEPENDS:${PN}-hwclock:append = " niacctbase busybox-hwclock"
+RDEPENDS:${PN}-hwclock:append:class-target = " niacctbase busybox-hwclock"
 RDEPENDS:${PN}-ptest += "${PN}-nilrt-ptest"
 
 pkg_postinst:${PN}-hwclock () {


### PR DESCRIPTION
### Summary of Changes

This PR addresses two build-related dependency issues:

- util-linux hwclock SDK QA fix

Restricts hwclock runtime dependencies to class-target only.This prevents nativesdk-util-linux-hwclock from pulling in
target-only dependencies (niacctbase, busybox-hwclock) and resolves do_package_qa build-deps errors.

- Added the `meta-erlang` layer entry in the `bblayers.conf`.


### Justification

[AB#3039672](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3039672)
[AB#3685211](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3685211)


### Testing
* [x] `util-linux` recipe builds successfully. 




### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
