### PR TITLE
ni-cgroups-v2: switch to reading pids from proc

### DIFF
--- a/recipes-ni/ni-cgroups/files/ni-cgroups-v2
+++ b/recipes-ni/ni-cgroups/files/ni-cgroups-v2
@@ -25,9 +25,12 @@ setup_cpuset()
 	done
 
 	# Assign tasks to the "ni/system" set by default
-	while read TASK; do
-		echo "$TASK" > "$CGROUP_DIR/ni/system/cgroup.procs" 2>/dev/null || true
-	done < "$CGROUP_DIR/cgroup.procs"
+	for pid in /proc/[0-9]*; do
+		pidnum=${pid##*/}
+		if [[ -d "/proc/$pidnum" ]]; then
+			echo "$pidnum" > "$CGROUP_DIR/ni/system/cgroup.procs" 2>/dev/null || true
+		fi
+	done
 
 	chown -R lvuser:ni "$CGROUP_DIR/ni"
 }


### PR DESCRIPTION
### Summary of Changes

The ni-cgroups-v2 init script attempts to move all the processes on the system into the ni/system cgroup set. It currently uses the top level 'cgroup.procs' file to determine their PIDs. However this creates a race condition because the kernel writes to 'cgroup.procs' when moving a process to a different cgroup set. As a result reading from this file is unstable and some PIDs are missed.

Switch to using /proc for determining what processes are running on the system.

[AB#3515413](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3515413)

### Testing

* [x] `bitbake ni-cgroups`
* [x] Installed from local feed on a PXIe-8861
* [x] Validated that lvrt and other system threads end up in `/sys/fs/cgroup/ni/system/cgroup.threads`
* [x] Validated that `/sys/fs/cgroup/ni/cgroup.threads` is empty as expected

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
