### PR TITLE
local.conf.sample: temporarily force TMPDIR to tmp-glibc

### DIFF
--- a/conf/templates/default/local.conf.sample
+++ b/conf/templates/default/local.conf.sample
@@ -64,9 +64,10 @@ DISTRO ?= "nilrt"
 # this includes the extraction and compilation of many applications and the toolchain
 # which can use Gigabytes of hard disk space.
 #
-# The default is a tmp directory under TOPDIR.
-#
-#TMPDIR = "${TOPDIR}/tmp"
+# Temporary compatibility override for ni-central components that still expect tmp-glibc.
+# Upstream OE-Core no longer uses TCLIBCAPPEND. Migration to ${TOPDIR}/tmp is tracked as tech debt.
+
+TMPDIR = "${TOPDIR}/tmp-glibc"
 
 #
 # SDK target architecture


### PR DESCRIPTION
### Summary of Changes

Upstream OE-Core removed `TCLIBCAPPEND`, so `tmp-glibc` is no longer created by default and builds now use `tmp/`.

Several ni-central `-next` components and scripts still expect artifacts under `tmp-glibc`, which would cause immediate build
failures.
Therefore, implemented a temporary override and also created a Tech Debt to clean it later


### Justification

[AB#3039672](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3039672)

Tech Debt to clean it later: [AB#3702465](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3702465)


### Testing

* [x] Verified that packages/ipks are building in the `tmp-glibc` dir only.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
