### PR TITLE
packagegroup-ni-safemode: Add xz

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-safemode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-safemode.bb
@@ -15,6 +15,7 @@ RDEPENDS_${PN} = " \
 	e2fsprogs-e2fsck \
 	e2fsprogs-mke2fs \
 	e2fsprogs-tune2fs \
+	xz \
 "
 
 RDEPENDS_${PN}_append_armv7a = " \


### PR DESCRIPTION
### Summary of Changes

Add xz to safemode to support BSI with data.tar.xz to reduce storage
requirement during BSI installation and prevent provisioning failure on
targets with lower storage.

### Justification

WI: [AB#3458936](https://dev.azure.com/ni/DevCentral/_workitems/edit/3458936)

### Testing

* [x] Built sumo safemode and verified `xz` is present.

### Note
This change is only meant for ARM safemode as only ARM targets have storage constraints affecting BSI installation.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
