### PR TITLE
Fixed build warnings in dist-next NILRT images

### DIFF
--- a/recipes-bsp/grub/nilrt-grub-runmode.bb
+++ b/recipes-bsp/grub/nilrt-grub-runmode.bb
@@ -3,6 +3,7 @@ DESCRIPTION = "nilrt distro-specific runmode boot files"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 SECTION = "base"
+S = "${UNPACKDIR}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/grub:"
 

--- a/recipes-bsp/grub/nilrt-grub-safemode.bb
+++ b/recipes-bsp/grub/nilrt-grub-safemode.bb
@@ -3,6 +3,7 @@ DESCRIPTION = "NILRT distro-specific safemode boot files"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 SECTION = "base"
+S = "${UNPACKDIR}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/grub:"
 

--- a/recipes-connectivity/crda/crda_1.1.3.bb
+++ b/recipes-connectivity/crda/crda_1.1.3.bb
@@ -15,8 +15,8 @@ SRC_URI = "git://github.com/mcgrof/crda.git;protocol=https;branch=master \
            "
 SRCREV = "47b1aaa36e770be587c33f0f5345fe8df550aabc"
 
-CFLAGS:append =" -DCONFIG_LIBNL32 -I${STAGING_INCDIR}/libnl3"
-LDFLAGS:append =" -lnl-3 -lnl-genl-3 -lm"
+CFLAGS:append = " -DCONFIG_LIBNL32 -I${STAGING_INCDIR}/libnl3"
+LDFLAGS:append = " -lnl-3 -lnl-genl-3 -lm"
 
 do_compile() {
         ${CC} ${CFLAGS} ${S}/reglib.c ${S}/crda.c -o crda ${LDFLAGS}

--- a/recipes-core/images/nilrt-recovery-media.bb
+++ b/recipes-core/images/nilrt-recovery-media.bb
@@ -18,7 +18,7 @@ VIRTUAL-RUNTIME_mountpoint = "util-linux-mountpoint"
 PREFERRED_PROVIDER_getopt = "util-linux-getopt"
 VIRTUAL-RUNTIME_getopt = "util-linux-getopt"
 VIRTUAL-RUNTIME_base-utils = "util-linux"
-PREFERRED_PROVIDER_virtual/base-utils="util-linux"
+PREFERRED_PROVIDER_virtual/base-utils = "util-linux"
 
 SRC_URI += "\
 	file://grubenv_non_ni_target \

--- a/recipes-core/initrdscripts/init-nilrt-ramfs.bb
+++ b/recipes-core/initrdscripts/init-nilrt-ramfs.bb
@@ -1,7 +1,7 @@
 SUMMARY = "NILRT initramfs init script"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
-
+S = "${UNPACKDIR}"
 
 PV = "1.0"
 

--- a/recipes-core/initrdscripts/init-restore-mode.bb
+++ b/recipes-core/initrdscripts/init-restore-mode.bb
@@ -1,6 +1,7 @@
 SUMMARY = "Extremely basic live image init script"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+S = "${UNPACKDIR}"
 
 
 PV = "1.0"

--- a/recipes-core/util-linux/util-linux-nilrt.bb
+++ b/recipes-core/util-linux/util-linux-nilrt.bb
@@ -1,5 +1,6 @@
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+S = "${UNPACKDIR}"
 
 PACKAGES:remove = "${PN}-dev ${PN}-staticdev ${PN}-dbg"
 

--- a/recipes-devtools/opkg/opkg-keyrings_%.bbappend
+++ b/recipes-devtools/opkg/opkg-keyrings_%.bbappend
@@ -1,4 +1,5 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+S = "${UNPACKDIR}"
 
 python () {
     buildname = d.getVar('BUILDNAME')

--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -4,7 +4,7 @@ require recipes-kernel/linux/linux-yocto.inc
 KBRANCH = "nilrt/${NI_RELEASE_VERSION}/${LINUX_VERSION}"
 GIT_KERNEL_REPO = "linux.git"
 
-machine_srcrev="${SRCREV}"
+machine_srcrev = "${SRCREV}"
 
 # Subfolder of the same name will be added to FILESEXTRAPATHS and also
 # used for nilrt-specific config fragment manipulation during build.
@@ -29,7 +29,7 @@ TOOLCHAIN_OPTIONS:append = " ${@bb.utils.contains('TUNE_FEATURES','callconventio
 
 # No need to do debug symbol handling for kernel builds; also the default behavior
 # incorrectly splits out some 'kernel-dev' files under /lib/modules/<ver>/build
-INHIBIT_PACKAGE_DEBUG_SPLIT="1"
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 
 # The NI kernel build includes on-target versioning tools that
 # link against the gcc provided runtime
@@ -48,12 +48,12 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 LIC_FILES_CHKSUM:xilinx-zynq = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 
 # This checks ${PV} == version from kernel sources which our PV/AUTOREV breaks, so skip it.
-KERNEL_VERSION_SANITY_SKIP="1"
+KERNEL_VERSION_SANITY_SKIP = "1"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/${KBUILD_FRAGMENTS_LOCATION}:"
 KBUILD_DEFCONFIG:x64 = "nati_x86_64_defconfig"
 KBUILD_DEFCONFIG:armv7a = "nati_zynq_defconfig"
-KCONFIG_MODE="--alldefconfig"
+KCONFIG_MODE = "--alldefconfig"
 
 # autoload if installed
 KERNEL_MODULE_AUTOLOAD += "ehci-hcd g_ether xilinx-xadcps"

--- a/recipes-ni/ni-firewalld-servicedefs/ni-firewalld-servicedefs.bb
+++ b/recipes-ni/ni-firewalld-servicedefs/ni-firewalld-servicedefs.bb
@@ -2,7 +2,7 @@ SUMMARY = "Firewalld XML service definitions for NI software"
 DESCRIPTION = "Installs firewalld service definitions for protocols implemented by NI software."
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
-
+S = "${UNPACKDIR}"
 PV = "1.0"
 
 SRC_URI = "\

--- a/recipes-ni/ni-modules-autoload/ni-modules-autoload.bb
+++ b/recipes-ni/ni-modules-autoload/ni-modules-autoload.bb
@@ -3,6 +3,7 @@ DESCRIPTION = "Initscript to autoload NI modules in /etc/modules.autoload.d"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 SECTION = "base"
+S = "${UNPACKDIR}"
 
 SRC_URI = "\
 	file://ni-modules-autoload \

--- a/recipes-ni/ni-safemode-utils/ni-safemode-utils.bb
+++ b/recipes-ni/ni-safemode-utils/ni-safemode-utils.bb
@@ -10,7 +10,7 @@ SRC_URI = "\
 	file://nisafemodeversion \
 "
 
-natinstbin="/usr/local/natinst/bin"
+natinstbin = "/usr/local/natinst/bin"
 
 FILES:${PN} += "\
 	${natinstbin}/nicompareversion   \

--- a/recipes-ni/ni-safemode-utils/ni-safemode-utils.bb
+++ b/recipes-ni/ni-safemode-utils/ni-safemode-utils.bb
@@ -3,6 +3,7 @@ DESCRIPTION = "nilrt distro-specific safemode utilities that provide basic syste
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 SECTION = "base"
+S = "${UNPACKDIR}"
 
 SRC_URI = "\
 	file://nicompareversion  \

--- a/recipes-ni/ni-shutdown-guard/ni-shutdown-guard.bb
+++ b/recipes-ni/ni-shutdown-guard/ni-shutdown-guard.bb
@@ -3,6 +3,7 @@ DESCRIPTION = "Utility to prevent shutdown/reboot to protect critical operations
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 SECTION = "base"
+S = "${UNPACKDIR}"
 
 SRC_URI = "\
 	file://holdoff-shutdown \

--- a/recipes-rt/librtpi/librtpi_0.0.1.bb
+++ b/recipes-rt/librtpi/librtpi_0.0.1.bb
@@ -12,7 +12,7 @@ SRC_URI = "\
 "
 
 PV = "0.0.1+git${SRCPV}"
-SRCREV="558653f9fd48ec755d8feca7bce3cd7824018d9b"
+SRCREV = "558653f9fd48ec755d8feca7bce3cd7824018d9b"
 
 inherit autotools ptest
 

--- a/recipes-support/nilrt-logging/nilrt-logging.bb
+++ b/recipes-support/nilrt-logging/nilrt-logging.bb
@@ -1,6 +1,7 @@
 SUMMARY = "Configuration for NILRT Logging"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+S = "${UNPACKDIR}"
 SRC_URI = "file://logging_paths.ini"
 
 FILES:${PN} += "${datadir}/ni-resetniconfig"

--- a/recipes-support/salt/salt_3000.2.bb
+++ b/recipes-support/salt/salt_3000.2.bb
@@ -110,7 +110,7 @@ INITSCRIPT_NAME:${PN}-minion = "${PN}-minion"
 INITSCRIPT_PARAMS:${PN}-minion = "defaults"
 
 SUMMARY:${PN}-common = "shared libraries that salt requires for all packages"
-DESCRIPTION:${PN}-common ="${DESCRIPTION_COMMON} This particular package provides shared libraries that \
+DESCRIPTION:${PN}-common = "${DESCRIPTION_COMMON} This particular package provides shared libraries that \
 salt-master, salt-minion, and salt-syndic require to function."
 RDEPENDS:${PN}-common = "\
     python3-backports-ssl-match-hostname \
@@ -127,7 +127,7 @@ RDEPENDS:${PN}-common = "\
 RRECOMMENDS:${PN}-common = "lsb-release"
 RSUGGESTS:${PN}-common = "python3-mako python3-git"
 RCONFLICTS:${PN}-common = "python3-mako (< 0.7.0)"
-CONFFILES:${PN}-common="${sysconfdir}/logrotate.d/${PN}-common"
+CONFFILES:${PN}-common = "${sysconfdir}/logrotate.d/${PN}-common"
 FILES:${PN}-common = "${bindir}/${PN}-call ${PYTHON_SITEPACKAGES_DIR} ${CONFFILES:${PN}-common}"
 
 SUMMARY:${PN}-ssh = "remote manager to administer servers via salt"
@@ -135,7 +135,7 @@ DESCRIPTION:${PN}-ssh = "${DESCRIPTION_COMMON} This particular package provides 
 is able to run salt modules and states on remote hosts via ssh. No minion or other salt specific software needs\
  to be installed on the remote host."
 RDEPENDS:${PN}-ssh = "${PN}-common (= ${EXTENDPKGV}) python3-core python3-msgpack"
-CONFFILES:${PN}-ssh="${sysconfdir}/${PN}/roster"
+CONFFILES:${PN}-ssh = "${sysconfdir}/${PN}/roster"
 FILES:${PN}-ssh = "${bindir}/${PN}-ssh ${CONFFILES:${PN}-ssh}"
 
 SUMMARY:${PN}-api = "generic, modular network access system"
@@ -152,11 +152,11 @@ INITSCRIPT_NAME:${PN}-api = "${PN}-api"
 INITSCRIPT_PARAMS:${PN}-api = "defaults"
 
 SUMMARY:${PN}-master = "remote manager to administer servers via salt"
-DESCRIPTION:${PN}-master ="${DESCRIPTION_COMMON} This particular package provides the salt controller."
+DESCRIPTION:${PN}-master = "${DESCRIPTION_COMMON} This particular package provides the salt controller."
 RDEPENDS:${PN}-master = "${PN}-common (= ${EXTENDPKGV}) python3-core python3-msgpack"
 RDEPENDS:${PN}-master += "${@bb.utils.contains('PACKAGECONFIG', 'zeromq', 'python3-pycryptodome python3-pyzmq (>= 13.1.0)', '',d)}"
 RDEPENDS:${PN}-master += "${@bb.utils.contains('PACKAGECONFIG', 'tcp', 'python3-pycryptodome', '',d)}"
-CONFFILES:${PN}-master="${sysconfdir}/init.d/${PN}-master  ${sysconfdir}/${PN}/master"
+CONFFILES:${PN}-master = "${sysconfdir}/init.d/${PN}-master  ${sysconfdir}/${PN}/master"
 RSUGGESTS:${PN}-master = "python3-git"
 FILES:${PN}-master = "${bindir}/${PN} ${bindir}/${PN}-cp ${bindir}/${PN}-key ${bindir}/${PN}-master ${bindir}/${PN}-run ${bindir}/${PN}-unity ${bindir}/spm ${CONFFILES:${PN}-master}"
 INITSCRIPT_NAME:${PN}-master = "${PN}-master"
@@ -166,7 +166,7 @@ SUMMARY:${PN}-syndic = "master-of-masters for salt, the distributed remote execu
 DESCRIPTION:${PN}-syndic = "${DESCRIPTION_COMMON} This particular package provides the master of masters for \
 salt; it enables the management of multiple masters at a time."
 RDEPENDS:${PN}-syndic = "${PN}-master (= ${EXTENDPKGV}) python3-core"
-CONFFILES:${PN}-syndic="${sysconfdir}/init.d/${PN}-syndic"
+CONFFILES:${PN}-syndic = "${sysconfdir}/init.d/${PN}-syndic"
 FILES:${PN}-syndic = "${bindir}/${PN}-syndic ${CONFFILES:${PN}-syndic}"
 INITSCRIPT_NAME:${PN}-syndic = "${PN}-syndic"
 INITSCRIPT_PARAMS:${PN}-syndic = "defaults"
@@ -179,7 +179,7 @@ CONFFILES:${PN}-cloud = "${sysconfdir}/${PN}/cloud"
 FILES:${PN}-cloud = "${bindir}/${PN}-cloud ${sysconfdir}/${PN}/cloud.conf.d/ ${sysconfdir}/${PN}/cloud.profiles.d/ ${sysconfdir}/${PN}/cloud.providers.d/ ${CONFFILES:${PN}-cloud}"
 
 SUMMARY:${PN}-tests = "salt stack test suite"
-DESCRIPTION:${PN}-tests ="${DESCRIPTION_COMMON} This particular package provides the salt unit test suite."
+DESCRIPTION:${PN}-tests = "${DESCRIPTION_COMMON} This particular package provides the salt unit test suite."
 RDEPENDS:${PN}-tests = "${PN}-common python3-pyzmq python3-six python3-tests python3-image bash"
 FILES:${PN}-tests = "${PYTHON_SITEPACKAGES_DIR}/salt-tests/tests/"
 

--- a/recipes-support/trousers/trousers_0.3.15.bb
+++ b/recipes-support/trousers/trousers_0.3.15.bb
@@ -30,7 +30,7 @@ inherit autotools pkgconfig useradd update-rc.d systemd
 INITSCRIPT_NAME = "trousers"
 INITSCRIPT_PARAMS = "start 99 2 3 4 5 . stop 19 0 1 6 ."
 
-EXTRA_OECONF="--with-gui=none"
+EXTRA_OECONF = "--with-gui=none"
 
 USERADD_PACKAGES = "${PN}"
 GROUPADD_PARAM:${PN} = "--system tss"


### PR DESCRIPTION
### Summary of Changes
All warnings encountered while building images have been resolved.
### Justification
[AB#3039668](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3039668)

### Testing

- [x] I have built the core package feed.(bitbake packagefeed-ni-core)
- [x] I have built the core base system image. (bitbake nilrt-base-system-image)
- [x] I have build the core safemode rootfs.(bitbake nilrt-safemode-rootfs)
- [x] I have build the core recovery media.( bitbake nilrt-recovery-media)

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
