### PR TITLE
pkgrp-kern-mod-ess: Remove built-in TPM modules

### DIFF
--- a/recipes-kernel/packagegroups/packagegroup-kernel-modules-essential.bb
+++ b/recipes-kernel/packagegroups/packagegroup-kernel-modules-essential.bb
@@ -408,9 +408,6 @@ RDEPENDS:${PN} = "\
 	kernel-module-thunderbolt \
 	kernel-module-tls \
 	kernel-module-tmp421 \
-	kernel-module-tpm \
-	kernel-module-tpm-tis \
-	kernel-module-tpm-tis-core \
 	kernel-module-ts-bm \
 	kernel-module-ts-fsm \
 	kernel-module-ts-kmp \


### PR DESCRIPTION
### Summary of Changes
Removed kernel-module-tpm, kernel-module-tpm-tis, kernel-module-tpm-tis-core from packagegroup-kernel-modules-essential


### Justification
TPM kernel modules are now built-in the Linux Kernel (see [256946e49a2f731450d600899b85aa099f986098](https://github.com/ni/linux/commit/256946e49a2f731450d600899b85aa099f986098)
`kernel-module-tpm`, `kernel-module-tpm-tis` and `kernel-module-tpm-tis-core` need to be removed from `packagegroup-kernel-modules-essential` to remove conflicts
[AB#3643436](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3643436)


### Testing
* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have built the safemode image with this PR in place. (`bitbake nilrt-safemode-rootfs`)
* [x] I have built the base system image with this PR in place. (`bitbake nilrt-base-system-image`)


### Procedure

* [ ] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
