### PR TITLE
Fix DKMS postinst path to restore kernel module auto-build

### DIFF
--- a/recipes-kernel/dkms/dkms.bb
+++ b/recipes-kernel/dkms/dkms.bb
@@ -27,7 +27,7 @@ do_compile[noexec] = "1"
 
 
 do_install() {
-	oe_runmake install DESTDIR=${D} LIBDIR=${libdir} 
+	oe_runmake install DESTDIR=${D} LIBDIR=${libdir}/dkms
 }
 
 
@@ -37,7 +37,12 @@ EXTRA_OEMAKE += " -o tarball"
 INSANE_SKIP:${PN} += "dev-deps"
 
 
-FILES:${PN} += " ${datadir}/bash-completion/* ${datadir}/zsh/* ${libdir}/dkms_autoinstaller ${libdir}/common.postinst"
+FILES:${PN} += " \
+	${datadir}/bash-completion/* \
+	${datadir}/zsh/* \
+	${libdir}/dkms/common.postinst \
+	${libdir}/dkms/dkms_autoinstaller \
+"
 
 RDEPENDS:${PN} += " \
 	bash \

--- a/recipes-kernel/packagegroups/packagegroup-kernel-modules-essential.bb
+++ b/recipes-kernel/packagegroups/packagegroup-kernel-modules-essential.bb
@@ -408,9 +408,6 @@ RDEPENDS:${PN} = "\
 	kernel-module-thunderbolt \
 	kernel-module-tls \
 	kernel-module-tmp421 \
-	kernel-module-tpm \
-	kernel-module-tpm-tis \
-	kernel-module-tpm-tis-core \
 	kernel-module-ts-bm \
 	kernel-module-ts-fsm \
 	kernel-module-ts-kmp \


### PR DESCRIPTION
### Summary of Changes

- This change fixes an issue where DKMS post-install scripts were not executed correctly, leading to missing kernel modules and failures in NI-PAL and syscfg.
- This PR also Cherry-picks this PR [commit](https://github.com/ni/meta-nilrt/pull/927) as that was causing failure in `packagegroup-kernel-modules-essential.bb`


### Justification

[AB#3039672](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3039672)
FYI: [PR Link](https://dev.azure.com/ni/DevCentral/_git/921942b5-b2be-4a87-b97c-79c194f82203/pullrequest/1143089)


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have built the BSI and installed successfully on target.
* [x] I have tested that installing packages also installs the relevant dependencies &  `common-postinst` script executes successfully after that(`lsni` , `system-config`, etc. is working as expected).


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
