### PR TITLE
Update XFCE X dependencies and remove obsolete xserver_common usage

### DIFF
--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -17,10 +17,6 @@ INHERIT += " create-spdx "
 # Mesa requires LLVM AMDGPU and SPIRV targets (CMake list, use semicolons).
 LLVM_TARGETS_TO_BUILD:append = ";AMDGPU;SPIRV"
 
-# for now not setting it to xserver-nodm-init as that creates a package-conflict with xserver-xfce
-# that should be resolved as a separate bug.
-VIRTUAL-RUNTIME_xserver_common = ""
-
 VIRTUAL-RUNTIME_mountpoint ?= "busybox"
 
 SKIP_META_SECURITY_SANITY_CHECK = "1"

--- a/recipes-xfce/xserver-xfce-init/xserver-xfce-init.bb
+++ b/recipes-xfce/xserver-xfce-init/xserver-xfce-init.bb
@@ -44,5 +44,5 @@ do_install() {
 
 FILES_${PN} += "${sysconfdir}/default/xserver-xfce"
 # Get util-linux for su
-RDEPENDS:${PN} = "${VIRTUAL-RUNTIME_xserver_common} xinit xfce4-session util-linux"
+RDEPENDS:${PN} = "xserver-xorg xinit xfce4-session util-linux"
 RCONFLICTS:${PN} = "xserver-nodm-init"


### PR DESCRIPTION
### Summary of Changes

xserver-xfce-init to depend directly on xserver-xorg following the upstream removal of xserver-common, and remove 
VIRTUAL-RUNTIME_xserver_common override from nilrt.conf.

These changes align NILRT with current upstream X11 packaging and eliminate dependency conflicts introduced by 
the removal of xserver-common.


### Justification

[AB#3646392](https://dev.azure.com/ni/DevCentral/_workitems/edit/3646392).


### Testing

The changes were tested on the following platforms:

NI cRIO-9045
- System boots to CLI by default
- After enabling UI in ni-rt.ini and rebooting, system starts in GUI (XFCE) mode
- After disabling UI and rebooting, system returns to CLI mode

NILRT Virtual Machine
- System boots to CLI by default
- Enabling UI in ni-rt.ini brings up GUI after reboot
- Disabling UI returns system to CLI after reboot


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
