### PR TITLE
nilrt-safemode: remove radeon module to reduce size

### DIFF
--- a/recipes-core/images/nilrt-safemode-initramfs.bb
+++ b/recipes-core/images/nilrt-safemode-initramfs.bb
@@ -29,13 +29,6 @@ PACKAGE_EXCLUDE += "python-core python3-core"
 
 PACKAGE_EXCLUDE += "rauc-mark-good"
 
-
-# Radeon firmware is huge and is not included in the safemode.
-# Blacklist the kernel module that gets automatically included.
-remove_radeon () {
-	echo "blacklist radeon" > "${IMAGE_ROOTFS}/etc/modprobe.d/blacklist_radeon.conf"
-}
-
 bootimg_fixup () {
 	# Empty out /boot. The kernel and grub are added to the exterior
 	# image and not this ramdisk container.
@@ -62,7 +55,7 @@ bootimg_fixup () {
 	opkg -o ${IMAGE_ROOTFS} -f ${IPKGCONF_TARGET} clean
 }
 
-IMAGE_PREPROCESS_COMMAND += " remove_radeon; bootimg_fixup; "
+IMAGE_PREPROCESS_COMMAND += " bootimg_fixup; "
 
 
 # We always want package-management support in this image, fail if not enabled

--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -124,6 +124,7 @@ RDEPENDS:${PN} = "\
 "
 
 RDEPENDS:${PN}:append:x64 = "\
+	kernel-module-radeon \
 	linux-firmware-radeon \
 "
 

--- a/recipes-kernel/packagegroups/packagegroup-kernel-modules-essential.bb
+++ b/recipes-kernel/packagegroups/packagegroup-kernel-modules-essential.bb
@@ -345,7 +345,6 @@ RDEPENDS:${PN} = "\
 	kernel-module-qcserial \
 	kernel-module-r8152 \
 	kernel-module-r8153-ecm \
-	kernel-module-radeon \
 	kernel-module-raid0 \
 	kernel-module-raid1 \
 	kernel-module-raid10 \


### PR DESCRIPTION
### Summary of Changes

Commit c53fc27f8ad5 ("nilrt-safemode-ramdisk: remove components from safemode to reduce size") removed the radeon firmware from safemode and blacklisted the kernel module but left it in place in the safemode image.

Since 'kernel-module-radeon' is not in use and explicitly blacklisted, make it a runmode only package. This reduces the safemode ramdisk.xz size by around 1.5 MB.

### Justification

[AB#3704250](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3704250)

### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] Rebuilt safemode image with `bitbake nilrt-safemode-rootfs` and validated the resulting `ramdisk.xz` does not include `radeon.ko`
* [x] Rebuilt runmode image with `bitbake nilrt-base-system-image` and validated that `radeon.ko` is included

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
