### PR TITLE
base-files: Fix mode check to also work on ARM

### DIFF
--- a/recipes-core/base-files/base-files_3.0.14.bbappend
+++ b/recipes-core/base-files/base-files_3.0.14.bbappend
@@ -51,7 +51,7 @@ do_install:append () {
 }
 
 pkg_postinst_ontarget:${PN} () {
-	if `grep -q "BOOT_IMAGE=/runmode/bzImage" /proc/cmdline`; then
+	if [ ! -e /etc/natinst/safemode ] && [ ! -e /ni_provisioning ]; then
 		sed -i "s/safe mode/run mode/g" /etc/issue
 		sed -i "s/safe mode/run mode/g" /etc/issue.net
 	fi


### PR DESCRIPTION
The if condition to check if it's safemode or runmode and modify strings in /etc/issue and /etc/issue.net is incorrect on ARM targets.

Update the condition to look for absence of /etc/natinst/safemode and /ni_provisioning which is the standard and it works on both x64 and ARM targets.

WI: [AB#3644605](https://dev.azure.com/ni/DevCentral/_workitems/edit/3644605)

### Testing
- [x] Ran ```if [ ! -f /etc/natinst/safemode ]; then echo "Runmode"; fi``` and verified the condition is true on ARM and x64 targets only in runmode.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
