### PR TITLE
initscripts-nilrt: Add script to sync root

### DIFF
--- a/recipes-core/initrdscripts/files/ni_provisioning.common
+++ b/recipes-core/initrdscripts/files/ni_provisioning.common
@@ -136,7 +136,7 @@ elif [ "$ARCH" = "x86_64" ]; then
 
 	show_help()
 	{
-		>&3 echo -e "\nUsage: $0 [-hav] [-t DEVICE] [-c y|n] [-b SECONDS] [-F RESTART_OPTION]\n"
+		>&3 echo -e "\nUsage: $0 [-hav] [-t DEVICE] [-c y|n] [-b SECONDS] [-p PASSWORD] [-F RESTART_OPTION]\n"
 		>&3 echo -e "Options\n"
 		>&3 echo "   -h : Show help."
 		>&3 echo "   -a : Ask at every error if continue. Default is N, so at the first error abort."
@@ -146,6 +146,7 @@ elif [ "$ARCH" = "x86_64" ]; then
 		>&3 echo "               that is not the recovery tool is used."
 		>&3 echo "   -c y|n : Initial value of the console out enable flag."
 		>&3 echo "   -b SECONDS : Initial value of bootdelay -- how long (seconds) to show boot menu."
+		>&3 echo "   -p ROOT_PASSWORD : Set the value of the root password."
 		>&3 echo "   -F RESTART_OPTION : Force provisioning (surpress the promts). RESTART_OPTION specifies"
 		>&3 echo "                       what should be done after a succesful provisioning and can have the"
 		>&3 echo "                       following values: reboot, poweroff or shell."
@@ -488,7 +489,7 @@ early_setup()
 
 	OPTIND=1
 
-	while getopts "havt:c:b:F:" opt; do
+	while getopts "havt:c:b:p:F:" opt; do
 		case "$opt" in
 			h)  show_help
 				exit 1
@@ -509,6 +510,8 @@ early_setup()
 				fi
 				;;
 			b)  grubenv_bootdelay="$OPTARG"
+				;;
+			p)  ROOT_PASSWORD="$OPTARG"
 				;;
 			F)  FORCE_PROVISIONING=1
 				if [ $OPTARG == "reboot" -o  "$OPTARG" == "poweroff" -o "$OPTARG" == "shell" ]; then

--- a/recipes-core/initrdscripts/files/ni_provisioning.safemode
+++ b/recipes-core/initrdscripts/files/ni_provisioning.safemode
@@ -37,4 +37,6 @@ trap - ERR
 exec 1>&3
 exec 2>&4
 
+set_root_password
+
 provision_successfull

--- a/recipes-core/initrdscripts/files/ni_provisioning.safemode.common
+++ b/recipes-core/initrdscripts/files/ni_provisioning.safemode.common
@@ -404,6 +404,43 @@ fixup_configfs()
 	umount $CONFIG_MOUNTPOINT
 }
 
+store_default_password()
+{
+	if [[ $ARCH == "x86_64" ]]; then
+		VAR_NAME="DefaultPassword-7c8c526b-2c07-4189-9495-b331d3b8d2cc"
+		VAR_PATH="/sys/firmware/efi/efivars/$VAR_NAME"
+		printf "\x07\x00\x00\x00%s" "$1" > "$VAR_PATH"
+	elif [[ $ARCH == "armv7l" ]]; then
+		fw_setenv default_password "$1"
+	fi
+}
+
+set_root_password()
+{
+	# Set the restore mode password
+	if [[ -n $ROOT_PASSWORD ]]; then
+		echo "root:$ROOT_PASSWORD" | chpasswd
+	else
+		passwd
+	fi
+
+	# Store the new root password hash
+	ROOT_ENTRY=$(grep "^root:" /etc/shadow)
+	ROOT_HASH=$(echo "$ROOT_ENTRY" | cut -d':' -f2)
+	store_default_password $ROOT_HASH
+
+	# Create the shared passwd and shadow files and add root entry
+	mount_bootfs_partition
+	echo > $BOOTFS_MOUNTPOINT/.passwd "root:x:0:0:root:/home/admin:/bin/sh"
+	echo > $BOOTFS_MOUNTPOINT/.shadow "root:*::0:99999:7:::"
+
+	chmod 600 $BOOTFS_MOUNTPOINT/.passwd
+	chmod 600 $BOOTFS_MOUNTPOINT/.shadow
+
+	# Manually call the acctsync script
+	service ni-acctsync stop $BOOTFS_MOUNTPOINT
+}
+
 sanity_check()
 {
 	print_info "Sanity check TARGET_DISK=$TARGET_DISK..."

--- a/recipes-core/packagegroups/packagegroup-ni-restoremode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-restoremode.bb
@@ -21,6 +21,7 @@ RDEPENDS:${PN} += "\
 	grep \
 	init-restore-mode \
 	kmod \
+	ni-acctsync \
 	ni-systemreplication \
 	parted \
 	procps \

--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -25,6 +25,7 @@ RDEPENDS:${PN} = "\
 	lldpd \
 	mpfr \
 	nftables \
+	ni-acctsync \
 	ni-cgroups \
 	ni-configpersistentlogs \
 	ni-locale-alias \

--- a/recipes-core/packagegroups/packagegroup-ni-safemode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-safemode.bb
@@ -15,6 +15,7 @@ RDEPENDS:${PN} = " \
 	e2fsprogs-e2fsck \
 	e2fsprogs-mke2fs \
 	e2fsprogs-tune2fs \
+	ni-acctsync \
 	ni-netcfgutil \
 	ni-shutdown-guard-safemode \
 	ni-systemimage \

--- a/recipes-ni/ni-acctsync/files/ni-acctsync
+++ b/recipes-ni/ni-acctsync/files/ni-acctsync
@@ -1,0 +1,105 @@
+#! /bin/sh
+#
+
+SYS_PASSWD="/etc/passwd"
+SYS_SHADOW="/etc/shadow"
+
+if [ -z "$2" ]; then
+    SHARED_PASSWD="/boot/.passwd"
+    SHARED_SHADOW="/boot/.shadow"
+else
+    SHARED_PASSWD="$2/.passwd"
+    SHARED_SHADOW="$2/.shadow"
+fi
+
+log() {
+    echo "[acct-sync] $1"
+}
+
+get_root_line() {
+    grep "^root:" "$1"
+}
+
+
+replace_root_line() {
+    SRC="$1"
+    DEST="$2"
+
+    SRC_ROOT=$(get_root_line "$SRC")
+    DEST_ROOT=$(get_root_line "$DEST")
+
+    if [ -z "$SRC_ROOT" ]; then
+        log "No entry for root found in $SRC. Nothing to sync."
+        return 1
+    fi
+
+    # Escape slashes for sed
+    ESCAPED_SRC_ROOT=$(printf '%s\n' "$SRC_ROOT" | sed 's/[\/&]/\\&/g')
+    ESCAPED_DEST_ROOT=$(printf '%s\n' "$DEST_ROOT" | sed 's/[\/&]/\\&/g')
+
+    if [ "$ESCAPED_SRC_ROOT" != "$ESCAPED_DEST_ROOT" ]; then
+        log "Syncing root info from $SRC to $DEST"
+        if grep -q "^root:" "$DEST"; then
+            sed -i "s/^root:.*/$ESCAPED_SRC_ROOT/" "$DEST"
+        else
+            sed -i "1i $ESCAPED_SRC_ROOT" "$DEST"
+            sed -i "/^[[:space:]]*$/d" "$DEST"
+        fi
+    else
+        log "Root entry in $SRC matches the one in $DEST, nothing to sync."
+    fi
+}
+
+log "Shared passwd path: $SHARED_PASSWD"
+log "Shared shadow path: $SHARED_SHADOW"
+
+case "$1" in
+    start)
+        log "Syncing root info from boot partition..."
+
+        if [ -f "$SHARED_PASSWD" ] && [ -f "$SHARED_SHADOW" ]; then
+            log "Found shared passwd and shadow files. Checking integrity with pwck..."
+
+            pwck -r "$SHARED_PASSWD" "$SHARED_SHADOW" >/dev/null 2>&1
+            STATUS=$?
+
+            if [ $STATUS -eq 0 ]; then
+                log "Integrity OK. Syncing..."
+                
+                replace_root_line "$SHARED_PASSWD" "$SYS_PASSWD"
+                replace_root_line "$SHARED_SHADOW" "$SYS_SHADOW"
+                log "Sync complete."
+            else
+                log "pwck returned $STATUS. Stopping sync."
+            fi
+        else
+            log "Shared passwd or shadow files not found. Stopping sync."
+        fi
+        ;;
+
+    stop)
+        log "Syncing root info to boot partition..."
+
+        if [ -f "$SHARED_PASSWD" ] && [ -f "$SHARED_SHADOW" ]; then
+            log "Found shared passwd and shadow files. Syncing..."
+
+            replace_root_line "$SYS_PASSWD" "$SHARED_PASSWD"
+            replace_root_line "$SYS_SHADOW" "$SHARED_SHADOW"
+            log "Sync complete."
+        else
+            log "Shared passwd or shadow files not found. Stopping sync."
+        fi
+        ;;
+
+    restart|force-reload)
+        $0 stop
+        $0 start
+        ;;
+
+    *)
+        echo "Usage: $0 {start|stop|restart|force-reload}"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/recipes-ni/ni-acctsync/ni-acctsync_1.0.bb
+++ b/recipes-ni/ni-acctsync/ni-acctsync_1.0.bb
@@ -1,0 +1,23 @@
+SUMMARY = "NI account sync setup"
+DESCRIPTION = "Installs init.d setup scripts that synchronize account information"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+LICENSE = "MIT"
+SECTION = "base"
+
+DEPENDS += "update-rc.d-native"
+
+SRC_URI = "\
+	file://ni-acctsync \
+"
+
+S = "${WORKDIR}"
+
+do_install () {
+	install -d ${D}${sysconfdir}/init.d/
+	install -Dm 0755 ${WORKDIR}/ni-acctsync ${D}${sysconfdir}/init.d/
+	update-rc.d -r ${D} ni-acctsync start 36 S . stop 11 0 6 .
+}
+
+RDEPENDS:${PN} += "\
+	update-rc.d \
+"


### PR DESCRIPTION
### Summary of Changes
Add a new init.d script that synchronizes the root entries in /etc/passwd and /etc/shadow between runmode and safemode using shared /etc/natinst/share/passwd and /etc/natinst/share/shadow files.

### Justification
With the removal of niauth we need a way of sharing the root password between runmode and safemode. This init script will automatically copy the root information to files in the natinst share partition when the system shuts down and then copy it back when the system starts.

### Testing
Local testing
-  Confirmed that the root data is only copied to /etc/natinst/share on shutdown if the passwd/shadow files exist there and there is a difference in the root data
- Confirmed that the root data is only copied to /etc/ on boot if the passwd/shadow files exist, pwck succeeds on the shared files, and there is a difference in the root data


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
