### PR TITLE
Support consoleout on ARM targets

### DIFF
--- a/recipes-ni/sysconfig-settings/sysconfig-settings.bb
+++ b/recipes-ni/sysconfig-settings/sysconfig-settings.bb
@@ -123,10 +123,18 @@ FILES:${PN}-console = "\
 RDEPENDS:${PN}-console += "sysconfig-settings fw-printenv"
 
 
-pkg_postinst_ontarget:${PN}-console () {
-	# add console out if we have a firmware variable for it (x86_64 targets only)
+pkg_postinst_ontarget:${PN}-console:x64 () {
+	# Add console out if we have a firmware variable for it
 	efiConsoleOutEnable=$(fw_printenv -n BootFirmwareConsoleOutEnable 2>/dev/null || true)
 	if ! [ -z "$efiConsoleOutEnable" ]; then
+		ln -sf ${settingsdatadir}/consoleout.ini ${systemsettingsdir}/consoleout.ini
+	fi
+}
+
+pkg_postinst_ontarget:${PN}-console:armv7a () {
+	# Add console out if it's not an Ethernet RIO target
+	TARGET_CLASS=$(fw_printenv -n TargetClass 2>&1)
+	if ! [ "$TARGET_CLASS" = "Ethernet RIO" ]; then
 		ln -sf ${settingsdatadir}/consoleout.ini ${systemsettingsdir}/consoleout.ini
 	fi
 }

--- a/recipes-ni/sysconfig-settings/sysconfig-settings.bb
+++ b/recipes-ni/sysconfig-settings/sysconfig-settings.bb
@@ -74,7 +74,10 @@ pkg_postinst_ontarget:${PN} () {
 	TARGET_CLASS=$(fw_printenv -n TargetClass 2>&1)
 
 	ln -sf ${settingsdatadir}/target_common.ini ${systemsettingsdir}/target_common.ini
-	ln -sf ${settingsdatadir}/rt_target.ini ${systemsettingsdir}/rt_target.ini
+	# Ethernet RIO targets should not have RT startup settings
+	if ! [ "$TARGET_CLASS" = "Ethernet RIO" ]; then
+		ln -sf ${settingsdatadir}/rt_target.ini ${systemsettingsdir}/rt_target.ini
+	fi
 
 	# cDAQ targets should not have FPGA startup settings, and CVS
 	# targets do not support FPGA autoload.


### PR DESCRIPTION
### Summary of Changes

Support consoleout on ARM targets.
Remove RT startup settings for Ethernet RIO as the target shouldn't have those.

### Justification

WI: [AB#3722477](https://dev.azure.com/ni/DevCentral/_workitems/edit/3722477)


### Testing

* [x] `bitbake packagefeed-ni-core`, built BSI.
* [x] Installed BSI on NI-9147 (Ethernet RIO) and cRIO-9066.
* [x] cRIO-9066 shows Console Out setting in HWCU.
* [x] Ethernet RIO doesn't show Console Out as expected.
* [x] `bitbake sysconfig-settings-console` on x64 and postinst contains x64 specific snippet.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
