### PR TITLE
Include only required i915 firmware in safemode

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -101,7 +101,6 @@ RDEPENDS:${PN}:append:x64 = "\
 	e2fsprogs-mke2fs \
 	efibootmgr \
 	efivar \
-	linux-firmware-i915 \
 	pstore-save \
 "
 

--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -124,6 +124,7 @@ RDEPENDS:${PN} = "\
 "
 
 RDEPENDS:${PN}:append:x64 = "\
+	linux-firmware-i915 \
 	kernel-module-radeon \
 	linux-firmware-radeon \
 "

--- a/recipes-core/packagegroups/packagegroup-ni-safemode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-safemode.bb
@@ -21,6 +21,35 @@ RDEPENDS:${PN} = " \
 	sysconfig-settings-ssh \
 "
 
+# GPU firmware, included as split packages to conserve space
+#
+# Intel Valleyview family, no i915 firmware in use
+#   cRIO-903x, CVS-1458RT, CVS-1459RT, IC-312x
+#   sbRIO-960x, sbRIO-962x, sbRIO-9638, cDAQ-913x
+#
+# Intel Broadwell family, no i915 firmware in use
+#   IC-317x
+#
+# Intel Haswell family, no i915 firmware in use
+#   PXIe-8821, PXIe-8840
+#
+# Intel Broxton family, uses 'bxt' dmc firmware, GuC and HuC disabled
+#   cRIO-904x
+#
+# Intel Tiger Lake family, uses 'tgl' dmc firmware, GuC and HuC disabled
+#   PXIe-8822, PXIe-8842, PXIe-8862
+#
+# N/A, no video output
+#   cRIO-905x
+#
+# N/A, radeon GPU
+#   PXIe-8861, PXIe-8880, PXIe-8881
+#
+RDEPENDS:${PN}:append:x64 = "\
+	linux-firmware-i915-bxt-dmc \
+	linux-firmware-i915-tgl-dmc \
+"
+
 RDEPENDS:${PN}:append:xilinx-zynq = " \
 	xz \
 "

--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -1,0 +1,25 @@
+ALLOW_EMPTY:${PN}-i915 = "1"
+PACKAGES_DYNAMIC = "${PN}-i915-.*"
+
+python populate_packages:prepend () {
+    def i915_license_hook(f, pkg, file_regex, output_pattern, modulename):
+        d.setVar('LICENSE:%s' % pkg, 'Firmware-i915')
+
+    i915_fwdir = d.expand('${nonarch_base_libdir}/firmware/i915')
+
+    # i915 firmware file names have the following structure:
+    #   <codename>_<subsystem>_<version>.bin
+    # create split packages based on Intel CPU/GPU codename and subsystem
+    pkgs = do_split_packages(d,
+                             i915_fwdir,
+                             r'^([^_]+_[^_]+).*\.bin$',
+                             output_pattern='${PN}-i915-%s',
+                             description='Intel i915:%s firmware',
+                             extra_depends='${PN}-i915-license',
+                             prepend=True,
+                             allow_links=True,
+                             hook=i915_license_hook
+                             )
+    if pkgs:
+        d.appendVar('RDEPENDS:%s-i915' % d.getVar('PN'), ' ' + ' '.join(pkgs))
+}

--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -61,7 +61,7 @@ KERNEL_MODULE_AUTOLOAD += "ehci-hcd g_ether xilinx-xadcps"
 # i915 video driver module options to disable render and display power saving
 # disabling them improves real-time determinism
 KERNEL_MODULE_PROBECONF += "i915"
-module_conf_i915 = "options i915 enable_rc6=0 enable_dc=0"
+module_conf_i915 = "options i915 enable_dc=0"
 
 # radeon video driver module options to disable (broken) dynamic power management
 KERNEL_MODULE_PROBECONF += "radeon"


### PR DESCRIPTION
### Summary of Changes

Reduce the size of the safemode image by only including the i915 firmware which is currently in use.

In order to accomplish that:

- Commit caf6dcf ("linux-firmware: split i915 firmware into sub-packages") creates separate packages based on the
Intel CPU/GPU abbreviated code-name and subsystem.
- Commit cd0e25b ("packagegroup-ni-safemode: include only minimum required i915 firmware")
  - Moves the `linux-firmware-i915` package from `packagegroup-ni-base.bb` into the `packagegroup-ni-runmode.bb`. We do want to continue to include the full i915 firmware set in runmode for maximum flexibility.
  - Only includes the required sub-packages in `packagegroup-ni-safemode.bb`. See commit details for supported hardware information.
- While we are at it commit 5380b90 ("linux-nilrt: remove obsolete i915 module parameter") does some clean-up to remove noise from the kernel log related to the `enable_rc6` module parameter which got removed upstream.

### Justification

[AB#3704250](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3704250)

### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] `bitbake nilrt-safemode-rootfs` and deployed the resulting safemode files to cRIO-9042, and PXIe-8862. Validated the i915 firmware is loaded correctly and only specified i915 firmware sub-packages are installed.
* [x] `bitbake nilrt-base-system-image`, extracted the resulting runmode image and validated that a full set of firmware files is present under `/lib/firmware/i915`
* [x] In order to validate what firmware is in use a modified kernel with additional logging was used on: cRIO-903x, cRIO-904x, PXIe-8821, PXIe-8840, and PXIe-8862. Also validated that PXIe-8861, PXIe-8880, and PXIe-8881 do not use i915 firmware (i.e., they use a radeon GPU) and checked that specs for cRIO-905x do not include video output.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
