### PR TITLE
Add `tpm2` to MACHINE_FEATURES and use OE-core's OVMF recipe

### DIFF
--- a/conf/machine/x64.conf
+++ b/conf/machine/x64.conf
@@ -10,6 +10,8 @@ DEFAULTTUNE ?= "core2-64"
 require conf/machine/include/x86/tune-core2.inc
 require conf/machine/include/x86/x86-base.inc
 
+MACHINE_FEATURES:append = " tpm2"
+
 XSERVER = "\
 	${XSERVER_X86_BASE} \
 	${XSERVER_X86_EXT} \

--- a/recipes-core/ovmf/ovmf_%.bbappend
+++ b/recipes-core/ovmf/ovmf_%.bbappend
@@ -1,0 +1,5 @@
+do_deploy:class-target:append() {
+    install --mode 0644 -t ${DEPLOYDIR}/ \
+        ${WORKDIR}/ovmf/ovmf.code.fd \
+        ${WORKDIR}/ovmf/ovmf.vars.fd
+}


### PR DESCRIPTION
### Summary of Changes

[OE-core PR #187](https://github.com/ni/openembedded-core/pull/187) corrects the OE-core `ovmf` recipe to support TPM2 devices, when building for MACHINEs that have the `tpm2` feature. This patchset adds that feature to NILRT x64 - needed for Secure Boot and Measured Boot - and also tweaks the OVMF recipe to extract the raw-formatted binaries on the following basis.

```
The OE-core ovmf recipe generates raw OVMF image files, but then
converts them to qcow2 images, and moves only the qcow2 files to the
deploy directory. QEMU can use either format, but only the raw format
supports writable EFI variables - which NILRT uses and which upstream OE
core testing does not.

So add a NILRT-specific bbappend which also outputs the raw-formatted
OVMF files, for use in NILRT QEMU virtual machines.
```


### Justification

These changes are necessary to use virtualized TPM2 devices in the NILRT QEMU virtual machines.


### Testing

After building the `ovmf` recipe, the `deploy/images/x64` directory contains the files...

```
ovmf.code.fd
ovmf.code.qcow2
ovmf.qcow2
ovmf.vars.fd
ovmf.vars.qcow2
systemd-bootx64.efi
```

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] Built the new NILRT QEMU VMs with these changes, and I am now able to attach a software TPM to the machine and read/write PCR states.


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).