### PR TITLE
ni-systemimage: Add support for tar.xz

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-safemode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-safemode.bb
@@ -49,7 +49,3 @@ RDEPENDS:${PN}:append:x64 = "\
 	linux-firmware-i915-bxt-dmc \
 	linux-firmware-i915-tgl-dmc \
 "
-
-RDEPENDS:${PN}:append:xilinx-zynq = " \
-	xz \
-"

--- a/recipes-ni/ni-systemimage/files/nisystemimage
+++ b/recipes-ni/ni-systemimage/files/nisystemimage
@@ -365,7 +365,7 @@ cleanup_netcfg () {
 ## Get Image
 ##
 
-image_get_tgz () {
+image_get_common () {
 	echo_verbose 2 "starting"
 	local -a CMDLINE=(tar c "${BASE_TAR_OPTS[@]}" -I "$COMPRESS")
 	(( $VERBOSE >= 2 )) && CMDLINE+=(-v)
@@ -375,6 +375,16 @@ image_get_tgz () {
 	CMDLINE+=(*)
 	run_cmd "${CMDLINE[@]}" | pv $DISPLAY_PROGRESS_ARG 1>&"$FD_IMAGE"
 	echo_verbose 2 "finished"
+}
+
+image_get_tgz () {
+	image_get_common
+}
+
+image_get_txz () {
+	# Change the global default compression utility.
+	COMPRESS=xz
+	image_get_common
 }
 
 init_fs_get () {
@@ -546,7 +556,7 @@ wipe_fs () {
 	echo_verbose 2 "finished"
 }
 
-image_set_tgz () {
+image_set_common () {
 	echo_verbose 2 "starting"
 	local -a CMDLINE=(tar x "${BASE_TAR_OPTS[@]}" -C "$WORKING_USERFS" -I "$COMPRESS")
 	(( $VERBOSE >= 2 )) && CMDLINE+=(-v)
@@ -564,6 +574,16 @@ image_set_tgz () {
 		fi
 	fi
 	echo_verbose 2 "finish"
+}
+
+image_set_tgz () {
+	image_set_common
+}
+
+image_set_txz () {
+	# Change the global default compression utility.
+	COMPRESS=xz
+	image_set_common
 }
 
 image_set () {
@@ -804,6 +824,7 @@ check_settings () {
 
 	case "$IMAGE_TYPE" in
 		tgz) ;;
+		txz) ;;
 		"") die_with_help "Format setting (-x) is required" ;;
 		*) die_with_help "Unknown format setting '$IMAGE_TYPE'" ;;
 	esac

--- a/recipes-ni/ni-systemimage/ni-systemimage.bb
+++ b/recipes-ni/ni-systemimage/ni-systemimage.bb
@@ -35,4 +35,5 @@ RDEPENDS:${PN} += "\
 	niacctbase \
 	pv \
 	tar \
+	xz \
 "


### PR DESCRIPTION
### Summary of Changes

ni-systemimage: Add support for tar.xz required for systemlink workflow on ARM targets.
Basically port `nisystemimage` changes in https://ni.visualstudio.com/DevCentral/_git/ni-central/pullrequest/1162473.

### Justification

WI: [AB#3727988](https://dev.azure.com/ni/DevCentral/_workitems/edit/3727988)

### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] `bitbake nilrt-safemode-rootfs` and installed on an x64 VM. Safemode contains `xz`.
* [x] "Create Image" and "Set Image" work from LabVIEW.
* [x] `nisystemimage get -x txz -f getimage.txz` and `nisystemimage set -x txz -f getimage.tar.xz` work.

### Note
Install size of `xz` package on safemode is 143KB. There were no dependencies installed with it.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
