### PR TITLE
ni-acctsync: Create init script to sync account info

### DIFF
--- a/recipes-core/initrdscripts/files/ni_provisioning.common
+++ b/recipes-core/initrdscripts/files/ni_provisioning.common
@@ -136,7 +136,7 @@ elif [ "$ARCH" = "x86_64" ]; then
 
 	show_help()
 	{
-		>&3 echo -e "\nUsage: $0 [-hav] [-t DEVICE] [-c y|n] [-b SECONDS] [-F RESTART_OPTION]\n"
+		>&3 echo -e "\nUsage: $0 [-hav] [-t DEVICE] [-c y|n] [-b SECONDS] [-p PASSWORD] [-F RESTART_OPTION]\n"
 		>&3 echo -e "Options\n"
 		>&3 echo "   -h : Show help."
 		>&3 echo "   -a : Ask at every error if continue. Default is N, so at the first error abort."
@@ -146,6 +146,7 @@ elif [ "$ARCH" = "x86_64" ]; then
 		>&3 echo "               that is not the recovery tool is used."
 		>&3 echo "   -c y|n : Initial value of the console out enable flag."
 		>&3 echo "   -b SECONDS : Initial value of bootdelay -- how long (seconds) to show boot menu."
+		>&3 echo "   -p ROOT_PASSWORD : Set the value of the root password."
 		>&3 echo "   -F RESTART_OPTION : Force provisioning (surpress the promts). RESTART_OPTION specifies"
 		>&3 echo "                       what should be done after a succesful provisioning and can have the"
 		>&3 echo "                       following values: reboot, poweroff or shell."
@@ -488,7 +489,7 @@ early_setup()
 
 	OPTIND=1
 
-	while getopts "havt:c:b:F:" opt; do
+	while getopts "havt:c:b:p:F:" opt; do
 		case "$opt" in
 			h)  show_help
 				exit 1
@@ -509,6 +510,8 @@ early_setup()
 				fi
 				;;
 			b)  grubenv_bootdelay="$OPTARG"
+				;;
+			p)  ROOT_PASSWORD="$OPTARG"
 				;;
 			F)  FORCE_PROVISIONING=1
 				if [ $OPTARG == "reboot" -o  "$OPTARG" == "poweroff" -o "$OPTARG" == "shell" ]; then

--- a/recipes-core/initrdscripts/files/ni_provisioning.safemode
+++ b/recipes-core/initrdscripts/files/ni_provisioning.safemode
@@ -37,4 +37,6 @@ trap - ERR
 exec 1>&3
 exec 2>&4
 
+set_root_password
+
 provision_successfull

--- a/recipes-core/initrdscripts/files/ni_provisioning.safemode.common
+++ b/recipes-core/initrdscripts/files/ni_provisioning.safemode.common
@@ -404,6 +404,29 @@ fixup_configfs()
 	umount $CONFIG_MOUNTPOINT
 }
 
+set_root_password()
+{
+	# Set the restore mode password
+	if [[ -n $ROOT_PASSWORD ]]; then
+		echo "root:$ROOT_PASSWORD" | chpasswd
+	else
+		passwd
+	fi
+
+	# Get the root password hash
+	ROOT_ENTRY=$(grep "^root:" /etc/shadow)
+	ROOT_HASH=$(echo "$ROOT_ENTRY" | cut -d':' -f2)
+
+	# Create the shared shadow file and add root entry
+	CONFIG_MOUNTPOINT=/var/volatile/configfs
+	mkdir -p $CONFIG_MOUNTPOINT
+	mount -L $PART3_LABEL $CONFIG_MOUNTPOINT
+	touch "$CONFIG_MOUNTPOINT/.shadow"
+	chmod 400 "$CONFIG_MOUNTPOINT/.shadow"
+	echo "$ROOT_HASH" > "$CONFIG_MOUNTPOINT/.shadow"
+	umount $CONFIG_MOUNTPOINT
+}
+
 sanity_check()
 {
 	print_info "Sanity check TARGET_DISK=$TARGET_DISK..."

--- a/recipes-core/packagegroups/packagegroup-ni-restoremode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-restoremode.bb
@@ -21,6 +21,7 @@ RDEPENDS:${PN} += "\
 	grep \
 	init-restore-mode \
 	kmod \
+	ni-acctsync \
 	ni-systemreplication \
 	parted \
 	procps \

--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -25,6 +25,7 @@ RDEPENDS:${PN} = "\
 	lldpd \
 	mpfr \
 	nftables \
+	ni-acctsync \
 	ni-cgroups \
 	ni-configpersistentlogs \
 	ni-locale-alias \

--- a/recipes-core/packagegroups/packagegroup-ni-safemode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-safemode.bb
@@ -15,6 +15,7 @@ RDEPENDS:${PN} = " \
 	e2fsprogs-e2fsck \
 	e2fsprogs-mke2fs \
 	e2fsprogs-tune2fs \
+	ni-acctsync \
 	ni-netcfgutil \
 	ni-shutdown-guard-safemode \
 	ni-systemimage \

--- a/recipes-ni/ni-acctsync/files/ni-acctsync
+++ b/recipes-ni/ni-acctsync/files/ni-acctsync
@@ -1,0 +1,143 @@
+#! /bin/sh
+#
+
+SYS_SHADOW="/etc/shadow"
+
+if [ -z "$2" ]; then
+    SHARED_SHADOW="/etc/natinst/share/.shadow"
+else
+    SHARED_SHADOW="$2/.shadow"
+fi
+
+log() {
+    logger -p auth.info "[acct-sync] $1"
+}
+
+get_root_line() {
+    grep "^root:" "$1"
+}
+
+check_hash_equality()
+{
+    SHARED_HASH_PATH="$1"
+    LOCAL_HASH_PATH="$2"
+    LOCAL_ROOT=$(get_root_line "$LOCAL_HASH_PATH")
+
+    LOCAL_HASH=$(echo "$LOCAL_ROOT" | cut -d':' -f2)
+    read -r SHARED_HASH < "$SHARED_HASH_PATH"
+
+    if [ "$LOCAL_HASH" = "$SHARED_HASH" ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+hash_sanity_check()
+{
+    SHADOW_HASH="$1"
+    
+    if [ -z "$SHADOW_HASH" ] || [ "$SHADOW_HASH" = "*" ] || [ "$SHADOW_HASH" = "!" ]; then
+        return 0
+    fi
+    
+    if [ -f "/etc/login.defs" ]; then
+        ENCRYPT_METHOD=$(awk '$1=="ENCRYPT_METHOD" { print $2; exit }' /etc/login.defs)
+        if [ -z "$ENCRYPT_METHOD" ]; then
+            log "ENCRYPT_METHOD not defined, defaulting to SHA512."
+            ENCRYPT_METHOD="SHA512"
+        fi
+    else
+        log "login.defs file not found. Assuming encryption method is SHA512."
+        ENCRYPT_METHOD="SHA512"
+    fi
+    
+    case "$ENCRYPT_METHOD" in
+        SHA512)
+            log "Checking sanity of SHA512 hash..."
+            if [[ "$SHADOW_HASH" =~ ^\$6\$[A-Za-z0-9./]{1,16}\$[A-Za-z0-9./]{86}$ ]]; then
+                log "Sanity check passed. Continue to sync."
+                return 0
+            else
+                log "Sanity check failed. Stopping sync."
+                return 1
+            fi
+            ;;
+        *)
+            log "Unexpected encrypt method. Stopping sync."
+            return 1
+            ;;
+    esac
+}
+
+insert_root_hash()
+{
+    SRC="$1"
+    DEST="$2"
+
+    if ! check_hash_equality "$SRC" "$DEST"; then
+        TMP_SHADOW="$(mktemp /tmp/shadow.XXXXXX)"
+        trap 'rm -f "$TMP_SHADOW"' EXIT HUP INT TERM
+        read -r SHADOW_HASH < "$SRC"
+
+        if hash_sanity_check "$SHADOW_HASH"; then
+            chmod --reference="$DEST" "$TMP_SHADOW"
+            chown --reference="$DEST" "$TMP_SHADOW"
+            awk -F: -v OFS=":" -v shadow_hash="$SHADOW_HASH" '$1 == "root" { $2 = shadow_hash } { print }' "$DEST" > "$TMP_SHADOW"
+            mv "$TMP_SHADOW" "$DEST"
+        fi
+    fi
+}
+
+extract_root_hash()
+{
+    SRC="$1"
+    DEST="$2"
+    SRC_ROOT=$(get_root_line "$SRC")
+
+    if ! check_hash_equality "$DEST" "$SRC"; then
+        TMP_HASH="$(mktemp /tmp/root_hash.XXXXXX)"
+        trap 'rm -f "$TMP_HASH"' EXIT HUP INT TERM
+        chmod --reference="$DEST" "$TMP_HASH"
+        chown --reference="$DEST" "$TMP_HASH"
+        echo "$SRC_ROOT" | cut -d':' -f2 > "$TMP_HASH"
+        mv "$TMP_HASH" "$DEST"
+    fi
+}
+
+case "$1" in
+    start)
+        log "Syncing root info from shared shadow file..."
+
+        if [ -f "$SHARED_SHADOW" ]; then
+            log "Found shared shadow file."
+            insert_root_hash "$SHARED_SHADOW" "$SYS_SHADOW"
+            log "Sync complete."
+        else
+            log "Shared shadow file not found. Stopping sync."
+        fi
+        ;;
+
+    stop)
+        log "Syncing root info to shared shadow file..."
+
+        if [ ! -f "$SHARED_SHADOW" ]; then
+            log "Creating shared shadow file..."
+            touch "$SHARED_SHADOW"
+            chmod 400 "$SHARED_SHADOW"
+        fi
+        extract_root_hash "$SYS_SHADOW" "$SHARED_SHADOW"
+        ;;
+
+    restart|force-reload)
+        $0 stop
+        $0 start
+        ;;
+
+    *)
+        echo "Usage: $0 {start|stop|restart|force-reload}"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/recipes-ni/ni-acctsync/ni-acctsync_1.0.bb
+++ b/recipes-ni/ni-acctsync/ni-acctsync_1.0.bb
@@ -1,0 +1,21 @@
+SUMMARY = "NI account sync setup"
+DESCRIPTION = "Installs init.d setup scripts that synchronize account information"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+LICENSE = "MIT"
+SECTION = "base"
+
+SRC_URI = "\
+	file://ni-acctsync \
+"
+
+S = "${UNPACKDIR}"
+
+inherit update-rc.d
+
+INITSCRIPT_NAME = "ni-acctsync"
+INITSCRIPT_PARAMS = "start 36 S . stop 11 0 6 ."
+
+do_install () {
+	install -d ${D}${sysconfdir}/init.d/
+	install -m 0700 ${S}/ni-acctsync ${D}${sysconfdir}/init.d/
+}

--- a/recipes-ni/ni-systemformat/files/nisystemformat
+++ b/recipes-ni/ni-systemformat/files/nisystemformat
@@ -23,6 +23,8 @@ RESET_OVERLAY=no
 NETCFG_TMP=/tmp/netconfig.$$
 declare -r BASENAME=${0##*/}
 
+ACCTINFO_TMP=/tmp/acctinfo
+
 NINETCFGUTIL=/usr/local/natinst/bin/ninetcfgutil
 
 if [ "$arch" = "x86_64" ]; then
@@ -345,6 +347,14 @@ format_rootfs_or_userfs_nosvc()
 {
 	netconfig_pre || return $?
 
+	# Backup the shared .shadow file to the tmp dir.
+	if [ -f "$CONFIG_MOUNT_POINT/.shadow" ]; then
+		trap 'rm -f "$ACCTINFO_TMP/.shadow"' EXIT HUP INT TERM
+		mkdir -p "$ACCTINFO_TMP" &&
+			cp "$CONFIG_MOUNT_POINT/.shadow" "$ACCTINFO_TMP" ||
+			return $?
+	fi
+
 	# Backup the restore files to the tmp dir. Do this even if we're only
 	# reformatting the configfs, because under some configurations,
 	# reformatting the configfs may also trigger reformatting the userfs.
@@ -372,6 +382,14 @@ format_rootfs_or_userfs_nosvc()
 		mkdir -p "$ROOTFS_MOUNT_POINT/.restore" &&
 			mv /tmp/restore/* "$ROOTFS_MOUNT_POINT/.restore" &&
 			rmdir /tmp/restore || (( ret )) || ret=$?
+	fi
+
+	# Move the .shadow file back to the configfs.
+	if [ -f "$ACCTINFO_TMP/.shadow" -a ! -f "$CONFIG_MOUNT_POINT/.shadow" ] &&
+		   mountpoint -q "$CONFIG_MOUNT_POINT"
+	then
+		mv -f "$ACCTINFO_TMP/.shadow" $CONFIG_MOUNT_POINT &&
+			rmdir $ACCTINFO_TMP	|| (( ret )) || ret=$?
 	fi
 
 	netconfig_post || (( ret )) || ret=$?


### PR DESCRIPTION
### Summary of Changes

Creates a new init script called ni-acctsync that synchronizes the root password hash between runmode and safemode using a shared .shadow file in the configfs partition. This commit also includes changes to the provisioning scripts to prompt users to set a root password and store it in the shared files as well as in an EFI variable. The formatting script was also updated to preserve the shared .shadow file when the configfs partition is formatted.


### Justification

With the removal of niauth we need a way of sharing the root password between runmode and safemode. The ni-acctsync init script will automatically copy the root password hash to a file in the configfs partition when the system shuts down and then insert the hash back into the /etc/shadow file when the system boots. This synchronization is only done if the hash stored in the shared .shadow file and the hash in the /etc/shadow are not equal.

This commit also includes changes to the NI provisioning scripts so that they will prompt users to set a root password when provisioning a device. This password can also be set using a command line argument which will allow manufacturing to automate the password setting process. Additionally the provisioning script stores the new password in an EFI variable so it can be recovered if the device is reset.


### Testing

Local testing:
* [X] Tested that the provisioning script prompts users for a password and that password is recorded in the bootfs partition and an EFI variable
* [X] Tested that using the -p argument for the provisioning script allows a password to be set automatically
* [X] Confirmed that the root hash is copied to the configfs .shadow file if there is a difference between the hashes and that the configfs .shadow file is created if it did not already exist.
* [X] Confirmed that the root hash is copied to the local shadow file if the shared .shadow file exists and has different information than the local shadow file. Also confirmed that the hash needs to be in the expected format to be copied.
* [X] Tested the full workflow by running the provisioning script and setting a password, booting into safemode, installing runmode, booting into runmode, and confirmed that the passwd and shadow files were synchronized properly at each step and the EFI variable persisted
* [X] Confirmed that the shared shadow file and updated local shadow file have the 400 permissions at each step.


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
