### PR TITLE
glibc: Backport fix for CVE-2026-0915

### DIFF
--- a/recipes-core/glibc/glibc/CVE-2026-0915-fix-getnetbyaddr-stack-leak.patch
+++ b/recipes-core/glibc/glibc/CVE-2026-0915-fix-getnetbyaddr-stack-leak.patch
@@ -1,0 +1,79 @@
+From e56ff82d5034ec66c6a78f517af6faa427f65b0b Mon Sep 17 00:00:00 2001
+From: Carlos O'Donell <carlos@redhat.com>
+Date: Thu, 15 Jan 2026 15:09:38 -0500
+Subject: resolv: Fix NSS DNS backend for getnetbyaddr (CVE-2026-0915)
+
+The default network value of zero for net was never tested for and
+results in a DNS query constructed from uninitialized stack bytes.
+The solution is to provide a default query for the case where net
+is zero.
+
+Adding a test case for this was straight forward given the existence of
+tst-resolv-network and if the test is added without the fix you observe
+this failure:
+
+FAIL: resolv/tst-resolv-network
+original exit status 1
+error: tst-resolv-network.c:174: invalid QNAME: \146\218\129\128
+error: 1 test failures
+
+With a random QNAME resulting from the use of uninitialized stack bytes.
+
+After the fix the test passes.
+
+Additionally verified using wireshark before and after to ensure
+on-the-wire bytes for the DNS query were as expected.
+
+No regressions on x86_64.
+
+Upstream-Status: Backport [https://sourceware.org/git/?p=glibc.git;a=commit;h=e56ff82d5034ec66c6a78f517af6faa427f65b0b]
+CVE: CVE-2026-0915
+
+Reviewed-by: Florian Weimer <fweimer@redhat.com>
+---
+ resolv/nss_dns/dns-network.c | 4 ++++
+ resolv/tst-resolv-network.c  | 6 ++++++
+ 2 files changed, 10 insertions(+)
+
+diff --git a/resolv/nss_dns/dns-network.c b/resolv/nss_dns/dns-network.c
+index e7d8866867..bfe49c0abc 100644
+--- a/resolv/nss_dns/dns-network.c
++++ b/resolv/nss_dns/dns-network.c
+@@ -207,6 +207,10 @@ _nss_dns_getnetbyaddr_r (uint32_t net, int type, struct netent *result,
+       sprintf (qbuf, "%u.%u.%u.%u.in-addr.arpa", net_bytes[3], net_bytes[2],
+ 	       net_bytes[1], net_bytes[0]);
+       break;
++    default:
++      /* Default network (net is originally zero).  */
++      strcpy (qbuf, "0.0.0.0.in-addr.arpa");
++      break;
+     }
+ 
+   net_buffer.buf = orig_net_buffer = (querybuf *) alloca (1024);
+diff --git a/resolv/tst-resolv-network.c b/resolv/tst-resolv-network.c
+index e62f4ee0e7..f6424939e4 100644
+--- a/resolv/tst-resolv-network.c
++++ b/resolv/tst-resolv-network.c
+@@ -46,6 +46,9 @@ handle_code (const struct resolv_response_context *ctx,
+ {
+   switch (code)
+     {
++    case 0:
++      send_ptr (b, qname, qclass, qtype, "0.in-addr.arpa");
++      break;
+     case 1:
+       send_ptr (b, qname, qclass, qtype, "1.in-addr.arpa");
+       break;
+@@ -265,6 +268,9 @@ do_test (void)
+                 "error: TRY_AGAIN\n");
+ 
+   /* Lookup by address, success cases.  */
++  check_reverse (0,
++                 "name: 0.in-addr.arpa\n"
++                 "net: 0x00000000\n");
+   check_reverse (1,
+                  "name: 1.in-addr.arpa\n"
+                  "net: 0x00000001\n");
+-- 
+cgit 
+

--- a/recipes-core/glibc/glibc_2.%.bbappend
+++ b/recipes-core/glibc/glibc_2.%.bbappend
@@ -21,6 +21,13 @@ SRC_URI =+ " \
 	file://alias-custom-locales.patch \
 "
 
+# Backport upstream fix for CVE-2026-0915
+SRC_URI += " \
+    file://CVE-2026-0915-fix-getnetbyaddr-stack-leak.patch \
+"
+
+CVE_STATUS[CVE-2026-0915] = "backported-patch: upstream commit e56ff82d5034ec66c6a78f517af6faa427f65b0b"
+
 ## package: ni-locale-alias ##
 PACKAGES =+ " ni-locale-alias "
 FILES:ni-locale-alias = "${datadir}/locale/locale.alias"


### PR DESCRIPTION
Apply upstream's patch for CVE-2026-0915 to glibc.


### Justification

[AB#3732939](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3732939)

### Testing
- [x] `bitbake glibc` succeeds.
- [x]  Ran `bitbake -c do_patch glibc` and verified patch is applied.
- [x]  With `INHERIT += "cve-check"` set in conf/local.conf, `bitbake glibc` shows the CVE as patched.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).