### PR TITLE
Skip meta-tpm sanity check for ARM(xilinx-zynq) targets

### DIFF
--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -20,6 +20,8 @@ VIRTUAL-RUNTIME_mountpoint ?= "busybox"
 
 SKIP_META_SECURITY_SANITY_CHECK = "1"
 
+SKIP_META_TPM_SANITY_CHECK:xilinx-zynq = "1"
+
 KERNEL_IMAGEDEST:xilinx-zynq = "boot"
 # on older NILRT distro flavors the kernel is installed in non-standard paths
 # for backward compatibility


### PR DESCRIPTION
Skip `meta-tpm` sanity check on ARM targets since TPM is only supported on `x64` targets.


### Summary of Changes

- Added `SKIP_META_TPM_SANITY_CHECK = "1"` in `nilrt.conf`.


### Justification

[AB#3599968](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3599968)


### Testing

- Verified that after the changes, the warning can’t be seen locally.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
