### PR TITLE
meta-nilrt: sysapi, ssh, uixml changes

### DIFF
--- a/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/recipes-connectivity/openssh/openssh_%.bbappend
@@ -16,13 +16,9 @@ do_patch_oe_source () {
 addtask patch_oe_source after do_patch before do_configure
 
 do_install:append () {
-	sed 's|check_for_no_start() {|&\
-	# if sshd is not enabled in ni-rt.ini, do not start sshd\
-	enable=`/usr/local/natinst/bin/nirtcfg --get section=SystemSettings,token=sshd.enabled,value="false" \|tr "[:upper:]" "[:lower:]"`\
-	if [ "$enable" != "true" ]; then\
-		[ "${VERBOSE}" != "no" ] \&\& echo "SSHD not enabled in ni-rt.ini"\
-		exit 0\
-	fi|' -i ${D}${sysconfdir}/init.d/sshd
+	sed -i '/check_for_no_start() {/a \
+	# Ignore sshd.enabled in /etc/natinst/share/ni.rt.ini\
+	enable="true"' ${D}${sysconfdir}/init.d/sshd
 
 	# customize sshd_config
 	sed -e 's|^[#[:space:]]*Banner .*|Banner /etc/issue.net|' \

--- a/recipes-core/images/includes/nilrt-proprietary.inc
+++ b/recipes-core/images/includes/nilrt-proprietary.inc
@@ -16,6 +16,7 @@ NI_PROPRIETARY_COMMON_PACKAGES = "\
         ni-software-installation-websvc \
         ni-ssl-webserver-support \
         ni-sysapi \
+        ni-sysapi-sshcli \
         ni-sysapi-remote \
         ni-sysapi-webservice \
         ni-sysmgmt-auth-utils \

--- a/recipes-core/packagegroups/packagegroup-ni-safemode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-safemode.bb
@@ -18,7 +18,6 @@ RDEPENDS:${PN} = " \
 	ni-netcfgutil \
 	ni-shutdown-guard-safemode \
 	ni-systemimage \
-	sysconfig-settings-ssh \
 "
 
 RDEPENDS:${PN}:append:xilinx-zynq = " \

--- a/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.binding.xml
+++ b/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.binding.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<binding>
-	<!-- sysattr=SecureShellServerEnabled -->
-	<has sysattr="335544320" />
-</binding>

--- a/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.const.de.xml
+++ b/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.const.de.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<uistrings>
-	<str name="sshd">Secure Shell Server (SSHD) aktivieren</str>
-</uistrings>

--- a/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.const.fr.xml
+++ b/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.const.fr.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<uistrings>
-	<str name="sshd">Activer le serveur Secure Shell (sshd)</str>
-</uistrings>

--- a/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.const.ja.xml
+++ b/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.const.ja.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<uistrings>
-	<str name="sshd">Secure Shellサーバ (sshd) を有効化</str>
-</uistrings>

--- a/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.const.ko.xml
+++ b/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.const.ko.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<uistrings>
-	<str name="sshd">SSH Server (sshd) 활성화</str>
-</uistrings>

--- a/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.const.xml
+++ b/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.const.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<uistrings>
-	<str name="sshd">Enable Secure Shell Server (sshd)</str>
-</uistrings>

--- a/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.const.zh-CN.xml
+++ b/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.const.zh-CN.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<uistrings>
-	<str name="sshd">启用SSH服务器(sshd)</str>
-</uistrings>

--- a/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.def.xml
+++ b/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.def.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<item>
-	<group id="startupsettings" caption="{startupsettings}" weight="100" order="0">
-		<!-- sysattr=SecureShellServerEnabled -->
-		<property id="sshd" caption="{sshd}" sysattr="335544320" writable="true" order="600" />
-	</group>
-</item>

--- a/recipes-ni/sysconfig-settings/sysconfig-settings.bb
+++ b/recipes-ni/sysconfig-settings/sysconfig-settings.bb
@@ -135,26 +135,6 @@ pkg_prerm_ontarget:${PN}-console () {
 	rm -f ${systemsettingsdir}/consoleout.ini
 }
 
-
-# sysconfig-settings-ssh package
-PACKAGES += "${PN}-ssh"
-SUMMARY:${PN}-ssh = "System configuration files for ssh"
-DESCRIPTION:${PN}-ssh = "SSH configuration files for the National Instruments System Configuration subsystem."
-
-SRC_URI:append = "\
-	file://uixml/nilinuxrt.sshd_enable.binding.xml \
-	file://uixml/nilinuxrt.sshd_enable.const.de.xml \
-	file://uixml/nilinuxrt.sshd_enable.const.fr.xml \
-	file://uixml/nilinuxrt.sshd_enable.const.ja.xml \
-	file://uixml/nilinuxrt.sshd_enable.const.ko.xml \
-	file://uixml/nilinuxrt.sshd_enable.const.xml \
-	file://uixml/nilinuxrt.sshd_enable.const.zh-CN.xml \
-	file://uixml/nilinuxrt.sshd_enable.def.xml \
-"
-
-FILES:${PN}-ssh = "${uixmldir}/nilinuxrt.sshd_enable.*"
-
-
 # sysconfig-settings-ui package
 PACKAGES += "${PN}-ui"
 SUMMARY:${PN}-ui = "System configuration files to enable UI"


### PR DESCRIPTION
### Summary of Changes
This PR is to make sures the below snac feature is implemented.
- [x] SSH daemon is enabled in NILRT safemode.
- [x] ni-sysapi-sshcli package is included.
- [x] SSH uixml file removed from safemode so that it can no longer be configured from MAX.

### Justification
This is one of the snac feature, kindly refer below feature azure link for more details
https://dev.azure.com/ni/DevCentral/_workitems/edit/3470276

### Testing
Uploaded the latest image on CRIO 9045  and Verified SSH is default enabled in all modes, and SSH is no longer configured from MAX.

![Safe_Mode_sysapi_sshcli_installed](https://github.com/user-attachments/assets/4a7a3dc6-2a64-422e-95b2-c69799cba3e7)

![Ni_Max_SSH_Not_Configurable_Safe_Mode](https://github.com/user-attachments/assets/2756dae9-0452-4368-ae4b-5b0d24f4de40)


* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin]