### PR TITLE
Move /var/log permission changes to BSI

### DIFF
--- a/files/group
+++ b/files/group
@@ -74,3 +74,4 @@ radiusd:x:301:
 audio:x:29:
 postgres:x:28:
 mail:x:8:
+adm:x:4:

--- a/recipes-extended/logrotate/logrotate/logrotate.conf
+++ b/recipes-extended/logrotate/logrotate/logrotate.conf
@@ -4,6 +4,8 @@
 #
 # see "man logrotate" for details
 
+su root adm
+
 # Defaults:
 # Investigate the log daily
 daily

--- a/recipes-ni/ni-configpersistentlogs/files/ni-configpersistentlogs
+++ b/recipes-ni/ni-configpersistentlogs/files/ni-configpersistentlogs
@@ -8,8 +8,8 @@ error_and_die() {
 }
 
 FILE_PATH_VOLATILES_CONFIG="/etc/default/volatiles/00_core"
-PERSISTENT_DIR_VAR_LOG_LINE="d root root 0755 /var/log none"
-VOLATILE_SYMLINK_VAR_LOG_LINE="l root root 0755 /var/log /var/volatile/log"
+PERSISTENT_DIR_VAR_LOG_LINE="d root adm 0770 /var/log none"
+VOLATILE_SYMLINK_VAR_LOG_LINE="l root adm 0770 /var/log /var/volatile/log"
 
 ENABLE_PERSISTENT_LOGS_INI_VAL=$(/usr/local/natinst/bin/nirtcfg --get section=SystemSettings,token=PersistentLogs.enabled,value="false" | tr "[:upper:]" "[:lower:]")
 

--- a/recipes-ni/ni-configpersistentlogs/files/set_log_permissions.sh
+++ b/recipes-ni/ni-configpersistentlogs/files/set_log_permissions.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+LOG_DIR="/var/log"
+
+if [ -d "${LOG_DIR}" ]; then
+	chown root:adm "${LOG_DIR}"
+	chmod 0770 "${LOG_DIR}"
+	if command -v setfacl >/dev/null 2>&1; then
+		setfacl -d -m g:adm:rwx "${LOG_DIR}"
+		setfacl -d -m o::0 "${LOG_DIR}"
+	fi
+fi
+
+exit 0

--- a/recipes-ni/ni-configpersistentlogs/ni-configpersistentlogs.bb
+++ b/recipes-ni/ni-configpersistentlogs/ni-configpersistentlogs.bb
@@ -8,6 +8,7 @@ PV = "1.0"
 
 SRC_URI = "\
 	file://ni-configpersistentlogs \
+	file://set_log_permissions.sh \
 "
 
 S = "${WORKDIR}"
@@ -20,11 +21,18 @@ inherit update-rc.d
 do_install () {
 	install -d ${D}${sysconfdir}/init.d/
 	install -m 0755 ${S}/ni-configpersistentlogs ${D}${sysconfdir}/init.d/
+	install -m 0755 ${S}/set_log_permissions.sh ${D}${sysconfdir}/init.d/
 }
 
 
 FILES:${PN} += "\
 	${sysconfdir}/init.d/ni-configpersistentlogs \
+	${sysconfdir}/init.d/set_log_permissions.sh \
 "
 
-RDEPENDS:${PN} += "bash initscripts"
+RDEPENDS:${PN} += "bash initscripts acl"
+DEPENDS += "update-rc.d-native"
+
+do_install:append () {
+	update-rc.d -r ${D} set_log_permissions.sh start 3 S .
+}


### PR DESCRIPTION
### Summary of Changes

- Added `su root adm` to the global logrotate configuration so that logrotate
  accepts `/var/log` being owned by group `adm` with mode 0770, fixing the error:
  `skipping "/var/log/dmesg" because parent directory has insecure permissions`.
- Updated `/etc/default/volatiles/00_core` entries in `ni-configpersistentlogs`
  to create `/var/log` with owner `root:adm` and mode `0770` (both persistent and
  volatile configurations).
- Added a new SysV init script `set_log_permissions.sh` (runs at start priority 3)
  that enforces `root:adm 0770` ownership and default ACLs on `/var/log` at boot
  time, keeping the base image consistent with the security hardening applied by
  nilrt-snac.
- Added `acl` as a runtime dependency of `ni-configpersistentlogs` to ensure
  `setfacl` is available.


### Justification

[AB#3698573](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3698573)

The `nilrt-snac` security hardening script sets `/var/log` to `root:adm 0770`
with default ACLs. Without this change the base image is inconsistent with that
policy and logrotate fails on any log under `/var/log` with a misleading
"insecure permissions" error.

See this [internal Teams chat](https://teams.microsoft.com/l/message/19:00d87ceefac44440821b903817b341c3@thread.tacv2/1770926793743?tenantId=eb06985d-06ca-4a17-81da-629ab99f6505&groupId=b028d9eb-0284-4d3f-a159-a4b340eb62df&parentMessageId=1770926793743&teamName=TM-LabVIEW%3A%20Engineering%20%2B%20Services&channelName=Engineering&createdTime=1770926793743) for discussion regarding this change and how it would affect LabVIEW RT.


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).