### PR TITLE
[next] fix: ni-wireless: use UNPACKDIR as source

### DIFF
--- a/recipes-ni/ni-wireless/ni-wireless-ath6kl-fw.bb
+++ b/recipes-ni/ni-wireless/ni-wireless-ath6kl-fw.bb
@@ -25,7 +25,7 @@ FILES:${PN} += "\
 
 RDEPENDS:${PN} += "ni-wireless-common"
 
-S = "${WORKDIR}"
+S = "${UNPACKDIR}"
 
 do_install() {
 	install -pd ${D}${base_libdir}/firmware/ath6k/AR6004/hw3.0

--- a/recipes-ni/ni-wireless/ni-wireless-common.bb
+++ b/recipes-ni/ni-wireless/ni-wireless-common.bb
@@ -12,7 +12,7 @@ WIRELESS_COMMON:xilinx-zynq = "wireless.common.arm"
 
 SRC_URI = "file://${WIRELESS_COMMON}"
 
-S = "${WORKDIR}"
+S = "${UNPACKDIR}"
 
 do_install() {
 	install -d ${D}${sysconfdir}/natinst/networking

--- a/recipes-ni/ni-wireless/ni-wireless-wl127x-fw.bb
+++ b/recipes-ni/ni-wireless/ni-wireless-wl127x-fw.bb
@@ -23,7 +23,7 @@ FILES:${PN} += "\
 
 RDEPENDS:${PN} += "ni-wireless-common"
 
-S = "${WORKDIR}"
+S = "${UNPACKDIR}"
 
 do_install() {
 	install -pd ${D}${base_libdir}/firmware/ti-connectivity


### PR DESCRIPTION


### Summary of Changes

Newer OE recipe logic has deprecated the WORKDIR variable, in exchange for the UNPACKDIR variable.


### Justification

```
ERROR: /home/usr0/projects/nilrt/nilrt/sources/meta-nilrt/recipes-ni/ni-wireless/ni-wireless-common.bb: Using S = ${WORKDIR} is no longer supported                                                | ETA:  --:--:--
ERROR: /home/usr0/projects/nilrt/nilrt/sources/meta-nilrt/recipes-ni/ni-wireless/ni-wireless-ath6kl-fw.bb: Using S = ${WORKDIR} is no longer supported
ERROR: /home/usr0/projects/nilrt/nilrt/sources/meta-nilrt/recipes-ni/ni-wireless/ni-wireless-wl127x-fw.bb: Using S = ${WORKDIR} is no longer supported
ERROR: Parsing halted due to errors, see error messages above
```


### Testing

* [x] `bitbake -c package ni-wireless-common`

```
$ tree packages-split/
packages-split/
├── ni-wireless-common
│   └── etc
│       └── natinst
│           └── networking
│               └── wireless.common
├── ni-wireless-common-dbg
├── ni-wireless-common-dev
├── ni-wireless-common-doc
├── ni-wireless-common-lic
│   └── usr
│       └── share
│           └── licenses
│               └── ni-wireless-common
│                   ├── generic_MIT
│                   └── MIT
├── ni-wireless-common-locale
├── ni-wireless-common-src
└── ni-wireless-common-staticdev

```


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
