### PR TITLE
ARM: Enable consoleout, fix persistent logging

### DIFF
--- a/recipes-core/base-files/base-files/xilinx-zynq/fstab
+++ b/recipes-core/base-files/base-files/xilinx-zynq/fstab
@@ -6,3 +6,4 @@ tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,stri
 tmpfs                /var/volatile        tmpfs      size=26%              0  0
 tmpfs                /dev/shm             tmpfs      mode=0777             0  0
 ubi0:bootfs          /boot                ubifs      noatime,sync          0  0
+ubi0:config          /etc/natinst/share   ubifs      sync                  0  0

--- a/recipes-core/base-files/base-files/xilinx-zynqhf/fstab
+++ b/recipes-core/base-files/base-files/xilinx-zynqhf/fstab
@@ -1,8 +1,0 @@
-rootfs               /                    auto       defaults              1  1
-proc                 /proc                proc       defaults              0  0
-devpts               /dev/pts             devpts     mode=0620,gid=5       0  0
-usbfs                /proc/bus/usb        usbfs      defaults              0  0
-tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,strictatime 0  0
-tmpfs                /var/volatile        tmpfs      size=26%              0  0
-tmpfs                /dev/shm             tmpfs      mode=0777             0  0
-ubi0:bootfs          /boot                ubifs      noatime,sync          0  0

--- a/recipes-core/images/files/nilrt-base-system-image.postinst
+++ b/recipes-core/images/files/nilrt-base-system-image.postinst
@@ -3,6 +3,8 @@
 # Copyright (c) 2013,2017 National Instruments
 #
 
+arch="`uname -m`"
+
 # Something in base is installing /etc/natinst/share/uninstall that may not be
 # getting installed for SystemLink. nisid will fail if this directory doesn't
 # install, so this component ought to install /etc/natinst/share/uninstall
@@ -23,6 +25,12 @@ fi
 # Enable PersistentLogs by default so that technical reports can be generated via
 # Hardware Config Utility.
 /usr/local/natinst/bin/nirtcfg -s section=systemsettings,token=PersistentLogs.enabled,value=True
+
+# Temporarily enable ConsoleOut for all ARM targets to debug AB#3748097.
+# Will be removed in AB#3760326.
+if [ "$arch" = "armv7l" ]; then
+	/usr/local/natinst/bin/nirtcfg -s section=systemsettings,token=ConsoleOut.enabled,value=True
+fi
 
 # Add the memory reservation for Base. We assert that if the section exists,
 # it's already been added.
@@ -53,7 +61,6 @@ if grep -qs artemis /sys/firmware/devicetree/base/compatible ; then
 
 fi
 
-arch="`uname -m`"
 mount_point="/boot"
 class="`/sbin/fw_printenv -n TargetClass`"
 


### PR DESCRIPTION
Enable consoleout on ARM by default to debug [AB#3748097](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3748097). Will be reverted in [AB#3760326](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3760326).

Fix persistent logging.

WI: [AB#3748097](https://dev.azure.com/ni/DevCentral/_workitems/edit/3748097)
WI: [AB#3758783](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3758783)

### Testing

- [x] Ran `/usr/local/natinst/bin/nirtcfg -s section=systemsettings,token=ConsoleOut.enabled,value=True` from safemode on an ARM target and verified it's enabled on next boot.
- [x] `bitbake base-files` and verified `fstab` contains changes. Manually made `fstab` changes on ARM target and verified persistent logging works.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
