### PR TITLE
packagegroup-ni-restoremode: Remove eudev

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-restoremode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-restoremode.bb
@@ -37,7 +37,6 @@ RDEPENDS:${PN}:append:x64 = "\
 	dmidecode           \
 	efibootmgr          \
 	efivar              \
-	eudev               \
 	grub                \
 	grub-editenv        \
 	grub-efi            \


### PR DESCRIPTION
### Summary of Changes

Fix build failure in systemd introduced due to last merge.

WI: [AB#3753835](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3753835)

### Testing

None


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
