### PR TITLE
Update ni-grpc-device and grpc build fix

### DIFF
--- a/recipes-devtools/grpc/grpc/0001-Fix-deprecated-MutexLock-pointer-constructor.patch
+++ b/recipes-devtools/grpc/grpc/0001-Fix-deprecated-MutexLock-pointer-constructor.patch
@@ -1,0 +1,180 @@
+From 425f71d2a2bc2971ba891ac79ac5fcf65fae62af Mon Sep 17 00:00:00 2001
+From: Shreejit C <shreejit.c@emerson.com>
+Date: Thu, 26 Feb 2026 10:40:03 +0530
+Subject: [PATCH] Fix deprecated MutexLock pointer constructor in
+ server_callback.h
+
+abseil-cpp lts_20260107 deprecated MutexLock(Mutex*) in favour of
+MutexLock(Mutex&). Update all 18 call sites in server_callback.h.
+
+Upstream-Status: Pending
+---
+ include/grpcpp/support/server_callback.h | 36 ++++++++++++------------
+ 1 file changed, 18 insertions(+), 18 deletions(-)
+
+diff --git a/include/grpcpp/support/server_callback.h b/include/grpcpp/support/server_callback.h
+index 246b9908ab..73370cc4dd 100644
+--- a/include/grpcpp/support/server_callback.h
++++ b/include/grpcpp/support/server_callback.h
+@@ -291,7 +291,7 @@ class ServerBidiReactor : public internal::ServerReactor {
+     ServerCallbackReaderWriter<Request, Response>* stream =
+         stream_.load(std::memory_order_acquire);
+     if (stream == nullptr) {
+-      grpc::internal::MutexLock l(&stream_mu_);
++      grpc::internal::MutexLock l(stream_mu_);
+       stream = stream_.load(std::memory_order_relaxed);
+       if (stream == nullptr) {
+         backlog_.send_initial_metadata_wanted = true;
+@@ -309,7 +309,7 @@ class ServerBidiReactor : public internal::ServerReactor {
+     ServerCallbackReaderWriter<Request, Response>* stream =
+         stream_.load(std::memory_order_acquire);
+     if (stream == nullptr) {
+-      grpc::internal::MutexLock l(&stream_mu_);
++      grpc::internal::MutexLock l(stream_mu_);
+       stream = stream_.load(std::memory_order_relaxed);
+       if (stream == nullptr) {
+         backlog_.read_wanted = req;
+@@ -339,7 +339,7 @@ class ServerBidiReactor : public internal::ServerReactor {
+     ServerCallbackReaderWriter<Request, Response>* stream =
+         stream_.load(std::memory_order_acquire);
+     if (stream == nullptr) {
+-      grpc::internal::MutexLock l(&stream_mu_);
++      grpc::internal::MutexLock l(stream_mu_);
+       stream = stream_.load(std::memory_order_relaxed);
+       if (stream == nullptr) {
+         backlog_.write_wanted = resp;
+@@ -368,7 +368,7 @@ class ServerBidiReactor : public internal::ServerReactor {
+     ServerCallbackReaderWriter<Request, Response>* stream =
+         stream_.load(std::memory_order_acquire);
+     if (stream == nullptr) {
+-      grpc::internal::MutexLock l(&stream_mu_);
++      grpc::internal::MutexLock l(stream_mu_);
+       stream = stream_.load(std::memory_order_relaxed);
+       if (stream == nullptr) {
+         backlog_.write_and_finish_wanted = true;
+@@ -403,7 +403,7 @@ class ServerBidiReactor : public internal::ServerReactor {
+     ServerCallbackReaderWriter<Request, Response>* stream =
+         stream_.load(std::memory_order_acquire);
+     if (stream == nullptr) {
+-      grpc::internal::MutexLock l(&stream_mu_);
++      grpc::internal::MutexLock l(stream_mu_);
+       stream = stream_.load(std::memory_order_relaxed);
+       if (stream == nullptr) {
+         backlog_.finish_wanted = true;
+@@ -451,7 +451,7 @@ class ServerBidiReactor : public internal::ServerReactor {
+   // customization point.
+   virtual void InternalBindStream(
+       ServerCallbackReaderWriter<Request, Response>* stream) {
+-    grpc::internal::MutexLock l(&stream_mu_);
++    grpc::internal::MutexLock l(stream_mu_);
+ 
+     if (GPR_UNLIKELY(backlog_.send_initial_metadata_wanted)) {
+       stream->SendInitialMetadata();
+@@ -506,7 +506,7 @@ class ServerReadReactor : public internal::ServerReactor {
+     ServerCallbackReader<Request>* reader =
+         reader_.load(std::memory_order_acquire);
+     if (reader == nullptr) {
+-      grpc::internal::MutexLock l(&reader_mu_);
++      grpc::internal::MutexLock l(reader_mu_);
+       reader = reader_.load(std::memory_order_relaxed);
+       if (reader == nullptr) {
+         backlog_.send_initial_metadata_wanted = true;
+@@ -519,7 +519,7 @@ class ServerReadReactor : public internal::ServerReactor {
+     ServerCallbackReader<Request>* reader =
+         reader_.load(std::memory_order_acquire);
+     if (reader == nullptr) {
+-      grpc::internal::MutexLock l(&reader_mu_);
++      grpc::internal::MutexLock l(reader_mu_);
+       reader = reader_.load(std::memory_order_relaxed);
+       if (reader == nullptr) {
+         backlog_.read_wanted = req;
+@@ -532,7 +532,7 @@ class ServerReadReactor : public internal::ServerReactor {
+     ServerCallbackReader<Request>* reader =
+         reader_.load(std::memory_order_acquire);
+     if (reader == nullptr) {
+-      grpc::internal::MutexLock l(&reader_mu_);
++      grpc::internal::MutexLock l(reader_mu_);
+       reader = reader_.load(std::memory_order_relaxed);
+       if (reader == nullptr) {
+         backlog_.finish_wanted = true;
+@@ -556,7 +556,7 @@ class ServerReadReactor : public internal::ServerReactor {
+   // customization point.
+   virtual void InternalBindReader(ServerCallbackReader<Request>* reader)
+       ABSL_LOCKS_EXCLUDED(reader_mu_) {
+-    grpc::internal::MutexLock l(&reader_mu_);
++    grpc::internal::MutexLock l(reader_mu_);
+ 
+     if (GPR_UNLIKELY(backlog_.send_initial_metadata_wanted)) {
+       reader->SendInitialMetadata();
+@@ -594,7 +594,7 @@ class ServerWriteReactor : public internal::ServerReactor {
+     ServerCallbackWriter<Response>* writer =
+         writer_.load(std::memory_order_acquire);
+     if (writer == nullptr) {
+-      grpc::internal::MutexLock l(&writer_mu_);
++      grpc::internal::MutexLock l(writer_mu_);
+       writer = writer_.load(std::memory_order_relaxed);
+       if (writer == nullptr) {
+         backlog_.send_initial_metadata_wanted = true;
+@@ -611,7 +611,7 @@ class ServerWriteReactor : public internal::ServerReactor {
+     ServerCallbackWriter<Response>* writer =
+         writer_.load(std::memory_order_acquire);
+     if (writer == nullptr) {
+-      grpc::internal::MutexLock l(&writer_mu_);
++      grpc::internal::MutexLock l(writer_mu_);
+       writer = writer_.load(std::memory_order_relaxed);
+       if (writer == nullptr) {
+         backlog_.write_wanted = resp;
+@@ -626,7 +626,7 @@ class ServerWriteReactor : public internal::ServerReactor {
+     ServerCallbackWriter<Response>* writer =
+         writer_.load(std::memory_order_acquire);
+     if (writer == nullptr) {
+-      grpc::internal::MutexLock l(&writer_mu_);
++      grpc::internal::MutexLock l(writer_mu_);
+       writer = writer_.load(std::memory_order_relaxed);
+       if (writer == nullptr) {
+         backlog_.write_and_finish_wanted = true;
+@@ -645,7 +645,7 @@ class ServerWriteReactor : public internal::ServerReactor {
+     ServerCallbackWriter<Response>* writer =
+         writer_.load(std::memory_order_acquire);
+     if (writer == nullptr) {
+-      grpc::internal::MutexLock l(&writer_mu_);
++      grpc::internal::MutexLock l(writer_mu_);
+       writer = writer_.load(std::memory_order_relaxed);
+       if (writer == nullptr) {
+         backlog_.finish_wanted = true;
+@@ -668,7 +668,7 @@ class ServerWriteReactor : public internal::ServerReactor {
+   // customization point.
+   virtual void InternalBindWriter(ServerCallbackWriter<Response>* writer)
+       ABSL_LOCKS_EXCLUDED(writer_mu_) {
+-    grpc::internal::MutexLock l(&writer_mu_);
++    grpc::internal::MutexLock l(writer_mu_);
+ 
+     if (GPR_UNLIKELY(backlog_.send_initial_metadata_wanted)) {
+       writer->SendInitialMetadata();
+@@ -712,7 +712,7 @@ class ServerUnaryReactor : public internal::ServerReactor {
+   void StartSendInitialMetadata() ABSL_LOCKS_EXCLUDED(call_mu_) {
+     ServerCallbackUnary* call = call_.load(std::memory_order_acquire);
+     if (call == nullptr) {
+-      grpc::internal::MutexLock l(&call_mu_);
++      grpc::internal::MutexLock l(call_mu_);
+       call = call_.load(std::memory_order_relaxed);
+       if (call == nullptr) {
+         backlog_.send_initial_metadata_wanted = true;
+@@ -727,7 +727,7 @@ class ServerUnaryReactor : public internal::ServerReactor {
+   void Finish(grpc::Status s) ABSL_LOCKS_EXCLUDED(call_mu_) {
+     ServerCallbackUnary* call = call_.load(std::memory_order_acquire);
+     if (call == nullptr) {
+-      grpc::internal::MutexLock l(&call_mu_);
++      grpc::internal::MutexLock l(call_mu_);
+       call = call_.load(std::memory_order_relaxed);
+       if (call == nullptr) {
+         backlog_.finish_wanted = true;
+@@ -749,7 +749,7 @@ class ServerUnaryReactor : public internal::ServerReactor {
+   // customization point.
+   virtual void InternalBindCall(ServerCallbackUnary* call)
+       ABSL_LOCKS_EXCLUDED(call_mu_) {
+-    grpc::internal::MutexLock l(&call_mu_);
++    grpc::internal::MutexLock l(call_mu_);
+ 
+     if (GPR_UNLIKELY(backlog_.send_initial_metadata_wanted)) {
+       call->SendInitialMetadata();

--- a/recipes-devtools/grpc/grpc_%.bbappend
+++ b/recipes-devtools/grpc/grpc_%.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-Fix-deprecated-MutexLock-pointer-constructor.patch"
+

--- a/recipes-ni/ni-grpc-device/ni-grpc-device_git.bb
+++ b/recipes-ni/ni-grpc-device/ni-grpc-device_git.bb
@@ -23,10 +23,11 @@ DEPENDS += "\
 	utf8cpp-native \
 "
 
-PV = "2.6.0"
+PV = "2.14.0"
 
 
 SRC_URI = "git://github.com/ni/grpc-device.git;name=grpc-device;branch=main;protocol=https \
+           git://github.com/ni/grpc-sideband.git;name=grpc-sideband;branch=main;protocol=https;destsuffix=git/third_party/grpc-sideband \
            file://ptest \
            file://0001-CMakeLists-Make-grpc-device-buildable-on-NILRT-11-10.patch \
            file://0001-Rename-shutdown-variable-to-shutdown_server-to-avoid.patch \
@@ -34,7 +35,7 @@ SRC_URI = "git://github.com/ni/grpc-device.git;name=grpc-device;branch=main;prot
 
 SRCREV_grpc-device = "609fdf8c7ec99597373cf35f2b9608422b1955c9"
 SRCREV_FORMAT = "grpc-device"
-
+SRCREV_grpc-sideband = "0ce928851df2e335ebdc385cced6d46a662c505e"
 inherit cmake python3native
 
 EXTRA_OECMAKE += "-DCMAKE_CROSSCOMPILING=True -DCMAKE_BUILD_TYPE=Release -DUSE_SUBMODULE_LIBS=OFF -DUSE_PYTHON_VIRTUALENV=OFF"


### PR DESCRIPTION
### Summary of Changes

- Updated the ni gRPC device recipe:
 Modified ni-grpc-device_git.bb to bump PV from 2.6.0 to 2.14.0.
- Added a gRPC patch via a bbappend: devtools/grpc/grpc/0001-Fix-deprecated-MutexLock-pointer-constructor.patch that updates grpcpp/support/server_callback.h to use MutexLock(Mutex&) instead of the deprecated MutexLock(Mutex*) (18 call sites), to match newer abseil-cpp.


### Justification

[AB#3599972](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3599972)
Faced build errors due to upstream merge.
<img width="1435" height="948" alt="image" src="https://github.com/user-attachments/assets/8d5e0591-1745-44bb-b1a6-9be5108169e4" />


### Testing

[AB#3599972](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3599972)

- [x] Built pyrex container
- [x] bitbake packagefeed-ni-core
- [x] bitbake package-index && bitbake nilrt-base-system-image
- [x] Installed BSI on a PXI-8881 and verified it boots successfully


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
