### PR TITLE
Dev/fix arm32 bsi build

### DIFF
--- a/conf/machine/xilinx-zynq.conf
+++ b/conf/machine/xilinx-zynq.conf
@@ -25,6 +25,8 @@ UBOOT_LOADADDRESS ?= "0x8000"
 UBOOT_ENTRYPOINT ?= "${UBOOT_LOADADDRESS}"
 UBOOT_ENV = "bootscript"
 UBOOT_ENV_BINARY ?= "bootscript.txt"
+UBOOT_ENV_SRC    ?= "bootscript.txt"
+UBOOT_ENV_SUFFIX ?= "scr"
 # Set to "" to not generate unnecessary /etc/${UBOOT_INITIAL_ENV}* files.
 UBOOT_INITIAL_ENV = ""
 # Since we don't actually use u-boot built here, use a random machine config.

--- a/conf/machine/xilinx-zynq.conf
+++ b/conf/machine/xilinx-zynq.conf
@@ -5,8 +5,8 @@
 TARGET_ARCH = "arm"
 DEFAULTTUNE = "cortexa9-vfpv3"
 
-KERNEL_CLASSES += "kernel-fit-image"
-KERNEL_IMAGETYPE = "bzImage"
+KERNEL_CLASSES += "kernel-fit-extra-artifacts"
+KERNEL_IMAGETYPE = "zImage"
 
 KERNEL_FEATURES:remove = "cfg/fs/vfat.scc"
 

--- a/conf/machine/xilinx-zynq.conf
+++ b/conf/machine/xilinx-zynq.conf
@@ -5,8 +5,8 @@
 TARGET_ARCH = "arm"
 DEFAULTTUNE = "cortexa9-vfpv3"
 
-KERNEL_CLASSES += "kernel-fitimage"
-KERNEL_IMAGETYPE = "fitImage"
+KERNEL_CLASSES += "kernel-fit-image"
+KERNEL_IMAGETYPE = "bzImage"
 
 KERNEL_FEATURES:remove = "cfg/fs/vfat.scc"
 

--- a/recipes-connectivity/ti-wifi-utils/files/0001-fix-efuse_param_type_enm.patch
+++ b/recipes-connectivity/ti-wifi-utils/files/0001-fix-efuse_param_type_enm.patch
@@ -2,6 +2,7 @@ From c4d382a73a1c96c4c1568d4b33363d3ce91c42ba Mon Sep 17 00:00:00 2001
 From: Can Wong <can.wong@emerson.com>
 Date: Wed, 22 Oct 2025 14:55:52 -0500
 Subject: [PATCH] fix efuse_param_type_enm
+Upstream-Status: Inappropriate
 
 ---
  plt.h | 2 +-

--- a/recipes-connectivity/ti-wifi-utils/files/0001-fix-packed-member-warning.patch
+++ b/recipes-connectivity/ti-wifi-utils/files/0001-fix-packed-member-warning.patch
@@ -2,6 +2,7 @@ From 868075373104c403bc96f061c3117d762a8dae69 Mon Sep 17 00:00:00 2001
 From: Can Wong <can.wong@emerson.com>
 Date: Wed, 22 Oct 2025 14:48:10 -0500
 Subject: [PATCH] fix packed member warning
+Upstream-Status: Inappropriate
 
 ---
  ini.c | 112 +++++++++++++++++++++++++++++++++++++++++-----------------

--- a/recipes-connectivity/ti-wifi-utils/ti-wifi-utils_git.bb
+++ b/recipes-connectivity/ti-wifi-utils/ti-wifi-utils_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "The calibrator and other useful utilities for TI wireless solution based on wl12xx driver"
 LICENSE = "0BSD"
-LIC_FILES_CHKSUM = "file://COPYING;md5=4725015cb0be7be389cf06deeae3683d"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/0BSD;md5=f667a3c3830a55a17ec3067709f4526c"
 
 DEPENDS = "libnl"
 
@@ -8,7 +8,7 @@ PV = "R8.6+git${SRCPV}"
 
 #Tag: R8.6
 SRCREV = "cf8965aad73764022669647fa33852558a657930"
-SRC_URI = "git://git.ti.com/wilink8-wlan/18xx-ti-utils.git;branch=master;tag=${SRCREV} \
+SRC_URI = "git://git.ti.com/wilink8-wlan/18xx-ti-utils.git;protocol=https;branch=master \
            file://0001-fix-packed-member-warning.patch \
            file://0001-fix-efuse_param_type_enm.patch \
 "

--- a/recipes-core/images/nilrt-runmode-rootfs.bb
+++ b/recipes-core/images/nilrt-runmode-rootfs.bb
@@ -14,6 +14,9 @@ IMAGE_INSTALL:append:x64 = "\
 	nilrt-grub-runmode \
 	"
 
+IMAGE_INSTALL:append:xilinx-zynq = "\
+	linux-nilrt-fitimage \
+	"
 require includes/nilrt-image-base.inc
 require includes/nilrt-xfce.inc
 require includes/nilrt-proprietary.inc
@@ -40,7 +43,7 @@ bootimg_fixup_x64() {
 }
 
 bootimg_fixup_arm() {
-	mv "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/fitImage" "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/linux_runmode.itb"
+	mv "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/zImage" "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/linux_runmode.itb"
 }
 
 IMAGE_PREPROCESS_COMMAND:append:x64 = " bootimg_fixup_x64; "

--- a/recipes-kernel/linux/linux-nilrt-fitimage.bb
+++ b/recipes-kernel/linux/linux-nilrt-fitimage.bb
@@ -1,0 +1,13 @@
+SUMMARY = "The Linux kernel as a FIT image (optionally with initramfs) for NILRT"
+SECTION = "kernel"
+
+# If an initramfs is included in the FIT image more licenses apply.
+# But also the kernel uses more than one license (see Documentation/process/license-rules.rst)
+LICENSE = "GPL-2.0-with-Linux-syscall-note"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0-with-Linux-syscall-note;md5=0bad96c422c41c3a94009dcfe1bff992"
+
+inherit linux-kernel-base kernel-fit-image
+
+# Set the version of this recipe to the version of the included kernel
+# (without taking the long way around via PV)
+PKGV = "${@get_kernelversion_file("${STAGING_KERNEL_BUILDDIR}")}"


### PR DESCRIPTION
### Summary of Changes
Created a new linux-nilrt-fitimage.bb recipe in meta-nilrt based on the upstream linux-yocto-fitimage.bb to support NILRT-specific kernel FIT image generation.

Updated xilinx-zynq.conf to use kernel-fit-extra-artifacts and set KERNEL_IMAGETYPE to zImage to ensure the required kernel artifacts are generated.

Included the linux-nilrt-fitimage package in the runmode rootfs for ARM builds.

Added bootimg_fixup_arm() in nilrt-runmode-rootfs.bb to rename the generated zImage to linux_runmode.itb to match NILRT bootloader expectations.

### Justification

[AB#3711980](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3711980)


### Testing

* [ ] I have built the core base system image. (bitbake nilrt-base-system-image)

### Procedure

* [ ] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
