### PR TITLE
nilrt-runmode-rootfs: cleanup /boot files in arm BSI

### DIFF
--- a/recipes-core/images/nilrt-runmode-rootfs.bb
+++ b/recipes-core/images/nilrt-runmode-rootfs.bb
@@ -41,6 +41,9 @@ bootimg_fixup_x64() {
 
 bootimg_fixup_arm() {
 	mv "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/fitImage" "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/linux_runmode.itb"
+    find ${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST} -maxdepth 1 -type f \
+        ! -name 'linux_runmode.itb' \
+        -exec rm -f {} +
 }
 
 IMAGE_PREPROCESS_COMMAND:append:x64 = " bootimg_fixup_x64; "


### PR DESCRIPTION
### Summary of Changes

Some files like Module.symvers-4.14.146-rt67-ni and config-4.14.146-rt67-ni present in /boot directory of arm BSI can fill up /boot partition. It is necessary to remove them to save some disk space as they do not cause any harm or change the system behavior even if removed. The logic used here is to remove all files except linux_runmode.itb since that is the only file needed to be present in /boot directory.

### Justification

[AB#3454532](https://dev.azure.com/ni/DevCentral/_workitems/edit/3454532)

### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] `bitbake nilrt-base-system-image`
* [x] Installed the BSI on an arm target and verified that Module.symvers-4.14.146-rt67-ni and config-4.14.146-rt67-ni files are no more present in /boot directory.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
