### PR TITLE
ni-wireless-wl127x-fw: Add initscript to get nvs

### DIFF
--- a/recipes-ni/ni-wireless/files/niwl12xxmakenvs
+++ b/recipes-ni/ni-wireless/files/niwl12xxmakenvs
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# If the nvs file doesn't exist grab it from the u-boot env (if that exists)
+if ! [ -f /lib/firmware/ti-connectivity/wl1271-nvs.bin -a \
+       -f /lib/firmware/ti-connectivity/wl127x-nvs.bin ]
+then
+   [ "${VERBOSE}" != "no" ] && echo "Creating wl12xx nvs."
+   wl12xxnvs=`fw_printenv -n wl12xxnvs 2> /dev/null` &&
+      echo $wl12xxnvs | tr '`' '\n' | uudecode &&
+      gunzip -f /lib/firmware/ti-connectivity/wl1271-nvs.bin.gz &&
+      ln -s /lib/firmware/ti-connectivity/wl1271-nvs.bin \
+            /lib/firmware/ti-connectivity/wl127x-nvs.bin
+fi

--- a/recipes-ni/ni-wireless/ni-wireless-wl127x-fw.bb
+++ b/recipes-ni/ni-wireless/ni-wireless-wl127x-fw.bb
@@ -9,13 +9,14 @@ NO_GENERIC_LICENSE[TI-TSPA] = "LICENCE.wl127x"
 LIC_FILES_CHKSUM = "file://LICENCE.wl127x;md5=ba590e1d103f891d0151609046aef9e8"
 
 SRC_URI = "\
+	file://niwl12xxmakenvs \
 	file://LICENCE.wl127x \
 	file://firmware/ti-connectivity/wl127x-fw-4-mr.bin \
 	file://firmware/ti-connectivity/wl127x-fw-4-plt.bin \
 	file://firmware/ti-connectivity/wl127x-fw-4-sr.bin \
 "
 
-inherit allarch
+inherit allarch update-rc.d
 
 FILES:${PN} += "\
 	${base_libdir}/firmware/ti-connectivity/*.bin \
@@ -25,7 +26,13 @@ RDEPENDS:${PN} += "ni-wireless-common"
 
 S = "${WORKDIR}"
 
+INITSCRIPT_NAME = "niwl12xxmakenvs"
+INITSCRIPT_PARAMS = "start 04 S ."
+
 do_install() {
+	install -d ${D}${sysconfdir}/init.d
+	install -m 0755 ${S}/niwl12xxmakenvs ${D}${sysconfdir}/init.d/
+
 	install -pd ${D}${base_libdir}/firmware/ti-connectivity
 	# Rename our tested and known-working firmware files so they work on newer kernels
 	install -m 0644 ${S}/firmware/ti-connectivity/wl127x-fw-4-mr.bin ${D}${base_libdir}/firmware/ti-connectivity/wl127x-fw-5-mr.bin


### PR DESCRIPTION
Ported niwl12xxmakenvs from nilrt_os_common.

WI: [AB#3218382](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3218382)

### Testing

- [x] `bitbake ni-wireless-wl127x-fw`
- [x] Installed `ni-wireless-wl127x-fw.ipk` on a myRIO and no longer see "wlcore: ERROR NVS file is needed during boot" errors.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
