### PR TITLE
Use u-boot's fw_printenv instead of libubootenv's

### DIFF
--- a/recipes-bsp/u-boot/files/fw_env.config
+++ b/recipes-bsp/u-boot/files/fw_env.config
@@ -3,5 +3,5 @@
 # environment sector is assumed present.
 
 # Device name		Device offset	Env. size	Flash sector size
-/dev/ubi0:u-boot-env1	0x0000		0x20000		0x20000
-/dev/ubi0:u-boot-env2	0x0000		0x20000		0x20000
+/dev/mtd4		0x0000		0x20000		0x20000
+/dev/mtd5		0x0000		0x20000		0x20000

--- a/recipes-bsp/u-boot/libubootenv_%.bbappend
+++ b/recipes-bsp/u-boot/libubootenv_%.bbappend
@@ -1,7 +1,5 @@
 COMPATIBLE_MACHINE = "xilinx-zynq"
-PROVIDES += "fw-printenv"
 DEPENDS += "niacctbase"
-RPROVIDES:${PN}-bin += "fw-printenv"
 RDEPENDS:${PN}-bin += "u-boot-env"
 
 do_install:append() {

--- a/recipes-bsp/u-boot/u-boot-tools_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-tools_%.bbappend
@@ -1,0 +1,27 @@
+PACKAGES += "${PN}-fw-utils"
+
+PROVIDES += "fw-printenv"
+RPROVIDES:${PN}-fw-utils = "fw-printenv"
+RCONFLICTS:${PN}-fw-utils = "libubootenv-bin"
+DEPENDS += "niacctbase"
+RDEPENDS:${PN}-fw-utils = "u-boot-env"
+
+do_compile:append() {
+	oe_runmake -C ${S} envtools NO_SDL=1 O=${B}
+}
+
+do_install:append() {
+	install tools/env/fw_printenv ${D}${bindir}/fw_printenv
+	ln -rs ${D}${bindir}/fw_printenv ${D}${bindir}/fw_setenv
+
+	# Setup ownership, perms so webserv user can execute fw_printenv
+	chmod 4550 ${D}${bindir}/fw_printenv
+	chown 0:${LVRT_GROUP} ${D}${bindir}/fw_printenv
+
+	install -d ${D}${base_sbindir}
+
+	ln -rs ${D}${bindir}/fw_printenv ${D}${base_sbindir}/fw_printenv
+	ln -rs ${D}${bindir}/fw_setenv ${D}${base_sbindir}/fw_setenv
+}
+
+FILES:${PN}-fw-utils = "${bindir}/fw_printenv ${bindir}/fw_setenv ${base_sbindir}/fw_printenv ${base_sbindir}/fw_setenv"

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests.bb
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests.bb
@@ -12,8 +12,7 @@ S = "${WORKDIR}"
 
 DEPENDS = "virtual/kernel"
 RDEPENDS:${PN}-ptest += "bash python3 docker"
-RDEPENDS:${PN}-ptest:append:x64 = " fw-printenv"
-RDEPENDS:${PN}-ptest:append:armv7a = " u-boot-fw-utils"
+RDEPENDS:${PN}-ptest:append = " fw-printenv"
 
 ALLOW_EMPTY:${PN} = "1"
 

--- a/recipes-kernel/kernel-tests/kernel-performance-tests.bb
+++ b/recipes-kernel/kernel-tests/kernel-performance-tests.bb
@@ -12,8 +12,7 @@ S = "${WORKDIR}"
 
 DEPENDS = "virtual/kernel"
 RDEPENDS:${PN}-ptest += "bash rt-tests fio iperf3 python3 python3-pip docker"
-RDEPENDS:${PN}-ptest:append:x64 = " fw-printenv"
-RDEPENDS:${PN}-ptest:append:armv7a = " u-boot-fw-utils"
+RDEPENDS:${PN}-ptest:append = " fw-printenv"
 
 ALLOW_EMPTY:${PN} = "1"
 

--- a/recipes-ni/ni-test-boot-time/ni-test-boot-time.bb
+++ b/recipes-ni/ni-test-boot-time/ni-test-boot-time.bb
@@ -37,5 +37,4 @@ ALLOW_EMPTY:${PN} = "1"
 PACKAGES:remove = "${PN}-dev ${PN}-staticdev ${PN}-dbg"
 
 RDEPENDS:${PN}-ptest += "bash gawk python3 python3-pip python3-requests"
-RDEPENDS:${PN}-ptest:append:x64 = " fw-printenv"
-RDEPENDS:${PN}-ptest:append:armv7a = " u-boot-fw-utils"
+RDEPENDS:${PN}-ptest:append = " fw-printenv"


### PR DESCRIPTION
### Summary of Changes

For MTD partitions that use UBI, `fw_printenv` from `libubootenv` only works at UBI layer and acquires exclusive lock of the volume during `fw_setenv` which causes `fw_printenv` to fail. This causes issues for other programs that expect these programs to always succeed.

`fw_printenv` from `u-boot` can operate at `MTD` layer and doesn't lock volume. So concurrent `fw_setenv` and `fw_printenv` calls can work.

So switch to `u-boot`'s `fw_printenv` to keep the same behavior we shipped with sumo.

Also update all `u-boot-fw-utils` dependencies to `fw-printenv`.

### Justification

WI: [AB#3737069](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3737069)

### Testing

- [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
- [x] Built BSI and installed on cRIO-9068.
- [x] Ran `fw_printenv` in a loop while `fw_setenv` was running in a loop and didn't see `fw_printenv` failing. This would fail with `libubootenv`-provided `fw_printenv` and `fw_setenv`.
- [x] `opkg install kernel-containerized-performance-tests-ptest kernel-performance-tests-ptest ni-test-boot-time-ptest` works.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
