### PR TITLE
Ensure BSI installation failures doesn't brick target

### DIFF
--- a/recipes-core/images/files/nilrt-base-system-image.postinst
+++ b/recipes-core/images/files/nilrt-base-system-image.postinst
@@ -81,6 +81,11 @@ if [ "$arch" = "armv7l" ]; then
    # So files that get extracted into /mnt/userfs/boot have to be moved into /boot.
 	if [ ! -f "$mount_point/linux_runmode.itb" ]; then
 		mv /mnt/userfs/boot/* "$mount_point"
+		# The ITB is staged in boot/runmode/ inside the rootfs archive to prevent
+		# u-boot from seeing a partially-installed runmode if BSI extraction fails.
+		# Move it to its final /boot location now that all other files are in place.
+		mv "$mount_point/runmode/linux_runmode.itb" "$mount_point/linux_runmode.itb"
+		rmdir "$mount_point/runmode" 2>/dev/null || true
 	fi
 elif [ "$arch" = "x86_64" ]; then
 	kernel="/mnt/userfs/boot/tmp/runmode"

--- a/recipes-core/images/files/nilrt-base-system-image.postinst
+++ b/recipes-core/images/files/nilrt-base-system-image.postinst
@@ -77,16 +77,11 @@ awk '{print $2;}' < /proc/mounts | grep -q /boot || exit 1
 /usr/sbin/setcap CAP_SYS_TIME+ep /mnt/userfs/sbin/hwclock.util-linux
 
 if [ "$arch" = "armv7l" ]; then
-   # safemodes older than 8.0 don't bind mount bootfs to /mnt/userfs/bootfs.
-   # So files that get extracted into /mnt/userfs/boot have to be moved into /boot.
-	if [ ! -f "$mount_point/linux_runmode.itb" ]; then
-		mv /mnt/userfs/boot/* "$mount_point"
-		# The ITB is staged in boot/runmode/ inside the rootfs archive to prevent
-		# u-boot from seeing a partially-installed runmode if BSI extraction fails.
-		# Move it to its final /boot location now that all other files are in place.
-		mv "$mount_point/runmode/linux_runmode.itb" "$mount_point/linux_runmode.itb"
-		rmdir "$mount_point/runmode" 2>/dev/null || true
-	fi
+	# The ITB is staged in boot/runmode/ inside the rootfs archive to prevent
+	# u-boot from seeing a partially-installed runmode if BSI extraction fails.
+	# Move it to its final /boot location now that all other files are in place.
+	mv "$mount_point/runmode/linux_runmode.itb" "$mount_point/linux_runmode.itb"
+	rmdir "$mount_point/runmode" 2>/dev/null || true
 elif [ "$arch" = "x86_64" ]; then
 	kernel="/mnt/userfs/boot/tmp/runmode"
 	# install the kernel

--- a/recipes-core/images/nilrt-runmode-rootfs.bb
+++ b/recipes-core/images/nilrt-runmode-rootfs.bb
@@ -40,7 +40,13 @@ bootimg_fixup_x64() {
 }
 
 bootimg_fixup_arm() {
-	mv "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/fitImage" "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/linux_runmode.itb"
+	# Stage the ITB under boot/runmode/ rather than directly in boot/.
+	# This prevents u-boot from attempting to boot a partially-extracted
+	# runmode installation: if BSI extraction fails (e.g. disk full), postinst
+	# never runs, so the ITB is never moved to its final /boot location and
+	# u-boot will correctly treat runmode as not installed.
+	install -d "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/runmode"
+	mv "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/fitImage" "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/runmode/linux_runmode.itb"
     find ${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST} -maxdepth 1 -type f \
         ! -name 'linux_runmode.itb' \
         -exec rm -f {} +


### PR DESCRIPTION
### Summary of Changes

- Stages linux_runmode.itb in boot/runmode/ during image creation.
- postinst script moves it to boot/ only after successful extraction.
- Ensures u‑boot never boots a partially installed runmode.
- Removes obsolete pre‑8.0 safemode fallback logic.


### Justification

[AB#3611003](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3611003).

### Testing

* [x] bitbake packagefeed-ni-core.
* [x] bitbake package-index
* [x] bitbake nilrt-base-system-image

- Installed the BSI on an ARM target.
- Confirmed that during extraction:
  - The directory /boot/runmode/ is created.
  - linux_runmode.itb is placed inside /boot/runmode/ (not directly under /boot/).
- Verified that once the postinst script runs:
  - linux_runmode.itb is moved to /boot/linux_runmode.itb.
  - The temporary directory /boot/runmode/ is removed.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
