### PR TITLE
u-boot-tools-fw-utils: Limit to ARM targets

### DIFF
--- a/recipes-bsp/u-boot/u-boot-tools_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-tools_%.bbappend
@@ -1,7 +1,7 @@
 PACKAGES += "${PN}-fw-utils"
 
-PROVIDES += "fw-printenv"
-RPROVIDES:${PN}-fw-utils = "fw-printenv"
+PROVIDES:xilinx-zynq += "fw-printenv"
+RPROVIDES:${PN}-fw-utils:xilinx-zynq = "fw-printenv"
 RCONFLICTS:${PN}-fw-utils = "libubootenv-bin"
 DEPENDS += "niacctbase"
 RDEPENDS:${PN}-fw-utils = "u-boot-env"


### PR DESCRIPTION
### Summary of Changes

There are multiple providers for fw-printenv on x64 (the other being fw_printenv.bb). Since we don't need u-boot-tools-fw-utils on x64, limit PROVIDES and RPROVIDES to ARM.

This fixes builds on x64 which were failing due to multiple providers.

Ideally we should select between multiple fw-printenv providers with `PREFERRED_PROVIDER` but that requires some more work, so leaving it for future.

### Justification

WI: [AB#3737069](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3737069), [AB#3762964](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3762964)

### Testing

- [x] `bitbake packagefeed-ni-core && bitbake package-index && bitbake nilrt-base-system-image && bitbake packagegroup-ni-desirable` on x64 and ARM.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
