### PR TITLE
libpam: Add pam hook to sync passwords

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -61,6 +61,7 @@ RDEPENDS:${PN} += "\
 	lsbinitscripts \
 	modutils-initscripts \
 	netbase \
+	ni-acctsync \
 	ni-hw-scripts \
 	ni-rtfeatures \
 	ni-safemode-utils \

--- a/recipes-core/packagegroups/packagegroup-ni-restoremode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-restoremode.bb
@@ -21,7 +21,6 @@ RDEPENDS:${PN} += "\
 	grep \
 	init-restore-mode \
 	kmod \
-	ni-acctsync \
 	ni-systemreplication \
 	parted \
 	procps \

--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -25,7 +25,6 @@ RDEPENDS:${PN} = "\
 	lldpd \
 	mpfr \
 	nftables \
-	ni-acctsync \
 	ni-cgroups \
 	ni-configpersistentlogs \
 	ni-locale-alias \

--- a/recipes-core/packagegroups/packagegroup-ni-safemode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-safemode.bb
@@ -15,7 +15,6 @@ RDEPENDS:${PN} = " \
 	e2fsprogs-e2fsck \
 	e2fsprogs-mke2fs \
 	e2fsprogs-tune2fs \
-	ni-acctsync \
 	ni-netcfgutil \
 	ni-shutdown-guard-safemode \
 	ni-systemimage \

--- a/recipes-extended/pam/libpam/scripts/ni-acctsync-pam
+++ b/recipes-extended/pam/libpam/scripts/ni-acctsync-pam
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+[ "$PAM_TYPE" = "password" ] || exit 0
+[ "$PAM_USER" = "root" ] || exit 0
+
+/etc/init.d/ni-acctsync stop

--- a/recipes-extended/pam/libpam_1.%.bbappend
+++ b/recipes-extended/pam/libpam_1.%.bbappend
@@ -1,11 +1,16 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
+RDEPENDS:${PN} += "ni-acctsync pam-plugin-exec"
+
 SRC_URI += "\
 	file://security/faillock.conf \
+	file://scripts/ni-acctsync-pam \
 "
 
 do_install:append() {
 	install -m 644 ${UNPACKDIR}/security/faillock.conf ${D}${sysconfdir}/security/faillock.conf
+	install -m 700 ${UNPACKDIR}/scripts/ni-acctsync-pam ${D}${sbindir}/ni-acctsync-pam
+	sed -E -i '/^password[[:space:]]+requisite[[:space:]]+pam_deny\.so$/a password\toptional\t\t\tpam_exec.so /usr/sbin/ni-acctsync-pam' "${D}${sysconfdir}/pam.d/common-password"
 }
 
 pkg_postinst:pam-plugin-faillock:append() {


### PR DESCRIPTION
### Summary of Changes

Update libpam_1.%.bbappend to add this line to /etc/pam.d/common-password:
`password	optional			pam_exec.so /usr/sbin/ni-acctsync-pam`
 This will execute '/etc/init.d/ni-acctsync stop' whenever a password is changed. Also add the pam-plugin-exec package to images.

[AB#3698760](https://dev.azure.com/ni/DevCentral/_workitems/edit/3698760)

### Justification

This will allow ni-acctsync to immediately update the shared .shadow file when the root password is changed instead of waiting for the system to shut down. This makes the password data stored in the configs partition more secure against cases where the device loses power before a new password can be synced.


### Testing

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [X] Built the base runmode and safemode images and confirmed that /etc/pam.d/common-password contains the expected line
* [X] Updated the root password via the passwd command and confirmed /etc/natinst/share/.shadow was immediately updated as well. Tested in runmode and safemode.
* [X] Tested that changing the password for non-root users does not trigger the ni-acctsync script


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
