### PR TITLE
Add ldd and monit based on customer feedback

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-desirable.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-desirable.bb
@@ -32,6 +32,7 @@ RDEPENDS:${PN} += "\
 	iperf3 \
 	ldd \
 	ltrace \
+	monit \
 	ntp \
 	nvme-cli \
 	openssl-dev \

--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -18,6 +18,7 @@ RDEPENDS:${PN} = "\
 	glibc-gconv-cp936 \
 	glibc-gconv-iso8859-1 \
 	iproute2-tc \
+	ldd \
 	libmpc \
 	libpython3 \
 	librtpi \


### PR DESCRIPTION
### Summary of Changes

- Add `ldd` package to the runmode base system image. This is a small (<5Kb) common utility which is very useful for debugging shared library dependencies. Adding it to runmode reduces the debug complexity for systems behind firewalls without access to package feeds or offline scenarios.
- Add `monit` to the desirable package group. Monit is a free open source utility for managing and monitoring, processes, programs, files, directories and filesystems.

### Justification

This is based on a direct customer request/feedback.

### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] `bitbake packagegroup-ni-runmode`
* [x] `bitbake packagegroup-ni-desirable`
* [x] `bitbake nilrt-base-system-image`
* [x] Installed resulting base image on a cRIO-9030 and validated `ldd` is present in the image
* [x] Installed `monit` from a local package feed on cRIO-9030 and validated there are no errors on install and the `monit` service starts

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
