### PR TITLE
Install ni-wifibledd on ARM and a minor change

### DIFF
--- a/recipes-core/images/includes/nilrt-proprietary.inc
+++ b/recipes-core/images/includes/nilrt-proprietary.inc
@@ -25,16 +25,14 @@ NI_PROPRIETARY_COMMON_PACKAGES = "\
         ni-webserver-libs \
         ni-webservices-webserver-support \
         ni-wif-landingpage \
+        ni-wifibledd \
         nicurl \
         nirtcfg \
         nirtmdnsd \
 "
 
-# TODO: ni-wifibledd is required for ARM but there is no ARM build for it.
-# Add it back to NI_PROPRIETARY_COMMON_PACKAGES when there is.
 NI_PROPRIETARY_COMMON_PACKAGES:append:x64 = "\
         ni-sdmon \
-        ni-wifibledd \
 "
 
 NI_PROPRIETARY_RUNMODE_PACKAGES = "\

--- a/recipes-core/images/includes/nilrt-proprietary.inc
+++ b/recipes-core/images/includes/nilrt-proprietary.inc
@@ -37,12 +37,12 @@ NI_PROPRIETARY_COMMON_PACKAGES:append:x64 = "\
 
 NI_PROPRIETARY_RUNMODE_PACKAGES = "\
         ni-arch-gen \
-        python3-ni-asset-discovery \
 "
 
 # SystemLink dependencies
 NI_PROPRIETARY_RUNMODE_PACKAGES:append = "\
         ni-sysmgmt-salt-minion-support \
         ni-sysmgmt-sysapi-expert \
+        python3-ni-asset-discovery \
         python3-ni-systemlink-sdk \
 "


### PR DESCRIPTION
### Summary of Changes

Install `ni-wifibledd` on ARM now that it has an ARM package.

Also move `python3-ni-asset-discovery` under SL deps.

### Justification

WI: [AB#3218382](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3218382)

### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] Built ARM BSI and verified `ni-wifibledd ` is included in it.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
