### PR TITLE
meta-nilrt: udev-extraconf: update worldwritable permissions

### DIFF
--- a/recipes-core/udev/udev-extraconf/rules.d/usb-serial-permissions.rules
+++ b/recipes-core/udev/udev-extraconf/rules.d/usb-serial-permissions.rules
@@ -1,2 +1,10 @@
-SUBSYSTEM=="tty", KERNEL=="ttyUSB*", GROUP="tty", MODE="0666"
-SUBSYSTEM=="tty", KERNEL=="ttyACM*", GROUP="tty", MODE="0666"
+# Import runtime toggle (NI_WORLDWRITABLE) from /etc/udev/scripts/ni-worldwritable.sh
+IMPORT{program}="/etc/udev/scripts/ni-worldwritable.sh"
+
+# When NI_WORLDWRITABLE=1, keep world-writable (0666)
+SUBSYSTEM=="tty", KERNEL=="ttyUSB*", ENV{NI_WORLDWRITABLE}=="1", MODE:="0666", GROUP="dialout"
+SUBSYSTEM=="tty", KERNEL=="ttyACM*", ENV{NI_WORLDWRITABLE}=="1", MODE:="0666", GROUP="dialout"
+
+# Otherwise default to 0664 (no world-write)
+SUBSYSTEM=="tty", KERNEL=="ttyUSB*", ENV{NI_WORLDWRITABLE}!="1", MODE:="0664", GROUP="dialout"
+SUBSYSTEM=="tty", KERNEL=="ttyACM*", ENV{NI_WORLDWRITABLE}!="1", MODE:="0664", GROUP="dialout"

--- a/recipes-core/udev/udev-extraconf/scripts/mount.sh
+++ b/recipes-core/udev/udev-extraconf/scripts/mount.sh
@@ -51,10 +51,23 @@ automount() {
 		MOUNT="$MOUNT -o silent"
 	fi
 
+	# --- Runtime configuration for VFAT permissions ---
+	# Read worldwritable.enabled from /etc/natinst/share/ni-rt.ini, if available.
+	# False (default) => fmask=0002,dmask=0002  (group-writable, not world-writable)
+	# True            => fmask=0000,dmask=0000  (world-writable)
+	enable=$(/usr/local/natinst/bin/nirtcfg --get section=SystemSettings,token=worldwritable.enabled,value="false" | tr "[:upper:]" "[:lower:]")
+
+	# Default VFAT options (restrictive)
+	VFAT_OPTS="fmask=0002,dmask=0002,quiet"
+	case "${enable}" in
+	    true)
+			VFAT_OPTS="fmask=0000,dmask=0000,quiet" ;;
+	esac
+
 	case "$ID_FS_TYPE" in
 		# If mounting vfat, set partition to be world-writable, and
 		# disable permissions warnings
-		vfat) MOUNT="$MOUNT -o fmask=0000,dmask=0000,quiet" ;;
+		vfat) MOUNT="$MOUNT -o $VFAT_OPTS" ;;
 	esac
 
 	if ! $MOUNT -t auto $DEVNAME "/media/$name"

--- a/recipes-core/udev/udev-extraconf/scripts/ni-worldwritable.sh
+++ b/recipes-core/udev/udev-extraconf/scripts/ni-worldwritable.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Echo udev environment keys for IMPORT{program}
+# Reads /etc/natinst/share/ni-rt.ini and outputs worldwritable.enabled=<true|false>
+
+enable=$(/usr/local/natinst/bin/nirtcfg --get section=SystemSettings,token=worldwritable.enabled,value="false" | tr "[:upper:]" "[:lower:]")
+
+case "$enable" in
+     true) NI_WORLDWRITABLE_VAL=1 ;;
+    *)     NI_WORLDWRITABLE_VAL=0 ;;
+esac
+
+# udev IMPORT{program} expects KEY=VALUE pairs on stdout
+echo "NI_WORLDWRITABLE=$NI_WORLDWRITABLE_VAL"
+exit 0


### PR DESCRIPTION
### Summary of Changes

Currently NILRT will automatically mount block and TTY devices as world-writable and should be updated to no longer do this.
We should try to avoid just changing the permissions and should instead have some way to toggle the world-writable permissions back on if needed. Hence to do this - /etc/natinst/share/ni-rt.ini - worldwritable.enabled="true" or worldwritable.enabled="false" is appended as per information provided from hardware config team/

- Controls whether VFAT/TTY mounts are world-writable.
- 0 = default restrictive (fmask=0002,dmask=0002)
- 1 = world-writable (fmask=0000,dmask=0000)
- Reads /** /etc/natinst/share/ni-rt.ini - worldwritable.enabled="true" or worldwritable.enabled="false" ** 

### Justification

Please refer below feature
https://dev.azure.com/ni/DevCentral/_workitems/edit/3470239


### Testing
Safemode:
VFAT and TTY: 
**- worldwritable.enabled="false"**
![worldwritable enabled_false](https://github.com/user-attachments/assets/4abfec0a-cdea-465d-8c71-6d7cc15fdda8)

**worldwritable.enabled="true"**
![worldwritable enabled_true](https://github.com/user-attachments/assets/6e0ecf93-1f76-4aed-9a6d-ae2c3fcedaa7)

Runmode:
VFAT and TTY: 
**- worldwritable.enabled="false"**
![worldwritable_runmode_false](https://github.com/user-attachments/assets/400eb549-c081-4b48-a202-15329ecd50ad)

**worldwritable.enabled="true"**
![worldwritable_runmode_true](https://github.com/user-attachments/assets/986a0985-34b2-48c9-bb08-66b3f4ffd26d)


* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
