### PR TITLE
meta-nilrt: niauth removal

### DIFF
--- a/recipes-core/images/includes/nilrt-proprietary.inc
+++ b/recipes-core/images/includes/nilrt-proprietary.inc
@@ -6,7 +6,6 @@ NI_PROPRIETARY_SAFEMODE_PACKAGES = "\
 
 NI_PROPRIETARY_COMMON_PACKAGES = "\
         libnitargetcfg \
-        ni-auth \
         ni-auth-webservice \
         ni-avahi-client \
         ni-ca-certs \

--- a/recipes-ni/niacctbase/niacctbase.bb
+++ b/recipes-ni/niacctbase/niacctbase.bb
@@ -8,7 +8,6 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 PV = "1.1"
 
 SRC_URI = "\
-	file://sudoers \
 	file://udev.rules \
 "
 
@@ -45,9 +44,7 @@ useradd_preinst:append () {
 
 
 do_install:append () {
-	install -d ${D}${sysconfdir}/sudoers.d/
-	install --mode=0660 ${S}/sudoers ${D}${sysconfdir}/sudoers.d/${PN}
-
+	
 	install -d ${D}${sysconfdir}/udev/rules.d
 	install --mode=0644 ${S}/udev.rules ${D}${sysconfdir}/udev/rules.d/90-${PN}.rules
 }
@@ -55,16 +52,7 @@ do_install:append () {
 
 ## subpackages
 PACKAGE_BEFORE_PN += " \
-	${PN}-sudo \
 	${PN}-udev \
-"
-# -sudo : sudo integration
-SUMMARY:${PN}-sudo = "${SUMMARY} - sudo integration"
-FILES:${PN}-sudo = "${sysconfdir}/sudoers.d/*"
-CONFFILES:${PN}-sudo = "${sysconfdir}/sudoers.d/*"
-RDEPENDS:${PN}-sudo = "\
-	niacctbase \
-	sudo-lib \
 "
 
 # -udev : udev rules for the `ni` group
@@ -75,5 +63,4 @@ RDEPENDS:${PN}-udev += " niacctbase udev"
 
 
 RDEPENDS:${PN} += " ${PN}-udev"
-RRECOMMENDS:${PN} += " ${PN}-sudo"
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-ni/niacctbase/niacctbase/sudoers
+++ b/recipes-ni/niacctbase/niacctbase/sudoers
@@ -1,3 +1,0 @@
-
-# Allow the admin user (UID 0) to invoke sudo without a password
-admin ALL=(ALL) NOPASSWD: ALL


### PR DESCRIPTION
 Summary of Changes

1. Removed the niauth package from nilrt-proprietary.inc file.
2. Removed the niacctbase-sudo from the niacctbase.bb file.

Justification
Please refer below link:
https://dev.azure.com/ni/DevCentral/_backlogs/backlog/RTOS/Features%20and%20Risks?System.AssignedTo=Sandeep.R.kumar%40emerson.com&workitem=3650235

Testing:

Attached the screen shot after removing niauth and niacctbase-sudo package from the files. checked the output on VM.
<img width="1381" height="739" alt="Screenshot 2026-02-16 150347" src="https://github.com/user-attachments/assets/2f489406-aeef-44e3-85a9-5ae035c46871" />

See attached 'Documents_niauth" for the steps I've taken.
[Documents_niauth.txt](https://github.com/user-attachments/files/25838618/Documents_niauth.txt)

Procedure

* [ ] I certify that the contents of this pull request complies with the [Developer Certificate of Origin]
