### PR TITLE
Revert "nilrt-base-system-image.postinst: Delete ubi lines"

### DIFF
--- a/recipes-core/images/files/nilrt-base-system-image.postinst
+++ b/recipes-core/images/files/nilrt-base-system-image.postinst
@@ -55,8 +55,8 @@ if grep -qs artemis /sys/firmware/devicetree/base/compatible ; then
     mkdir -p /etc/natinst/share
 
     # configure the path for fw_printenv to read environmental variables from u-boot
-    # replace /dev/ubi* with /boot/uboot/uboot.env
-    sed -i '/ubi/d' /mnt/userfs/etc/fw_env.config
+    # replace /dev/mtd4 and /dev/mtd5 with /boot/uboot/uboot.env
+    sed -i '/mtd/d' /mnt/userfs/etc/fw_env.config
     echo /boot/uboot/uboot.env         0x0000         0x20000 >> /mnt/userfs/etc/fw_env.config
 
 fi


### PR DESCRIPTION
With dd87d9faa41f04fd9ffc169b100c8c6ade349c60, we are back to using mtd instead of ubi in fw_env.config.

So revert commit e51b79d960c0967e67418de7f7934e4e5241aee9.

### Justification

This fixes the issue mentioned in https://dev.azure.com/ni/DevCentral/_workitems/edit/3737069#10931439

WI: [AB#3737069](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3737069)

### Testing

* [x] Ran `sed -i '/mtd/d' /etc/fw_env.config` on affected machine and `fw_printenv` starts working.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
