### PR TITLE
ni_provisioning: default password for answers file

### DIFF
--- a/recipes-core/initrdscripts/files/ni_provisioning.common
+++ b/recipes-core/initrdscripts/files/ni_provisioning.common
@@ -146,7 +146,7 @@ elif [ "$ARCH" = "x86_64" ]; then
 		>&3 echo "               that is not the recovery tool is used."
 		>&3 echo "   -c y|n : Initial value of the console out enable flag."
 		>&3 echo "   -b SECONDS : Initial value of bootdelay -- how long (seconds) to show boot menu."
-		>&3 echo "   -p ROOT_PASSWORD : Set the value of the root password."
+		>&3 echo "   -p PROVISION_ROOT_PASSWORD : Set the value of the root password."
 		>&3 echo "   -F RESTART_OPTION : Force provisioning (surpress the promts). RESTART_OPTION specifies"
 		>&3 echo "                       what should be done after a succesful provisioning and can have the"
 		>&3 echo "                       following values: reboot, poweroff or shell."
@@ -511,7 +511,7 @@ early_setup()
 				;;
 			b)  grubenv_bootdelay="$OPTARG"
 				;;
-			p)  ROOT_PASSWORD="$OPTARG"
+			p)  PROVISION_ROOT_PASSWORD="$OPTARG"
 				;;
 			F)  FORCE_PROVISIONING=1
 				if [ $OPTARG == "reboot" -o  "$OPTARG" == "poweroff" -o "$OPTARG" == "shell" ]; then

--- a/recipes-core/initrdscripts/files/ni_provisioning.safemode.common
+++ b/recipes-core/initrdscripts/files/ni_provisioning.safemode.common
@@ -407,10 +407,12 @@ fixup_configfs()
 set_root_password()
 {
 	# Set the restore mode password
-	if [[ -n $ROOT_PASSWORD ]]; then
-		echo "root:$ROOT_PASSWORD" | chpasswd
-	else
+	if ! [[ -v PROVISION_ROOT_PASSWORD ]]; then
 		passwd
+	elif [[ -z "$PROVISION_ROOT_PASSWORD" ]]; then
+		passwd -d root
+	else
+		echo "root:$PROVISION_ROOT_PASSWORD" | chpasswd
 	fi
 
 	# Get the root password hash


### PR DESCRIPTION

### Summary of Changes

Update the provisioning script to support the answers file setting the root password. This involves changing the ROOT_PASSWORD variable to PROVISION_ROOT_PASSWORD and updating the script to support cases where the variable is empty.


### Justification

This change will allow users to automatically set the root password during provisioning using the answers file.


### Testing

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [X] Added an answers file containing PROVISION_PASSWORD="test" and confirmed the password was set during provisioning
* [X] Added an answers file containing PROVISION_PASSWORD="" and confirmed the password was blank after provisioning


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
