### PR TITLE
kernel-modules-essential: Remove unbuildable or built-in modules

### DIFF
--- a/recipes-kernel/packagegroups/packagegroup-kernel-modules-essential.bb
+++ b/recipes-kernel/packagegroups/packagegroup-kernel-modules-essential.bb
@@ -33,8 +33,6 @@ RDEPENDS:${PN} = "\
 	kernel-module-ath6kl-usb \
 	kernel-module-atkbd \
 	kernel-module-auth-rpcgss \
-	kernel-module-authenc \
-	kernel-module-authencesn \
 	kernel-module-ax88179-178a \
 	kernel-module-ax88796b \
 	kernel-module-backlight \
@@ -76,16 +74,12 @@ RDEPENDS:${PN} = "\
 	kernel-module-crc-itu-t \
 	kernel-module-crc7 \
 	kernel-module-crc8 \
-	kernel-module-crypto-null \
 	kernel-module-crypto-simd \
 	kernel-module-ctr \
 	kernel-module-curve25519-x86-64 \
 	kernel-module-cuse \
-	kernel-module-dax \
 	kernel-module-deflate \
 	kernel-module-digi-acceleport \
-	kernel-module-dm-crypt \
-	kernel-module-dm-mod \
 	kernel-module-dm-raid \
 	kernel-module-dmi-sysfs \
 	kernel-module-drbg \
@@ -113,7 +107,6 @@ RDEPENDS:${PN} = "\
 	kernel-module-esp4-offload \
 	kernel-module-esp6 \
 	kernel-module-esp6-offload \
-	kernel-module-essiv \
 	kernel-module-ezusb \
 	kernel-module-failover \
 	kernel-module-ff-memless \


### PR DESCRIPTION
nati_x86_64_defconfig was updated [1] which causes some modules to not be buildable or already built-into kernel.

Remove these modules.

1: https://github.com/ni/linux/commit/3da1661fb29d8af12e2cf0f00cdba189d3f61d0e

### Justification

WI: [AB#3786106](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3786106)

### Testing

* [x] `bitbake packagefeed-ni-core && bitbake package-index && bitbake nilrt-base-system-image` for x64.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).

### Note
- Needs to be cherry-picked into systemd and next branches.