### PR TITLE
rtgroups: Add rules for ktimersoftd and rcu_sched

### DIFF
--- a/recipes-rt/rtctl/files/rtgroups
+++ b/recipes-rt/rtctl/files/rtgroups
@@ -45,6 +45,8 @@ kthreadd:f:25:*:\[kthreadd\]$
 irqthread:f:15:*:\[irq\/.+
 irq_work:f:12:*:\[irq_work\/.+\]$
 ktimers:f:10:*:\[ktimers\/.+\]$
+ktimersoftd:f:10:*:\[ktimersoftd\/.+\]$
 rcu:f:2:*:\[rcu(b|c|og)\/[0-9]+\]$
 rcu_preempt:f:2:\[rcu_preempt\]$
+rcu_sched:f:2:\[rcu_sched\]$
 ksoftirqd:f:1:*:\[ksoftirqd\/.+\]$


### PR DESCRIPTION
4.14 kernel has `ktimersoftd` and `rcu_sched` threads. Set their priority similar to `ktimers` and `rcu_preempt`.

### Justification

Fix [test failure](https://dashboard.ni.systems/dashboard/#/products/ni%20linux%20rt%20system%20image/26.3.0/test?test_id=1562222430).

### Testing

* [x] Copied the file on a cRIO-9068 and verified with `chrt -p <pid>` that priorities for ktimersoftd and rcu_sched threads are fifo/10 and fifo/2 respectively.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
