### PR TITLE
mountutils: Enable zlib compression for ARM rootfs

### DIFF
--- a/recipes-ni/initscripts-nilrt/files/mountutils
+++ b/recipes-ni/initscripts-nilrt/files/mountutils
@@ -230,7 +230,7 @@ format_ubi_volume()
 	# Create an empty ubifs (write version 4) so that kernel doesn't
 	# make a newer version of ubifs on mount. Linux 4.14 makes ubifs v5
 	# on empty volumes. Previous versions of Linux make ubifs v4.
-	mkfs.ubifs /dev/ubi${ubidev}_$2
+	mkfs.ubifs --compr=zlib /dev/ubi${ubidev}_$2
 }
 
 # mount_ubi_volume() - mounts an ubi volume


### PR DESCRIPTION
Ported this from [nilrt_os_common](https://dev.azure.com/ni/DevCentral/_git/921942b5-b2be-4a87-b97c-79c194f82203/pullrequest/1098659?path=/src/rtos/rtoslegacyd/nilrt_os_common/source/arch/armv7-a/mountutils). 

### Justification

WI: [AB#3218382](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3218382)

### Testing

None. The code *usually* only runs on safemode which is not yet building in scarthgap. Also it has already been tested on sumo safemode.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
