### PR TITLE
postinst: avoid false positives when scanning logs for errors

### DIFF
--- a/recipes-devtools/run-postinsts/files/test-run-postinsts-log.sh
+++ b/recipes-devtools/run-postinsts/files/test-run-postinsts-log.sh
@@ -20,7 +20,7 @@ source "$CONFIG_FILE" || fail "Failed to run $CONFIG_FILE"
 
 # only present on first boot
 if [ -e "$LOGFILE" ]; then
-    if egrep -i 'warn|error|fatal|fail' "$LOGFILE"; then
+    if grep -Eiw 'warn(ing)?|error(s|ed)?|err|fatal|fail(ed|ure|ures)?' "$LOGFILE"; then
         fail "One or more errors in LOGFILE=$LOGFILE"
     fi
 fi


### PR DESCRIPTION

### Summary of Changes

Replace deprecated egrep usage with grep -E and improve the log matching pattern to avoid false positives.

Previously, the pattern 'warn|error|fatal|fail' matched substrings such as 'str_error_r.o' and triggered failures due to the egrep deprecation warning.

Updated the command to use:
grep -Eiw 'warn(ing)?|error|fatal|fail'

This ensures only whole words are matched and includes both 'warn' and 'warning', reducing incorrect test failures.


### Justification

[AB#3429565](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3429565)


### Testing

TODO: Detail what testing has been done to ensure this submission meets requirements.

* [x] I validated this change by running the test script on target(RTOS-8862): /usr/lib/run-postinsts/ptest/test-run-postinsts-log.sh
<img width="704" height="96" alt="image" src="https://github.com/user-attachments/assets/4ec234e4-5a6f-4fac-a7e8-6dec6ca052c5" />

### Note

This change should also be cherry‑picked into the dist-next and the relevant release branches.
 
### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
