### PR TITLE
Revert "nilrt-bsi.postinst: Enable console out on ARM"

### DIFF
--- a/recipes-core/images/files/nilrt-base-system-image.postinst
+++ b/recipes-core/images/files/nilrt-base-system-image.postinst
@@ -3,8 +3,6 @@
 # Copyright (c) 2013,2017 National Instruments
 #
 
-arch="`uname -m`"
-
 # Something in base is installing /etc/natinst/share/uninstall that may not be
 # getting installed for SystemLink. nisid will fail if this directory doesn't
 # install, so this component ought to install /etc/natinst/share/uninstall
@@ -25,12 +23,6 @@ fi
 # Enable PersistentLogs by default so that technical reports can be generated via
 # Hardware Config Utility.
 /usr/local/natinst/bin/nirtcfg -s section=systemsettings,token=PersistentLogs.enabled,value=True
-
-# Temporarily enable ConsoleOut for all ARM targets to debug AB#3748097.
-# Will be removed in AB#3760326.
-if [ "$arch" = "armv7l" ]; then
-	/usr/local/natinst/bin/nirtcfg -s section=systemsettings,token=ConsoleOut.enabled,value=True
-fi
 
 # Add the memory reservation for Base. We assert that if the section exists,
 # it's already been added.
@@ -61,6 +53,7 @@ if grep -qs artemis /sys/firmware/devicetree/base/compatible ; then
 
 fi
 
+arch="`uname -m`"
 mount_point="/boot"
 class="`/sbin/fw_printenv -n TargetClass`"
 


### PR DESCRIPTION
This reverts commit 07bf82a77f173cd169565d3e81d84c1798cd0ab4.

Reverting this as it was added for debugging and shouldn't end up in finals.

### Justification

WI: [AB#3760326](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3760326)


### Testing

None

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).

### Note
Needs to be cherry-picked/ff-merged into `nilrt/26.3/scarthgap`