### PR TITLE
nilrt-snac: staple to the v3.1.1 release

### DIFF
--- a/recipes-ni/nilrt-snac/nilrt-snac_git.bb
+++ b/recipes-ni/nilrt-snac/nilrt-snac_git.bb
@@ -14,8 +14,8 @@ SRC_URI = "\
 	file://run-ptest \
 "
 
-SRCREV = "${AUTOREV}"
-PV = "2.1.0+git${SRCPV}"
+SRCREV = "bc92e9b92d4f2669d49ea0f7cdc5fcca91f635a6"
+PV = "3.1.1"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
### Summary of Changes

nilrt-snac: staple to the v3.1.1 release

Service for the LV 2026Q2 release.


### Justification

Service for the LV 2026Q2 release.


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)\
* [x] Built ``packagegroup-ni-desirable``.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
