### PR TITLE
nilrt-snac: upgrade to v3.1.1

### DIFF
--- a/recipes-ni/nilrt-snac/nilrt-snac_git.bb
+++ b/recipes-ni/nilrt-snac/nilrt-snac_git.bb
@@ -15,7 +15,7 @@ SRC_URI = "\
 "
 
 SRCREV = "${AUTOREV}"
-PV = "2.1.0+git${SRCPV}"
+PV = "3.1.1+git${SRCPV}"
 
 
 inherit ptest


### PR DESCRIPTION
### Summary of Changes

Release corresponding to the LV 2026Q2 / NILRT 11.5 release.


### Justification

Regular currency upgrade.


### Testing

* This is what the recipe has already been building. This PR just updates the package version.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
* Cherry pick this back to **scarthgap**.