### PR TITLE
nisetupkernelconfig: fixup /var/local/natinst/log perms if mkdir'd

### DIFF
--- a/recipes-ni/initscripts-nilrt/files/nisetupkernelconfig
+++ b/recipes-ni/initscripts-nilrt/files/nisetupkernelconfig
@@ -9,6 +9,8 @@ safemodeflag=/etc/natinst/safemode
 if [ -f $safemodeflag ]; then
   if [ ! -d /mnt/userfs/var/local/natinst/log ]; then
     mkdir -p /mnt/userfs/var/local/natinst/log
+    chown lvuser:ni /mnt/userfs/var/local/natinst/log
+    chmod 775 /mnt/userfs/var/local/natinst/log
   fi
   echo "/mnt/userfs/var/local/natinst/log/core_dump.%E" > /proc/sys/kernel/core_pattern
 else


### PR DESCRIPTION
### Summary of Changes

/var/local/natinst/log must be owned by lvuser:ni with mode 775; otherwise, NI software will fail to start. nisetupkernelconfig is failing to do this if it decides to mkdir it.

---

The known steps to reproduce this in an organic way are rather obscure but are known to be customer-visible.

1. [Create an RT System Image](https://www.ni.com/docs/en-US/bundle/ni-system-configuration-lv-ref/page/nisyscfg/create_system_image.html) while blacklisting the `/var/local/natinst/log` directory to ensure that existing logs are not stored in the image.
2. [Reformat the RT target](https://www.ni.com/docs/en-US/bundle/ni-system-configuration-lv-ref/page/nisyscfg/format_system.html). **Do not install a Base System Image (BSI).**
3. [Set the system image](https://www.ni.com/docs/en-US/bundle/ni-system-configuration-lv-ref/page/nisyscfg/set_system_image.html) back onto the reformatted target. Again, include `/var/local/natinst/log` in the blacklist. (I believe that if you don't install the BSI then it is not necessary to blacklist this on Set Image in order to reproduce this.)

The upshot is that the BSI is setting the right permissions on install, but system images skip that entirely. Normally `/var/local/natinst/log` is saved to a system image, with the right permissions. But if it's omitted then it will have whatever permissions safemode has set for it, which, thanks to this initscript, are incorrect.

### Justification

[AB#3808658](https://dev.azure.com/ni/DevCentral/_workitems/edit/3808658)

### Testing

None (trivial change)

* [ ] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)

### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
