### PR TITLE
images: add docker-archive output for containers

### DIFF
--- a/classes/image-oci-docker.bbclass
+++ b/classes/image-oci-docker.bbclass
@@ -1,0 +1,35 @@
+# Converts an OCI image archive to docker-archive format, which can be
+# loaded directly with `docker load -i <file>.docker.tar`.
+#
+# This class depends on the OCI image already being built (via image-oci),
+# and uses skopeo-native to perform the conversion.
+#
+# Usage: Add "docker" to IMAGE_FSTYPES and inherit this class:
+#   IMAGE_FSTYPES = "container oci docker"
+#   inherit image-oci-docker
+
+IMAGE_TYPEDEP:docker = "oci"
+do_image_docker[depends] += "skopeo-native:do_populate_sysroot"
+
+# The docker image name:tag to embed in the archive.
+DOCKER_IMAGE_NAME ?= "${IMAGE_BASENAME}"
+DOCKER_IMAGE_TAG ?= "${OCI_IMAGE_TAG}"
+
+IMAGE_CMD:docker() {
+    cd ${IMGDEPLOYDIR}
+
+    oci_tar="${IMAGE_NAME}${IMAGE_NAME_SUFFIX}-oci-${OCI_IMAGE_TAG}-${OCI_IMAGE_ARCH}-linux.oci-image.tar"
+    docker_tar="${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.docker.tar"
+
+    if [ ! -f "${oci_tar}" ]; then
+        bbfatal "OCI archive not found: ${oci_tar}"
+    fi
+
+    bbnote "Converting OCI archive to docker-archive format..."
+    skopeo copy \
+        "oci-archive:${oci_tar}" \
+        "docker-archive:${docker_tar}:${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"
+
+    # Create convenience symlink
+    ln -sf "${docker_tar}" "${IMAGE_BASENAME}-${OCI_IMAGE_TAG}-docker.tar"
+}

--- a/recipes-core/images/includes/nilrt-container.inc
+++ b/recipes-core/images/includes/nilrt-container.inc
@@ -39,8 +39,9 @@ OCI_IMAGE_BACKEND = "sloci-image"
 
 
 inherit image-oci
+inherit image-oci-docker
 
-IMAGE_FSTYPES = "container oci"
+IMAGE_FSTYPES = "container oci docker"
 
 
 SFILES = "${THISDIR}/files/container"


### PR DESCRIPTION
### Summary of Changes

This adds a new image-oci-docker bbclass that converts the OCI image archive produced by image-oci into docker-archive format using skopeo-native. The resulting .docker.tar can be loaded directly with `docker load -i` — no host-side tooling (skopeo, Dockerfile, etc.) is required.

Both nilrt-slim-container and nilrt-runmode-container now produce a .docker.tar artifact alongside the existing OCI tar.

#### How to Build
`bitbake nilrt-slim-container`
`bitbake nilrt-runmode-container`

#### How to use — Docker
`docker load -i build/tmp-glibc/deploy/images/x64/nilrt-slim-container-<VERSION>-slim-docker.tar`
`docker load -i build/tmp-glibc/deploy/images/x64/nilrt-runmode-container-<VERSION>-docker.tar`

`docker run -it nilrt-slim-container:<VERSION>-slim`
`docker run -it nilrt-runmode-container:<VERSION>`
`docker run --privileged --network=host -it nilrt-runmode-container:<VERSION>`  # for LabVIEW

#### How to use — Podman (unchanged)
`podman load -i build/tmp-glibc/deploy/images/x64/nilrt-slim-container-11.5-slim-oci.tar`
`podman load -i build/tmp-glibc/deploy/images/x64/nilrt-runmode-container-11.5-oci.tar`
`podman tag localhost/11.5:latest nilrt:11.5`
`podman tag localhost/11.5-slim:latest nilrt:11.5-slim`
`podman run -it nilrt:11.5`
`podman run -it nilrt:11.5-slim`
`podman run --privileged --network=host -it nilrt:11.5`  # for LabVIEW.

### Justification

[AB#3756158](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3756158).

### Testing

- Built both container images; .docker.tar produced and `docker load -i` loads the image with correct name and tag.
- Verified inside Docker container:
  - `cat /etc/os-release | grep VARIANT` → VARIANT_ID=container
  - `whoami` → root (slim container, no NIAuth)
  - `whoami`→ admin (runmode container)
  - `cat /boot/grub/grubenv` → synthetic PXI grubenv with serial#=ABCDEFG
  - `opkg update` → package manager connects and refreshes feeds
- Compared filesystem contents between podman (OCI tar) and Docker (docker-archive tar) containers — they are identical.
