### PR TITLE
ni_provisioning: target disk from answers file

### DIFF
--- a/recipes-core/initrdscripts/files/ni_provisioning
+++ b/recipes-core/initrdscripts/files/ni_provisioning
@@ -24,17 +24,17 @@ early_setup "$@"
 # Source default answer file to prompt user for all questions
 source_default_answer_file
 
-# Source user's answer file, if present
-source_answer_file
-echo
-
-set_target_from_answer_file
-
 if in_recovery_mode; then
 	echo "Automatic provision and reboot in recovery mode"
 	PROVISION_REPARTITION_TARGET="y"
 	PROVISION_REBOOT_METHOD="reboot"
 fi
+
+# Source user's answer file, if present
+source_answer_file
+echo
+
+set_target_from_answer_file
 
 if [[ $restore == "provision-safe" ]]; then
 	if [[ "$PROVISION_REPARTITION_TARGET" != "y" ]]; then

--- a/recipes-core/initrdscripts/files/ni_provisioning
+++ b/recipes-core/initrdscripts/files/ni_provisioning
@@ -24,6 +24,12 @@ early_setup "$@"
 # Source default answer file to prompt user for all questions
 source_default_answer_file
 
+# Source user's answer file, if present
+source_answer_file
+echo
+
+set_target_from_answer_file
+
 if in_recovery_mode; then
 	echo "Automatic provision and reboot in recovery mode"
 	PROVISION_REPARTITION_TARGET="y"
@@ -31,10 +37,6 @@ if in_recovery_mode; then
 fi
 
 if [[ $restore == "provision-safe" ]]; then
-	# source user's answer file, if present
-	source_answer_file
-	echo
-
 	if [[ "$PROVISION_REPARTITION_TARGET" != "y" ]]; then
 		ask_for_continue
 	fi
@@ -51,10 +53,6 @@ elif [[ $restore == "backward-migrate" ]]; then
 	ASK_BEFORE_REBOOT=1
 	PROVISION_REBOOT_METHOD="reboot"
 elif [[ $restore == "provision" ]]; then
-	# source user's answer file, if present
-	source_answer_file
-	echo
-
 	if [[ "$PROVISION_PART_NILRT_ID" = "auto" ]]; then
 		ask_for_continue
 
@@ -108,10 +106,6 @@ elif [[ $restore == "migrate" ]]; then
 elif [[ $restore == "get-image" ]]; then
 	echo "Get Image"
 
-	# source user's answer file, if present
-	source_answer_file
-	echo
-
 	source /sbin/nisystemreplication get
 	if [[ "${FORCE_PROVISIONING}" -eq 1 ]]; then
 		PROVISION_REBOOT_METHOD=${RESTART_OPTION}
@@ -119,10 +113,6 @@ elif [[ $restore == "get-image" ]]; then
 	ASK_BEFORE_REBOOT=1
 elif [[ $restore == "set-image" ]]; then
 	echo "Set Image"
-
-	# source user's answer file, if present
-	source_answer_file
-	echo
 
 	source /sbin/nisystemreplication set
 	if [[ "${FORCE_PROVISIONING}" -eq 1 ]]; then

--- a/recipes-core/initrdscripts/files/ni_provisioning.common
+++ b/recipes-core/initrdscripts/files/ni_provisioning.common
@@ -70,6 +70,16 @@ provision_successfull()
 	echo -e ${GREEN}"PROVISIONING SUCCESSFUL!"${NC} 1>&3 2>&4
 }
 
+set_target_from_answer_file()
+{
+	if [[ -n "$PROVISION_TARGET_DISK" ]]; then
+		TARGET_DISK="$PROVISION_TARGET_DISK"
+		if [[ "${TARGET_DISK: -1}" =~ [0-9] ]]; then
+			PART_SEPARATOR='p'
+		fi
+	fi
+}
+
 umount_partition()
 {
 	if [ ! -z "`mount | grep $1`" ]; then

--- a/recipes-core/initrdscripts/files/ni_provisioning.common
+++ b/recipes-core/initrdscripts/files/ni_provisioning.common
@@ -24,6 +24,7 @@ ARCH=$(uname -m)
 VERBOSE_ARGS=${VERBOSE_ARGS:-"-q"}
 MKFS_ARGS=${MKFS_ARGS:-"$VERBOSE_ARGS -F -I 256"}
 verbose_mode=${verbose_mode:-0}
+interactive_disk_selection=${interactive_disk_selection:-0}
 
 if [ "$verbose_mode" -eq 0 ]; then
 	do_silent() { "$@" &>/dev/null; };
@@ -74,6 +75,7 @@ set_target_from_answer_file()
 {
 	if [[ -n "$PROVISION_TARGET_DISK" ]]; then
 		TARGET_DISK="$PROVISION_TARGET_DISK"
+		PART_SEPARATOR=''
 		if [[ "${TARGET_DISK: -1}" =~ [0-9] ]]; then
 			PART_SEPARATOR='p'
 		fi
@@ -154,6 +156,7 @@ elif [ "$ARCH" = "x86_64" ]; then
 		>&3 echo "   -t DEVICE : DEVICE is the device name for the disk to update. (e.g /dev/sda)"
 		>&3 echo "               If DEVICE is not specificed, the first non-removable block device"
 		>&3 echo "               that is not the recovery tool is used."
+		>&3 echo "   -i : Enable interactive disk selection."
 		>&3 echo "   -c y|n : Initial value of the console out enable flag."
 		>&3 echo "   -b SECONDS : Initial value of bootdelay -- how long (seconds) to show boot menu."
 		>&3 echo "   -p PROVISION_ROOT_PASSWORD : Set the value of the root password."
@@ -169,6 +172,7 @@ elif [ "$ARCH" = "x86_64" ]; then
 		local path=$1
 		local block=$2
 		local mmc_ok=${3:-false}
+		local removable_ok=${4:-false}
 
 		if ! (( $? == 0 )); then
 			(( verbose_mode )) && echo "SKIPPED $path_abbrev: udevadm failed" >&2
@@ -183,9 +187,11 @@ elif [ "$ARCH" = "x86_64" ]; then
 
 		# Skip removable devices; we're only interested in internal disks. This
 		# catches USBs and CDs.
-		if ! (( $(<$path/removable) == 0 )); then
-			(( verbose_mode )) && echo "SKIPPED $path_abbrev: removable!=0" >&2
-			return 1
+		if ! $removable_ok; then
+			if ! (( $(<$path/removable) == 0 )); then
+				(( verbose_mode )) && echo "SKIPPED $path_abbrev: removable!=0" >&2
+				return 1
+			fi
 		fi
 
 		# Skip read-only devices. This catches mmcblk*boot*, but *not*
@@ -268,6 +274,53 @@ elif [ "$ARCH" = "x86_64" ]; then
 
 		if [[ $selected_block ]]; then
 			echo "$selected_block"
+		else
+			return 1
+		fi
+	}
+
+	select_target_block_device()
+	{
+		local -n selected_block=$1
+		local block_index="?"
+		local mmc_ok=true
+		local block_devices=()
+
+		for path in /sys/block/*; do
+			path_abbrev=${path##/sys/block/}
+			local block=$(udevadm info -r --query=name --path=$path)
+			check_block_device $path $block $mmc_ok true || continue
+
+			# Add each valid block device to block_devices
+			block_devices+=( "$block" )
+		done
+
+		if [ ${#block_devices[@]} -eq 0 ]; then
+			return 1
+		fi
+
+		for i in "${!block_devices[@]}"; do
+			local dev="${block_devices[$i]}"
+			local block_name=$(lsblk -dn -o NAME "$dev")
+			local block_model=$(lsblk -dn -o MODEL "$dev")
+			local block_serial=$(lsblk -dn -o SERIAL "$dev")
+			printf "%s) %s\t%s\t%s\n" "$i" "$block_name" "$block_model" "$block_serial"
+		done
+
+		# Build a regex pattern for the available devices
+		max_index=$((${#block_devices[@]} - 1))
+		regex="^("
+		for ((i = 0; i <= max_index; i++)); do
+			regex+="$i|"
+		done
+		regex="${regex%|})$"
+
+		prompt_user "Select a block device to provision" "$regex" "0" block_index
+
+		selected_block=${block_devices[$block_index]}
+
+		if [[ $selected_block ]]; then
+			return 0
 		else
 			return 1
 		fi
@@ -499,7 +552,7 @@ early_setup()
 
 	OPTIND=1
 
-	while getopts "havt:c:b:p:F:" opt; do
+	while getopts "havit:c:b:p:F:" opt; do
 		case "$opt" in
 			h)  show_help
 				exit 1
@@ -508,6 +561,8 @@ early_setup()
 				;;
 			v)  verbose_mode=1
 				>&3 echo "Verbose mode..."
+				;;
+			i)  interactive_disk_selection=1
 				;;
 			t)  TARGET_DISK="$OPTARG"
 				;;
@@ -546,18 +601,22 @@ early_setup()
 	fi
 
 	if [[ -z $TARGET_DISK ]]; then
-		local search_begin="`get_time_delta 0`"
-		while [ "`get_time_delta "$search_begin"`" -le "$TARGET_DISK_SEARCH_TIME" ]; do
-			(( verbose_mode )) && echo "Searching for TARGET_DISK..." >&2
-			TARGET_DISK="`find_target_block_device`" || TARGET_DISK=""
-			if [[ -z $TARGET_DISK ]]; then
-				(( verbose_mode )) && echo "not found" >&2
-				sleep 1
-			else
-				(( verbose_mode )) && echo "found TARGET_DISK=$TARGET_DISK" >&2
-				break
-			fi
-		done
+		if [[ $interactive_disk_selection -eq 1 ]]; then
+			select_target_block_device TARGET_DISK
+		else
+			local search_begin="`get_time_delta 0`"
+			while [ "`get_time_delta "$search_begin"`" -le "$TARGET_DISK_SEARCH_TIME" ]; do
+				(( verbose_mode )) && echo "Searching for TARGET_DISK..." >&2
+				TARGET_DISK="`find_target_block_device`" || TARGET_DISK=""
+				if [[ -z $TARGET_DISK ]]; then
+					(( verbose_mode )) && echo "not found" >&2
+					sleep 1
+				else
+					(( verbose_mode )) && echo "found TARGET_DISK=$TARGET_DISK" >&2
+					break
+				fi
+			done
+		fi
 
 		if [[ -z $TARGET_DISK ]]; then
 			die "No target device found for installation after $TARGET_DISK_SEARCH_TIME seconds."


### PR DESCRIPTION
### Summary of Changes

There are two primary changes:

- Make disk selection possible using the answers file
    - This was done by adding a new PROVISION_TARGET_DISK that can be added to the answers file and will overwrite the current TARGET_DISK variable when present.
    - I also added some slight refactoring to read the answers file immediately after reading the script arguments instead of doing it in each branch of the following if-block.
- Add a interactive disk selection mode
    - This can be enablede by using a new -i argument for the ni_provisioning script when running it manually.
    - When enabled, a list of valid provisioning targets will be gathered using the same method we currently use to automatically select a target and each option will be printed followed by a prompt to select one.
        - There is a slight change to which block devices are valid, which is that removable devices are displayed in the interactive option.

The default behavior is unchanged, which is to say that if the default provisioning option is selected and no answer file is present, then the first valid block device that is found will be selected for provisioning.

### Justification

These changes will help support the upcoming Kinabalu devices that have multiple internal disks and require a way to select which one should be provisioned.

[AB#3813755](https://dev.azure.com/ni/DevCentral/_workitems/edit/3813755)


### Testing

For all of the testing I set up a cRIO-9033 and added an SD card that could be provisioned.

- [X] Tested that the behavior if PROVISION_TARGET_DISK is undefined or if the interactive case is not used matches our current default behavior. This is that the first valid disk is selected and any removable disks are skipped.
- [X] Tested that PROVISION_TARGET_DISK can be added to an answer file and the disk specified there is selected.
- [X] Tested that using the -i script argument provides a list of valid targets and allows the user to select one.
    - Confirmed that removable disks are displayed as options.
    - Checked that the user prompt does not accept any inputs besides the displayed numbers.
    - ![provisioning 1](https://github.com/user-attachments/assets/97a7b938-de18-4249-9254-f899002206e7)
    - ![provisioning 2](https://github.com/user-attachments/assets/ec5a3a66-7a82-4087-858f-6c81b618e337)



* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
