### PR TITLE
Build ARM safemode

### DIFF
--- a/conf/machine/xilinx-zynq.conf
+++ b/conf/machine/xilinx-zynq.conf
@@ -22,6 +22,7 @@ INITRAMFS_FSTYPES = "cpio.gz.u-boot"
 # To generate bootscript section in FIT image, u-boot needs to be built.
 UBOOT_ARCH = "arm"
 UBOOT_LOADADDRESS ?= "0x8000"
+UBOOT_RD_LOADADDRESS ?= "0x01000000"
 UBOOT_ENTRYPOINT ?= "${UBOOT_LOADADDRESS}"
 UBOOT_ENV = "bootscript"
 UBOOT_ENV_BINARY ?= "bootscript.txt"

--- a/recipes-bsp/u-boot/files/bootscript.txt
+++ b/recipes-bsp/u-boot/files/bootscript.txt
@@ -1,45 +1,87 @@
-if test ${DeviceCode} -eq 0x7AAE; then
-  setenv set_args 'setenv bootargs ${consoleparam} root=/dev/mmcblk0p3 rw ${usb_gadget_args} rcu_nocbs=all rootdelay=1 $othbootargs'
-else
-  setenv set_args 'setenv bootargs ${consoleparam} $mtdparts ubi.mtd=boot-config ubi.mtd=root root=ubi1:rootfs rw rootfstype=ubifs ${usb_gadget_args} rcu_nocbs=all $othbootargs'
-fi
+if fdt addr ${loadaddr} && fdt get value rd_desc /images/ramdisk-1 description; then
+  # Initramfs present. So this must be safemode
 
-# usb host or device mode switching
-if test -n ${otg_usb_en} && test ${otg_usb_en} -eq 1; then
-  fdt addr ${loadaddr} && fdt get value fdtname /configurations/conf-ni-${DeviceCode}.dtb fdt && fdt get addr fdtaddr /images/${fdtname} data && fdt addr ${fdtaddr} && if itest.l ${usb_otgsc_id:-ffffffff} == 0; then
-    fdt set /amba@0/usb@${otg_usb_base_addr} dr_mode host;
-  elif itest.l ${usb_otgsc_id:-ffffffff} == 100; then
-    fdt set /amba@0/usb@${otg_usb_base_addr} dr_mode peripheral;
-  fi;
-fi
-
-# wireless region switching
-if test -n ${wirelessRegionFactory} && test -n ${wireless_board_id} && test -n ${wlan_sdio_base_addr}; then
-  fdt addr ${loadaddr} && fdt get value fdtname /configurations/conf-ni-${DeviceCode}.dtb fdt && fdt get addr fdtaddr /images/${fdtname} data && fdt addr ${fdtaddr} && fdt set /amba@0/sdhci@${wlan_sdio_base_addr}/wlan@0 atheros,board-id ${wireless_board_id} && fdt set /amba@0/sdhci@${wlan_sdio_base_addr}/wlan@0 atheros,region-code ${wirelessRegionFactory};
-fi
-
-# cRIO-9068 doesn't have USB gadget, so skip it on that device
-if test ${DeviceCode} != 0x76D6; then
-  # myRIO should use ethaddr for the USB gadget to ensure a persistent address
-  if test ${DeviceCode} == 0x762F || test ${DeviceCode} == 0x76D3; then
-    usb_gadget_addr=${ethaddr}
+  if test ${DeviceCode} -eq 0x7AAE; then
+    setenv set_args 'setenv bootargs ${consoleparam} ramdisk_size=populate-ramdisk-size root=/dev/ram rw ${usb_gadget_args} $othbootargs';
   else
-    usb_gadget_addr=${usbgadgetethaddr}
+    setenv set_args 'setenv bootargs ${consoleparam} $mtdparts ubi.mtd=boot-config ubi.mtd=root ramdisk_size=populate-ramdisk-size root=/dev/ram rw ${usb_gadget_args} $othbootargs';
   fi
-  usb_gadget_args="g_ether.idVendor=${USBVendorID} g_ether.idProduct=${USBProductID} g_ether.iProduct=\"${USBProduct} [${hostname}]\" g_ether.iSerialNumber=${serial#} g_ether.dev_addr=${usb_gadget_addr} g_ether.bcdDevice=${USBDevice}"
+
+  # usb host or device mode switching
+  if test -n ${otg_usb_en} && test ${otg_usb_en} -eq 1; then
+    fdt addr ${loadaddr} && fdt get value fdtname /configurations/conf-ni-${DeviceCode}.dtb fdt && fdt get addr fdtaddr /images/${fdtname} data && fdt addr ${fdtaddr} && if itest.l ${usb_otgsc_id:-ffffffff} == 0; then
+      fdt set /amba@0/usb@${otg_usb_base_addr} dr_mode host;
+    elif itest.l ${usb_otgsc_id:-ffffffff} == 100; then
+      fdt set /amba@0/usb@${otg_usb_base_addr} dr_mode peripheral;
+    fi;
+  fi
+
+  # wireless region switching
+  if test -n ${wirelessRegionFactory} && test -n ${wireless_board_id} && test -n ${wlan_sdio_base_addr}; then
+    fdt addr ${loadaddr} && fdt get value fdtname /configurations/conf-ni-${DeviceCode}.dtb fdt && fdt get addr fdtaddr /images/${fdtname} data && fdt addr ${fdtaddr} && fdt set /amba@0/sdhci@${wlan_sdio_base_addr}/wlan@0 atheros,board-id ${wireless_board_id} && fdt set /amba@0/sdhci@${wlan_sdio_base_addr}/wlan@0 atheros,region-code ${wirelessRegionFactory};
+  fi
+
+  # cRIO-9068 doesn't have USB gadget, so skip it on that device
+  if test ${DeviceCode} != 0x76D6; then
+    usb_gadget_args="g_ether.idVendor=${USBVendorID} g_ether.idProduct=${USBProductID} g_ether.iProduct=\"${USBProduct} [${hostname}]\" g_ether.iSerialNumber=${serial#} g_ether.dev_addr=${usbgadgetethaddr} g_ether.bcdDevice=${USBDevice}"
+  fi
+
+  if test -n \"$bootscriptenvsafe\" ; then run bootscriptenvsafe; fi
+
+  silent_tmp=${silent}
+  setenv silent
+  echo "Booting safe mode..."
+  setenv silent ${silent_tmp}
+
+  run set_args
+  bootm ${loadaddr}#conf-ni-${DeviceCode}.dtb
+
+else
+  # Initramfs not present. So this must be runmode
+
+  if test ${DeviceCode} -eq 0x7AAE; then
+    setenv set_args 'setenv bootargs ${consoleparam} root=/dev/mmcblk0p3 rw ${usb_gadget_args} rcu_nocbs=all rootdelay=1 $othbootargs'
+  else
+    setenv set_args 'setenv bootargs ${consoleparam} $mtdparts ubi.mtd=boot-config ubi.mtd=root root=ubi1:rootfs rw rootfstype=ubifs ${usb_gadget_args} rcu_nocbs=all $othbootargs'
+  fi
+
+  # usb host or device mode switching
+  if test -n ${otg_usb_en} && test ${otg_usb_en} -eq 1; then
+    fdt addr ${loadaddr} && fdt get value fdtname /configurations/conf-ni-${DeviceCode}.dtb fdt && fdt get addr fdtaddr /images/${fdtname} data && fdt addr ${fdtaddr} && if itest.l ${usb_otgsc_id:-ffffffff} == 0; then
+      fdt set /amba@0/usb@${otg_usb_base_addr} dr_mode host;
+    elif itest.l ${usb_otgsc_id:-ffffffff} == 100; then
+      fdt set /amba@0/usb@${otg_usb_base_addr} dr_mode peripheral;
+    fi;
+  fi
+
+  # wireless region switching
+  if test -n ${wirelessRegionFactory} && test -n ${wireless_board_id} && test -n ${wlan_sdio_base_addr}; then
+    fdt addr ${loadaddr} && fdt get value fdtname /configurations/conf-ni-${DeviceCode}.dtb fdt && fdt get addr fdtaddr /images/${fdtname} data && fdt addr ${fdtaddr} && fdt set /amba@0/sdhci@${wlan_sdio_base_addr}/wlan@0 atheros,board-id ${wireless_board_id} && fdt set /amba@0/sdhci@${wlan_sdio_base_addr}/wlan@0 atheros,region-code ${wirelessRegionFactory};
+  fi
+
+  # cRIO-9068 doesn't have USB gadget, so skip it on that device
+  if test ${DeviceCode} != 0x76D6; then
+    # myRIO should use ethaddr for the USB gadget to ensure a persistent address
+    if test ${DeviceCode} == 0x762F || test ${DeviceCode} == 0x76D3; then
+      usb_gadget_addr=${ethaddr}
+    else
+      usb_gadget_addr=${usbgadgetethaddr}
+    fi
+    usb_gadget_args="g_ether.idVendor=${USBVendorID} g_ether.idProduct=${USBProductID} g_ether.iProduct=\"${USBProduct} [${hostname}]\" g_ether.iSerialNumber=${serial#} g_ether.dev_addr=${usb_gadget_addr} g_ether.bcdDevice=${USBDevice}"
+  fi
+
+  if test -n \"$bootscriptenvrun\" ; then run bootscriptenvrun; fi
+
+  silent_tmp=${silent}
+  setenv silent
+  echo "Booting LabVIEW RT..."
+  setenv silent ${silent_tmp}
+
+  test -n "$manufacturer" ||
+      setenv manufacturer National Instruments &&
+      setenv .flags manufacturer:so &&
+      saveenv;
+
+  run set_args
+  bootm ${loadaddr}#conf-ni-${DeviceCode}.dtb
 fi
-
-if test -n \"$bootscriptenvrun\" ; then run bootscriptenvrun; fi
-
-silent_tmp=${silent}
-setenv silent
-echo "Booting LabVIEW RT..."
-setenv silent ${silent_tmp}
-
-test -n "$manufacturer" ||
-    setenv manufacturer National Instruments &&
-    setenv .flags manufacturer:so &&
-    saveenv;
-
-run set_args
-bootm ${loadaddr}#conf-ni-${DeviceCode}.dtb

--- a/recipes-core/images/nilrt-safemode-initramfs.bb
+++ b/recipes-core/images/nilrt-safemode-initramfs.bb
@@ -39,10 +39,6 @@ bootimg_fixup () {
 	mkdir -p "${IMAGE_ROOTFS}/etc/natinst/share"
 	mkdir -p "${IMAGE_ROOTFS}/mnt/userfs"
 
-	echo "LABEL=nibootfs /boot ext4 sync 0 0" >> "${IMAGE_ROOTFS}/etc/fstab"
-	echo "LABEL=niconfig /etc/natinst/share ext4 sync 0 0" >> "${IMAGE_ROOTFS}/etc/fstab"
-	echo "LABEL=nirootfs /mnt/userfs ext4 defaults 0 0" >> "${IMAGE_ROOTFS}/etc/fstab"
-
 	# Add safemode marker
 	echo "safemode" > "${IMAGE_ROOTFS}/etc/natinst/safemode"
 
@@ -55,7 +51,14 @@ bootimg_fixup () {
 	opkg -o ${IMAGE_ROOTFS} -f ${IPKGCONF_TARGET} clean
 }
 
+bootimg_fixup_x64 () {
+	echo "LABEL=nibootfs /boot ext4 sync 0 0" >> "${IMAGE_ROOTFS}/etc/fstab"
+	echo "LABEL=niconfig /etc/natinst/share ext4 sync 0 0" >> "${IMAGE_ROOTFS}/etc/fstab"
+	echo "LABEL=nirootfs /mnt/userfs ext4 defaults 0 0" >> "${IMAGE_ROOTFS}/etc/fstab"
+}
+
 IMAGE_PREPROCESS_COMMAND += " bootimg_fixup; "
+IMAGE_PREPROCESS_COMMAND:append:x64 = " bootimg_fixup_x64; "
 
 
 # We always want package-management support in this image, fail if not enabled

--- a/recipes-core/images/nilrt-safemode-initramfs.bb
+++ b/recipes-core/images/nilrt-safemode-initramfs.bb
@@ -57,8 +57,13 @@ bootimg_fixup_x64 () {
 	echo "LABEL=nirootfs /mnt/userfs ext4 defaults 0 0" >> "${IMAGE_ROOTFS}/etc/fstab"
 }
 
+bootimg_fixup_arm () {
+    echo "ubi1:rootfs /mnt/userfs ubifs defaults 0 0" >> "${IMAGE_ROOTFS}/etc/fstab"
+}
+
 IMAGE_PREPROCESS_COMMAND += " bootimg_fixup; "
 IMAGE_PREPROCESS_COMMAND:append:x64 = " bootimg_fixup_x64; "
+IMAGE_PREPROCESS_COMMAND:append:xilinx-zynq = " bootimg_fixup_arm; "
 
 
 # We always want package-management support in this image, fail if not enabled

--- a/recipes-kernel/linux/linux-nilrt-arm-safemode_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-arm-safemode_git.bb
@@ -6,6 +6,7 @@ COMPATIBLE_MACHINE = "xilinx-zynq"
 require linux-nilrt-alternate.inc
 
 INITRAMFS_IMAGE = "nilrt-safemode-initramfs"
+FIT_DESC = "zynq_safemode - ${BUILDNAME}"
 
 kernel_do_deploy:append() {
     # Create a symlink that's useful to identify the correct fitImage and is also shorter.

--- a/recipes-kernel/linux/linux-nilrt-arm-safemode_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-arm-safemode_git.bb
@@ -1,0 +1,17 @@
+DESCRIPTION = "NILRT safemode itb for ARM targets"
+NI_RELEASE_VERSION = "master"
+LINUX_VERSION:xilinx-zynq = "4.14"
+COMPATIBLE_MACHINE = "xilinx-zynq"
+
+require linux-nilrt-alternate.inc
+
+INITRAMFS_IMAGE = "nilrt-safemode-initramfs"
+
+kernel_do_deploy:append() {
+    # Create a symlink that's useful to identify the correct fitImage and is also shorter.
+    ln -snf fitImage-${INITRAMFS_IMAGE_NAME}-${KERNEL_FIT_NAME}${KERNEL_FIT_BIN_EXT} "$deployDir/linux_safemode.itb"
+}
+
+# This is the place to overwrite the source AUTOREV from linux-nilrt.inc, if
+# the kernel recipe requires a particular ref.
+#SRCREV = ""


### PR DESCRIPTION
### Summary of Changes

Changes to support building ARM safemode (`linux_safemode.itb`).

### Justification

WI: [AB#3221310](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3221310)

### Testing

* [x] `bitbake linux-nilrt-arm-safemode`
* [x] Copied `tmp-glibc/deploy/images/xilinx-zynq/kernel-standard/linux_safemode.itb` to `/boot/.safe/` of a cRIO-9068 and verified it boots into safemode.
* [x] Format operation from HWCU works.
* [x] HWCU is able to install BSI.
* [x] Built BSI with these changes and verified it still works on cRIO-9068.
* [x] Ran `bitbake -e nilrt-safemode-initramfs` on x64 and verified `bootimg_fixup_x64` ends up in `IMAGE_PREPROCESS_COMMAND`.
* [x] Ran `bitbake nilrt-safemode-initramfs` on x64 without issues.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
