### PR TITLE
ni_provisioning: Mount drives by name not label

### DIFF
--- a/recipes-core/initrdscripts/files/ni_provisioning.safemode.common
+++ b/recipes-core/initrdscripts/files/ni_provisioning.safemode.common
@@ -217,7 +217,7 @@ mount_grub_partition()
 {
 	GRUB_MOUNTPOINT=/var/volatile/grub
 	mkdir $GRUB_MOUNTPOINT -p
-	MOUNT_ERROR=`mount -L $PART1_LABEL $GRUB_MOUNTPOINT 2>&1` || die "$MOUNT_ERROR"
+	MOUNT_ERROR=`mount ${TARGET_DISK}${PART_SEPARATOR}1 $GRUB_MOUNTPOINT 2>&1` || die "$MOUNT_ERROR"
 }
 
 install_grub()
@@ -244,7 +244,7 @@ mount_bootfs_partition()
 {
 	BOOTFS_MOUNTPOINT=/var/volatile/bootfs
 	mkdir $BOOTFS_MOUNTPOINT -p
-	BOOTFS_ERROR=`mount -L $PART2_LABEL $BOOTFS_MOUNTPOINT 2>&1` || die "$BOOTFS_ERROR"
+	BOOTFS_ERROR=`mount ${TARGET_DISK}${PART_SEPARATOR}2 $BOOTFS_MOUNTPOINT 2>&1` || die "$BOOTFS_ERROR"
 }
 
 install_safemode()
@@ -381,7 +381,7 @@ fixup_configfs()
 	CONFIG_MOUNTPOINT=/var/volatile/configfs
 
 	mkdir -p $CONFIG_MOUNTPOINT
-	mount -L $PART3_LABEL $CONFIG_MOUNTPOINT
+	mount ${TARGET_DISK}${PART_SEPARATOR}3 $CONFIG_MOUNTPOINT
 
 	# Set root dir ownership to lvuser:ni
 	chown 500:500 $CONFIG_MOUNTPOINT
@@ -422,7 +422,7 @@ set_root_password()
 	# Create the shared shadow file and add root entry
 	CONFIG_MOUNTPOINT=/var/volatile/configfs
 	mkdir -p $CONFIG_MOUNTPOINT
-	mount -L $PART3_LABEL $CONFIG_MOUNTPOINT
+	mount ${TARGET_DISK}${PART_SEPARATOR}3 $CONFIG_MOUNTPOINT
 	touch "$CONFIG_MOUNTPOINT/.shadow"
 	chmod 400 "$CONFIG_MOUNTPOINT/.shadow"
 	echo "$ROOT_HASH" > "$CONFIG_MOUNTPOINT/.shadow"


### PR DESCRIPTION
### Summary of Changes

Update the ni_provisioning script to mount drives using the TARGET_DISK variable instead of the partition label variables. This prevents an issue of non-deterministic operations when there are multiple partitions with the same label.

### Justification

This fixes [AB#3826955](https://dev.azure.com/ni/DevCentral/_workitems/edit/3826955) which causes provisioning to fail if there is another disk provisioned with NILRT in the system.


### Testing

Testing was done on a cRIO-9033 with an SD card
- [X] Successfully provisioned the internal disk and booted into it
- [X] Successfully provisioned the SD card and booted into it

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
