### PR TITLE
meta-nilrt: make next-BSI buildable on arm

### DIFF
--- a/conf/machine/xilinx-zynq.conf
+++ b/conf/machine/xilinx-zynq.conf
@@ -5,8 +5,8 @@
 TARGET_ARCH = "arm"
 DEFAULTTUNE = "cortexa9-vfpv3"
 
-KERNEL_CLASSES += "kernel-fitimage"
-KERNEL_IMAGETYPE = "fitImage"
+KERNEL_CLASSES += "kernel-fit-extra-artifacts"
+KERNEL_IMAGETYPE = "zImage"
 
 KERNEL_FEATURES:remove = "cfg/fs/vfat.scc"
 
@@ -18,11 +18,13 @@ MACHINE_FEATURES = "apm ext2 vfat ethernet screen usbgadget usbhost wifi"
 SERIAL_CONSOLES = "115200;ttyS0"
 
 INITRAMFS_FSTYPES = "cpio.gz.u-boot"
+FIT_SUPPORTED_INITRAMFS_FSTYPES = "cpio.gz.u-boot"
 
 # To generate bootscript section in FIT image, u-boot needs to be built.
 UBOOT_ARCH = "arm"
 UBOOT_LOADADDRESS ?= "0x8000"
 UBOOT_ENTRYPOINT ?= "${UBOOT_LOADADDRESS}"
+FIT_UBOOT_ENV = "bootscript.txt"
 UBOOT_ENV = "bootscript"
 UBOOT_ENV_BINARY ?= "bootscript.txt"
 # Set to "" to not generate unnecessary /etc/${UBOOT_INITIAL_ENV}* files.

--- a/recipes-connectivity/ti-wifi-utils/files/0001-fix-efuse_param_type_enm.patch
+++ b/recipes-connectivity/ti-wifi-utils/files/0001-fix-efuse_param_type_enm.patch
@@ -2,6 +2,7 @@ From c4d382a73a1c96c4c1568d4b33363d3ce91c42ba Mon Sep 17 00:00:00 2001
 From: Can Wong <can.wong@emerson.com>
 Date: Wed, 22 Oct 2025 14:55:52 -0500
 Subject: [PATCH] fix efuse_param_type_enm
+Upstream-Status: Inappropriate [NI specific]
 
 ---
  plt.h | 2 +-

--- a/recipes-connectivity/ti-wifi-utils/files/0001-fix-packed-member-warning.patch
+++ b/recipes-connectivity/ti-wifi-utils/files/0001-fix-packed-member-warning.patch
@@ -2,6 +2,7 @@ From 868075373104c403bc96f061c3117d762a8dae69 Mon Sep 17 00:00:00 2001
 From: Can Wong <can.wong@emerson.com>
 Date: Wed, 22 Oct 2025 14:48:10 -0500
 Subject: [PATCH] fix packed member warning
+Upstream-Status: Inappropriate [NI specific]
 
 ---
  ini.c | 112 +++++++++++++++++++++++++++++++++++++++++-----------------

--- a/recipes-connectivity/ti-wifi-utils/ti-wifi-utils_git.bb
+++ b/recipes-connectivity/ti-wifi-utils/ti-wifi-utils_git.bb
@@ -8,7 +8,7 @@ PV = "R8.6+git${SRCPV}"
 
 #Tag: R8.6
 SRCREV = "cf8965aad73764022669647fa33852558a657930"
-SRC_URI = "git://git.ti.com/wilink8-wlan/18xx-ti-utils.git;branch=master;tag=${SRCREV} \
+SRC_URI = "git://git.ti.com/wilink8-wlan/18xx-ti-utils.git;protocol=https;branch=master \
            file://0001-fix-packed-member-warning.patch \
            file://0001-fix-efuse_param_type_enm.patch \
 "

--- a/recipes-core/images/includes/nilrt-proprietary.inc
+++ b/recipes-core/images/includes/nilrt-proprietary.inc
@@ -16,7 +16,6 @@ NI_PROPRIETARY_COMMON_PACKAGES = "\
         ni-software-installation-websvc \
         ni-ssl-webserver-support \
         ni-sysapi \
-        ni-sysapi-sshcli \
         ni-sysapi-remote \
         ni-sysapi-webservice \
         ni-sysmgmt-auth-utils \
@@ -36,6 +35,7 @@ NI_PROPRIETARY_COMMON_PACKAGES = "\
 NI_PROPRIETARY_COMMON_PACKAGES:append:x64 = "\
         ni-sdmon \
         ni-wifibledd \
+        ni-sysapi-sshcli \
 "
 
 NI_PROPRIETARY_RUNMODE_PACKAGES = "\

--- a/recipes-core/images/nilrt-runmode-rootfs.bb
+++ b/recipes-core/images/nilrt-runmode-rootfs.bb
@@ -14,6 +14,10 @@ IMAGE_INSTALL:append:x64 = "\
 	nilrt-grub-runmode \
 	"
 
+IMAGE_INSTALL:append:xilinx-zynq = "\
+	linux-nilrt-fitimage \
+	"
+
 require includes/nilrt-image-base.inc
 require includes/nilrt-xfce.inc
 require includes/nilrt-proprietary.inc

--- a/recipes-kernel/linux/linux-nilrt-fitimage.bb
+++ b/recipes-kernel/linux/linux-nilrt-fitimage.bb
@@ -1,0 +1,23 @@
+SUMMARY = "The Linux kernel as a FIT image (optionally with initramfs) for NILRT"
+SECTION = "kernel"
+
+# If an initramfs is included in the FIT image more licenses apply.
+# But also the kernel uses more than one license (see Documentation/process/license-rules.rst)
+LICENSE = "GPL-2.0-with-Linux-syscall-note"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0-with-Linux-syscall-note;md5=0bad96c422c41c3a94009dcfe1bff992"
+
+inherit linux-kernel-base kernel-fit-image
+
+# Set the version of this recipe to the version of the included kernel
+# (without taking the long way around via PV)
+PKGV = "${@get_kernelversion_file("${STAGING_KERNEL_BUILDDIR}")}"
+
+FIT_DESC = "Kernel fitImage for ${DISTRO_NAME}/${PKGV}/${MACHINE}"
+
+DEPENDS += "u-boot"
+
+do_prepare_bootscript() {
+    # Copy bootscript.txt from u-boot’s deploy dir into our sources
+    cp ${DEPLOY_DIR_IMAGE}/bootscript.txt ${UNPACKDIR}/bootscript.txt
+}
+addtask prepare_bootscript before do_compile after do_configure


### PR DESCRIPTION
### Summary of Changes

bitbake nilrt-base-system-image on arm arch fails because of the
 new FIT image implementation in the upstream https://github.com/openembedded/openembedded-core/commit/05d0c7342d7638dbe8a9f2fd3d1c709ee87d6579.

In order to make dist-next BSI buildable on arm arch, we need to create a new recipe that uses the new FIT implementation and builds the required FIT image.

The PR also fixes few build issues encountered while building the BSI.

### Justification

[AB#3711980](https://dev.azure.com/ni/DevCentral/_workitems/edit/3711980/)


### Testing

- [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
- [x]  bitbake nilrt-base-system-image on ARM next
- [x] Tested the changes on NI-cRIO 9147 and NI-cRIO 9068 arm targets by copying the BSI tar file into the target and installing it.

<img width="2337" height="614" alt="image" src="https://github.com/user-attachments/assets/615aefc8-c02a-4407-ba3b-c2536a2402b9" />

<img width="463" height="227" alt="image" src="https://github.com/user-attachments/assets/a70a48ac-1fbe-41fb-ab09-7911a6728971" />

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).

### Note
Dependent PR: https://github.com/ni/openembedded-core/pull/193