### PR TITLE
linux-nilrt-arm-safemode: Set NI specific FIT vars

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-arm-safemode_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-arm-safemode_git.bb
@@ -7,6 +7,9 @@ require linux-nilrt-alternate.inc
 
 INITRAMFS_IMAGE = "nilrt-safemode-initramfs"
 FIT_DESC = "zynq_safemode - ${BUILDNAME}"
+FIT_VERSION = "${BUILDNAME}"
+FIT_DEVICECODE = "0x${@d.getVar('NILRT_ARM_DEVICE_CODES').split()[0]}"
+FIT_DEVICECODES = "${@' '.join('0x' + x for x in (d.getVar('NILRT_ARM_DEVICE_CODES')).split())}"
 
 kernel_do_deploy:append() {
     # Create a symlink that's useful to identify the correct fitImage and is also shorter.


### PR DESCRIPTION
Firmware upgrade scripts require version, DeviceCode, DeviceCodes to be present in FIT image.

Changes have been [made in oe-core](https://github.com/ni/openembedded-core/pull/194) to generate these from FIT_VERSION, FIT_DEVICECODE, FIT_DEVICECODES so set them here.

WI: [AB#3221312](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3221312)


### Testing
- [x] `bitbake linux-nilrt-arm-safemode` with these changes and verified FIT contains the variables.
- [x] cRIO-9068 firmware can be upgraded from 26.3 to the one built with this and https://github.com/ni/openembedded-core/pull/194.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
