### PR TITLE
ni-grpc-device: update PV to 2.18 snapshot and require sideband runtime

### DIFF
--- a/recipes-ni/ni-grpc-device/ni-grpc-device_git.bb
+++ b/recipes-ni/ni-grpc-device/ni-grpc-device_git.bb
@@ -24,7 +24,7 @@ DEPENDS += "\
 	utf8cpp-native \
 "
 
-PV = "2.6.0"
+PV = "2.18.0+git${SRCPV}"
 
 
 SRC_URI = "\
@@ -137,6 +137,7 @@ FILES:${PN} += "\
 "
 RDEPENDS:${PN} += "\
 	grpc \
+	ni-grpc-sideband \
 	protobuf \
 "
 


### PR DESCRIPTION
### Summary of Changes

Update the `ni-grpc-device` recipe to reflect the newer upstream `grpc-device` source currently pinned by `SRCREV`.

This change:
- updates `PV` from `2.6.0` to `2.18.0+git${SRCPV}` so the package version matches the upstream project version while still indicating the source is an unreleased git snapshot
- adds an explicit runtime dependency on `ni-grpc-sideband`

### Justification

The recipe was updated to a much newer `grpc-device` commit, but the package version was still reporting `2.6.0`. Upstream `grpc-device` currently declares `VERSION 2.18.0`, and the pinned NILRT commit is not tagged as an official `v2.18.0` release, so the recipe should identify it as a `2.18.0` git snapshot instead of a released build.

The explicit `ni-grpc-sideband` runtime dependency is needed because `ni-grpc-device` links against the sideband library and the current sideband packaging places the library payload in the `-dev` output due to the unversioned `.so`.

### Testing

Validated with:
- `bitbake -c clean ni-grpc-device`
- `bitbake ni-grpc-device`
- verified that sideband packages were produced in deploy output
- verified pkgdata/runtime dependency resolution for `ni-grpc-device`

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).