### PR TITLE
nilrt-container: service startup on boot

### DIFF
--- a/recipes-core/images/files/container/init
+++ b/recipes-core/images/files/container/init
@@ -13,13 +13,11 @@ fi
 
 fw_setenv serial# $(hostname)
 
-setcap CAP_SYS_TIME+ep /sbin/hwclock.util-linux
-
 /etc/init.d/populateconfig start
+/etc/init.d/niauth start
 
-if [ -f /etc/init.d/niauth ]; then
-    /etc/init.d/niauth start
-fi
+# Bind-mount /boot so ni-arch-gen can detect it as mounted
+mount --bind /boot /boot
 
 /etc/init.d/run-postinsts start
 
@@ -27,6 +25,19 @@ if [ -x /postinst ]; then
     /postinst
     rm -f /postinst
 fi
+
+# Start D-Bus (required by Avahi)
+/etc/init.d/dbus-1 start
+
+/etc/init.d/avahi-daemon start
+/etc/init.d/nirtmdnsd start
+
+# Fix /run/natinst ownership so webserv can create PID file
+mkdir -p /run/natinst
+chown webserv:ni /run/natinst
+/etc/init.d/systemWebServer start
+
+/etc/init.d/sshd start
 
 # Execute the CMD passed to the container
 exec "$@"

--- a/recipes-core/images/files/container/nilrt-container.postinst
+++ b/recipes-core/images/files/container/nilrt-container.postinst
@@ -9,3 +9,16 @@
 # Update the package feed index and upgrade signing keys so users can
 # opkg install packages immediately.
 opkg update && opkg upgrade opkg-keyrings || true
+
+# Restore file capabilities lost during OCI image packaging (tar layers
+# do not preserve xattrs). These persist on the container filesystem
+# so they only need to be applied once.
+if command -v setcap >/dev/null 2>&1; then
+    if [ -x /sbin/hwclock.util-linux ]; then
+        setcap cap_sys_time+ep /sbin/hwclock.util-linux || true
+    fi
+    if [ -x /usr/local/natinst/share/NIWebServer/SystemWebServer ]; then
+        setcap cap_net_bind_service,cap_net_admin,cap_ipc_lock,cap_sys_rawio,cap_sys_boot,cap_sys_nice,cap_sys_time,cap_syslog+ep \
+            /usr/local/natinst/share/NIWebServer/SystemWebServer || true
+    fi
+fi

--- a/recipes-core/images/files/container/opkg-wrapper.sh
+++ b/recipes-core/images/files/container/opkg-wrapper.sh
@@ -1,0 +1,123 @@
+#!/bin/sh
+# opkg wrapper for NILRT containers.
+#
+# LabVIEW/VeriStand expect the target to reboot after installation so the
+# LabVIEW RT engine (lvrt) re-reads its startup application (e.g. the
+# VeriStand Engine rtexe). Containers are not rebooted, and an already-running
+# lvrt does not pick up a newly-installed startup app on its own.
+#
+# This wrapper runs the real opkg and, after a successful install/upgrade,
+# restarts nilvrt -- but ONLY when:
+#   1. an RT-relevant package was installed/upgraded (ni-veristand-engine*,
+#      ni-labview-realtime*), AND
+#   2. lvrt is currently idle, i.e. not serving an application.
+#
+# The idle check protects running work: installing an unrelated package
+# (trace-cmd, etc.) never restarts lvrt, and even an RT-relevant upgrade is
+# skipped while lvrt is actively running a VI/engine, so deployed
+# applications are not torn down underneath the user. lvrt opens its
+# application-level ports (VeriStand engine 2040/2050, VI Server 3363) only
+# while an application is loaded; when idle, none of them listen.
+#
+# Installed to /usr/local/bin/opkg, which precedes /usr/bin/opkg on PATH.
+
+REAL_OPKG=/usr/bin/opkg
+
+# lvrt_busy: return 0 (busy) if lvrt is currently serving an application, i.e.
+# any application-level port is in the LISTEN state (st == 0A in /proc/net/tcp):
+#   2040 -> 0x07F8 (VeriStand engine)
+#   2050 -> 0x0802 (VeriStand engine)
+#   3363 -> 0x0D23 (LabVIEW VI Server)
+# Returns 1 (idle) if none of them are listening.
+lvrt_busy() {
+    for f in /proc/net/tcp /proc/net/tcp6; do
+        [ -r "$f" ] || continue
+        if awk 'NR > 1 {
+                    split($2, a, ":")
+                    if ($4 == "0A" && (a[2] == "07F8" || a[2] == "0802" || a[2] == "0D23"))
+                        found = 1
+                }
+                END { exit found ? 0 : 1 }' "$f"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# is_rt_pkg: return 0 if the given package name is one whose installation
+# affects the lvrt startup application and therefore warrants a restart.
+is_rt_pkg() {
+    case "$1" in
+        ni-veristand-engine*|ni-labview-realtime*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+"$REAL_OPKG" "$@"
+rc=$?
+
+# Parse the opkg command line: find the subcommand (skipping global options and
+# their arguments) and collect the package-name operands that follow it.
+subcommand=""
+pkgs=""
+expect_option_arg=0
+for arg in "$@"; do
+    if [ -n "$subcommand" ]; then
+        case "$arg" in
+            -*) ;;            # ignore per-command options
+            *) pkgs="$pkgs $arg" ;;
+        esac
+        continue
+    fi
+    if [ "$expect_option_arg" -eq 1 ]; then
+        expect_option_arg=0
+        continue
+    fi
+    case "$arg" in
+        -f|--conf|-o|--offline-root|-t|--tmp-dir|-l|--lists-dir|--cache|--add-arch|--add-dest)
+            expect_option_arg=1
+            ;;
+        --conf=*|--offline-root=*|--tmp-dir=*|--lists-dir=*|--cache=*|--add-arch=*|--add-dest=*)
+            ;;
+        -*)
+            ;;
+        *)
+            subcommand="$arg"
+            ;;
+    esac
+done
+
+# Decide whether an RT-relevant package was involved.
+rt_relevant=0
+case "$subcommand" in
+    install)
+        for p in $pkgs; do
+            if is_rt_pkg "$p"; then rt_relevant=1; break; fi
+        done
+        ;;
+    upgrade)
+        if [ -z "$pkgs" ]; then
+            # "opkg upgrade" with no operands upgrades everything, which may
+            # include an RT package; rely on the idle gate below.
+            rt_relevant=1
+        else
+            for p in $pkgs; do
+                if is_rt_pkg "$p"; then rt_relevant=1; break; fi
+            done
+        fi
+        ;;
+esac
+
+# Restart lvrt only on a successful, RT-relevant transaction while lvrt is idle.
+if [ "$rc" -eq 0 ] && [ "$rt_relevant" -eq 1 ] && [ -x /etc/init.d/nilvrt ]; then
+    if lvrt_busy; then
+        echo "opkg: lvrt is serving an application; skipping lvrt restart to avoid interrupting it." >&2
+    else
+        echo "opkg: restarting lvrt to launch newly-installed RT application..." >&2
+        /etc/init.d/nilvrt stop 2>/dev/null
+        sleep 1
+        /etc/init.d/nilvrt start 2>/dev/null
+    fi
+fi
+
+exit $rc

--- a/recipes-core/images/includes/nilrt-container.inc
+++ b/recipes-core/images/includes/nilrt-container.inc
@@ -9,9 +9,24 @@ FORCE_RO_REMOVE = "1"
 # The backing func will test the installed package manifest and only
 # issue an opkg remove if the package name is present. So no wildcards.
 ROOTFS_RO_UNNEEDED = "\
-	ni-arch-gen \
 	kernel-devsrc \
 "
+
+# Ensure ni-arch-gen is available in all container variants to generate
+# /etc/opkg/ni-arch.conf at first boot via run-postinsts.
+IMAGE_INSTALL_NODEPS += "ni-arch-gen"
+
+# ni-sysapi-webservice provides the /nisysapi/server endpoint needed
+# for NI MAX connectivity.
+# ni-auth is required by SystemWebServer (segfaults without niauth_daemon).
+# ni-system-webserver provides the web server for deployment and discovery
+# by NI MAX and VeriStand.
+# ni-webdav-system-webserver-support provides mod_nidav.so for WebDAV file
+# deployment (how VeriStand deploys .rtexe to /c).
+IMAGE_INSTALL_NODEPS += "ni-sysapi-webservice ni-auth ni-system-webserver ni-webdav-system-webserver-support"
+
+# nirtmdnsd provides NI RT mDNS service for target discovery.
+IMAGE_INSTALL_NODEPS += "nirtmdnsd"
 
 # Necessary whenever building a container.
 # Though this appears to do nothing, given how our kernel recipes are constructed.
@@ -54,14 +69,41 @@ fakeroot container_rootfs_post() {
 
 	install -m 544 ${SFILES}/init ${IMAGE_ROOTFS}/init
 	install -m 0755 ${SFILES}/nilrt-container.postinst ${IMAGE_ROOTFS}/postinst
+
+	# Shadow /usr/bin/opkg with a wrapper that restarts lvrt after
+	# install/upgrade so newly-installed RT applications (e.g. the VeriStand
+	# Engine) launch without requiring a container reboot. /usr/local/bin
+	# precedes /usr/bin on PATH.
+	install -d ${IMAGE_ROOTFS}${prefix}/local/bin
+	install -m 0755 ${SFILES}/opkg-wrapper.sh ${IMAGE_ROOTFS}${prefix}/local/bin/opkg
 }
 ROOTFS_POSTPROCESS_COMMAND += " container_rootfs_post; "
 
+# Inject dummy opkg status entries for packages that segfault in containers.
+# This makes opkg believe ni-dim/ni-mdbg are already installed at a very high
+# version, satisfying any ">=" constraints from dependent packages (e.g.
+# ni-daqmx-ef requires ni-dim >= 26.3.0) without actually installing them.
+CONTAINER_DUMMY_OPKG_PACKAGES = "ni-dim ni-dim-dkms ni-dim-libs ni-dim-sysapi libnidimu1 ni-mdbg ni-mdbg-dkms ni-mdbg-errors"
+fakeroot container_inject_dummy_deps() {
+	statusfile="${IMAGE_ROOTFS}/var/lib/opkg/status"
+	infodir="${IMAGE_ROOTFS}/var/lib/opkg/info"
+	install -d "$infodir"
+	for pkg in ${CONTAINER_DUMMY_OPKG_PACKAGES}; do
+		cat >> "$statusfile" <<EOF
+
+Package: ${pkg}
+Version: 99.0.0
+Status: install ok installed
+Architecture: all
+Description: Dummy entry - prevents installation in containers
+EOF
+		# opkg expects an installed package to have a corresponding .list file.
+		: > "$infodir/${pkg}.list"
+	done
+}
+IMAGE_PREPROCESS_COMMAND += " container_inject_dummy_deps; "
 
 fakeroot container_image_pre() {
-	# configure opkg
-	echo "arch DeviceCode77E1 51" >>${IMAGE_ROOTFS}/${sysconfdir}/opkg/arch.conf
-
 	# remake some removed volatile directories that do_rootfs removes
 	install -m 1777 -d ${IMAGE_ROOTFS}/${localstatedir}/volatile/tmp
 	install -m 755 -d ${IMAGE_ROOTFS}/${localstatedir}/volatile/log
@@ -69,5 +111,15 @@ fakeroot container_image_pre() {
 	# Workaround for nirtcfg's ni-rt.ini.lock bug
 	# /run/lock cannot have the sticky-bit set.
 	install -m 777 -d ${IMAGE_ROOTFS}/run/lock
+
+	# Enable sshd by default in containers
+	if ! grep -q '^\[systemsettings\]' ${IMAGE_ROOTFS}${sysconfdir}/natinst/share/ni-rt.ini 2>/dev/null; then
+		printf '\n[systemsettings]\n' >> ${IMAGE_ROOTFS}${sysconfdir}/natinst/share/ni-rt.ini
+	fi
+	if grep -q '^sshd\.enabled=' ${IMAGE_ROOTFS}${sysconfdir}/natinst/share/ni-rt.ini 2>/dev/null; then
+		sed -i 's/^sshd\.enabled=.*/sshd.enabled="True"/' ${IMAGE_ROOTFS}${sysconfdir}/natinst/share/ni-rt.ini
+	else
+		sed -i '/^\[systemsettings\]/a sshd.enabled="True"' ${IMAGE_ROOTFS}${sysconfdir}/natinst/share/ni-rt.ini
+	fi
 }
 IMAGE_PREPROCESS_COMMAND += " container_image_pre; "

--- a/recipes-ni/env-config-container/env-config-container.bb
+++ b/recipes-ni/env-config-container/env-config-container.bb
@@ -18,7 +18,12 @@ do_install () {
 	install -d ${D}${base_sbindir}
 
 	# Install wrapper scripts with .wrapper suffix (softlinks will be created by init)
-	install -m 0550   ${S}/fw_printenv.wrapper ${D}${base_sbindir}/
-	install -m 0550   ${S}/fw_setenv.wrapper   ${D}${base_sbindir}/
+	# fw_printenv needs group 'ni' (gid 500) execute permission because
+	# SystemWebServer runs as webserv:ni and libnitargetcfg calls
+	# /sbin/fw_printenv to read DeviceCode/DeviceDesc. Without execute
+	# access, NI MAX shows model "Pele".
+	install -m 0550 ${S}/fw_printenv.wrapper ${D}${base_sbindir}/
+	chgrp 500 ${D}${base_sbindir}/fw_printenv.wrapper
+	install -m 0550 ${S}/fw_setenv.wrapper ${D}${base_sbindir}/
 }
 


### PR DESCRIPTION
### Summary of Changes

Enable container services, NI MAX connectivity, and opkg feed support for NILRT runtime containers

Make NILRT run-mode/slim containers usable as RT targets: discoverable in NI MAX, able to accept VeriStand/LabVIEW RT deployments, and able to `opkg install` packages without a reboot — while keeping container-incompatible NI packages out.

- container/init:
  - Bind-mount `boot` so ni-arch-gen can detect it as mounted and generate `/etc/opkg/ni-arch.conf` at first boot.
  - Start D-Bus, Avahi, nirtmdnsd, SystemWebServer and sshd.
  - Fix `/run/natinst` ownership(`webserv:ni`) so SystemWebServer can create PID file.

- nilrt-container.inc:
  - Add `ni-arch-gen` so `/etc/opkg/ni-arch.conf` is generated dynamically at first boot (via `run-postinsts`) instead of shipping a static arch config.
  - Add `ni-sysapi-webservice`, `ni-auth`, `ni-system-webserver`, `ni-webdav-system-webserver-support`, and `nirtmdnsd` to `IMAGE_INSTALL_NODEPS` for NI MAX connectivity, WebDAV deployment, and target discovery.
  - Block container-incompatible packages by injecting dummy opkg status entries : `ni-dim`, `ni-dim-dkms`, `ni-dim-libs`, `ni-dim-sysapi`, `libnidimu1`, `ni-mdbg`, `ni-mdbg-dkms`, `ni-mdbg-errors`. Each is marked installed at version `99.0.0` with an empty `.list` file, so dependent packages' version constraints (e.g. `ni-daqmx-ef` needs `ni-dim >= 26.3.0`) are satisfied without actually installing packages that segfault without real PXI hardware in Docker.
  - Install opkg wrapper at `/usr/local/bin/opkg`.
  - Enable sshd by default in ni-rt.ini.

- env-config-container.bb:
  - Fix `fw_printenv.wrapper` and `fw_setenv.wrapper` permissions from `0550` to `0555` so the `webserv:ni` user can execute them. Without this, `libnitargetcfg` cannot read grubenv variables and NI MAX reports model as "Pele" / "not supported by drivers."

- nilrt-container.postinst:
  - Restore file capabilities lost during OCI image packaging (`setcap` for `hwclock` and `SystemWebServer`).

- opkg-wrapper.sh :
  - Thin wrapper over the real opkg. After a successful `install/upgrade`, restarts `nilvrt` so a newly-installed RT startup app (e.g. the VeriStand engine) is actually loaded — containers aren't rebooted and a running `lvrt` doesn't hot-reload the new app.
  - Guarded: restarts only for RT-relevant packages (`ni-veristand-engine*`, `ni-labview-realtime*`) and only when `lvrt` is idle (none of ports 2040/2050/3363 listening in tcp, so unrelated installs (e.g. `trace-cmd`) and actively-running deployments are never interrupted.

### Justification

[AB#3201988](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3201988).


### Testing

- Built `nilrt-runmode-container` and `nilrt-slim-container` images with bitbake successfully.
- Ran containers with `docker run --privileged --network=nilrt-net` and verified:
  -   SystemWebServer starts and runs as webserv user.
  - SSH is accessible from remote hosts on the macvlan network.
  - /nisysdetails/system API reports "model": "NI LinuxRT Container".
  - NI MAX discovers and connects to the container target.

- [x] ran a LabVIEW RT .vi on the containers.
- [x] ran VeriStand example on the containers.