### PR TITLE
images: add first-boot postinst for containers

### DIFF
--- a/recipes-core/images/files/container/init
+++ b/recipes-core/images/files/container/init
@@ -23,5 +23,10 @@ fi
 
 /etc/init.d/run-postinsts start
 
+if [ -x /postinst ]; then
+    /postinst
+    rm -f /postinst
+fi
+
 # Execute the CMD passed to the container
 exec "$@"

--- a/recipes-core/images/files/container/nilrt-container.postinst
+++ b/recipes-core/images/files/container/nilrt-container.postinst
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Copyright (c) 2025 National Instruments
+#
+# Post-installation script for NILRT container images.
+# Runs once on first container start to update the opkg feed index
+# and upgrade signing keys.
+
+# Update the package feed index and upgrade signing keys so users can
+# opkg install packages immediately.
+opkg update && opkg upgrade opkg-keyrings || true

--- a/recipes-core/images/includes/nilrt-container.inc
+++ b/recipes-core/images/includes/nilrt-container.inc
@@ -53,6 +53,7 @@ fakeroot container_rootfs_post() {
 	install ${SFILES}/grubenv ${IMAGE_ROOTFS}/boot/grub/grubenv
 
 	install -m 544 ${SFILES}/init ${IMAGE_ROOTFS}/init
+	install -m 0755 ${SFILES}/nilrt-container.postinst ${IMAGE_ROOTFS}/postinst
 }
 ROOTFS_POSTPROCESS_COMMAND += " container_rootfs_post; "
 


### PR DESCRIPTION
### Summary of Changes

Adds a container postinst that runs `opkg update + opkg upgrade opkg-keyrings` on first container start. Without this, users must manually run `opkg update` before installing packages.

- Runs after `run-postinsts` (needs GPG keys populated first)
- Deleted after first execution — does not re-run on container restart
- Fails gracefully if no network (|| true)
- Works with both Docker and Podman

** [For more context](https://dev.azure.com/ni/DevCentral/_workitems/edit/3202008#11087828)

### Justification

[AB#3202008](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3202008)


### Testing
- [x] - Verified inside Docker container (slim + runmode):
- First run → opkg update downloads all 7 feeds, opkg upgrade opkg-keyrings completes with "No packages installed or removed"
- opkg list | grep onboard → packages listed (feed index cached)
- test ! -f /postinst → postinst deleted after execution
- docker start -a <container> → no opkg update output (postinst not re-run)

- [x] Verified inside Podman container (slim + runmode):
- First run → opkg update downloads all 7 feeds, CMD executes
- podman start -a <container> → no opkg update output (postinst not re-run)

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
