### PR TITLE
ARM safemode changes to work on low memory targets

### DIFF
--- a/recipes-bsp/u-boot/files/0001-tools-Add-fdtview-a-tool-to-validate-FIT-images.patch
+++ b/recipes-bsp/u-boot/files/0001-tools-Add-fdtview-a-tool-to-validate-FIT-images.patch
@@ -1,0 +1,590 @@
+From 69ea62a6c6b925a9fc4a6a92f852c3d8ef29c4b0 Mon Sep 17 00:00:00 2001
+From: Chaitanya Vadrevu <chaitanya.vadrevu@emerson.com>
+Date: Fri, 24 Apr 2026 16:03:12 -0500
+Subject: [PATCH] tools: Add fdtview, a tool to validate FIT images
+
+Upstream-Status: Inappropriate [NI specific]
+
+Signed-off-by: Chaitanya Vadrevu <chaitanya.vadrevu@emerson.com>
+---
+ tools/Makefile  |   4 +-
+ tools/fdtview.c | 541 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 544 insertions(+), 1 deletion(-)
+ create mode 100644 tools/fdtview.c
+
+diff --git a/tools/Makefile b/tools/Makefile
+index 1aa1e36137b..5d7fc165e6c 100644
+--- a/tools/Makefile
++++ b/tools/Makefile
+@@ -63,7 +63,7 @@ HOSTCFLAGS_img2srec.o := -pedantic
+ hostprogs-y += mkenvimage
+ mkenvimage-objs := mkenvimage.o os_support.o generated/lib/crc32.o
+ 
+-hostprogs-y += dumpimage mkimage
++hostprogs-y += dumpimage mkimage fdtview
+ hostprogs-$(CONFIG_TOOLS_LIBCRYPTO) += fit_info fit_check_sign
+ hostprogs-$(CONFIG_TOOLS_LIBCRYPTO) += fdt_add_pubkey
+ 
+@@ -151,6 +151,7 @@ dumpimage-mkimage-objs := aisimage.o \
+ 
+ dumpimage-objs := $(dumpimage-mkimage-objs) dumpimage.o
+ mkimage-objs   := $(dumpimage-mkimage-objs) mkimage.o
++fdtview-objs   := $(dumpimage-mkimage-objs) fdtview.o
+ fit_info-objs   := $(dumpimage-mkimage-objs) fit_info.o
+ fit_check_sign-objs   := $(dumpimage-mkimage-objs) fit_check_sign.o
+ fdt_add_pubkey-objs   := $(dumpimage-mkimage-objs) fdt_add_pubkey.o
+@@ -189,6 +190,7 @@ endif
+ HOSTCFLAGS_fit_image.o += -DMKIMAGE_DTC=\"$(CONFIG_MKIMAGE_DTC_PATH)\"
+ 
+ HOSTLDLIBS_dumpimage := $(HOSTLDLIBS_mkimage)
++HOSTLDLIBS_fdtview := $(HOSTLDLIBS_mkimage)
+ HOSTLDLIBS_fit_info := $(HOSTLDLIBS_mkimage)
+ HOSTLDLIBS_fit_check_sign := $(HOSTLDLIBS_mkimage)
+ HOSTLDLIBS_fdt_add_pubkey := $(HOSTLDLIBS_mkimage)
+diff --git a/tools/fdtview.c b/tools/fdtview.c
+new file mode 100644
+index 00000000000..e4397572554
+--- /dev/null
++++ b/tools/fdtview.c
+@@ -0,0 +1,541 @@
++
++#include "os_support.h"
++#include <errno.h>
++#include <fcntl.h>
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++#include <sys/ioctl.h>
++#include <sys/types.h>
++#include <sys/stat.h>
++#include <time.h>
++#include <unistd.h>
++#include <u-boot/sha1.h>
++#include "fdt_host.h"
++#include <image.h>
++#include <ctype.h>
++#include <mtd/mtd-user.h>
++
++#define MAX_LEVEL	32		/* how deeply nested we will go */
++
++static void usage(void);
++
++struct fdtview_params {
++	char *path;
++	char *propname;
++	char *imagefile;
++	char *cmdname;
++	int lflag;
++	int oflag;
++	int pflag;
++	int iflag;
++} params;
++
++/*
++ * Heuristic to guess if this is a string or concatenated strings.
++ */
++static int is_printable_string(const void *data, int len)
++{
++	const char *s = data;
++
++	/* zero length is not */
++	if (len == 0)
++		return 0;
++
++	/* must terminate with zero */
++	if (s[len - 1] != '\0' && s[len - 1] != '\n')
++		return 0;
++
++	/* printable or a null byte (concatenated strings) */
++	while (((*s == '\0') || isprint(*s) || isspace(*s)) && (len > 0)) {
++		/*
++		 * If we see a null, there are three possibilities:
++		 * 1) If len == 1, it is the end of the string, printable
++		 * 2) Next character also a null, not printable.
++		 * 3) Next character not a null, continue to check.
++		 */
++		if (s[0] == '\0') {
++			if (len == 1)
++				return 1;
++			if (s[1] == '\0')
++				return 0;
++		}
++		s++;
++		len--;
++	}
++
++	/* Not the null termination, or not done yet: not printable */
++	if (*s != '\0' || len != 0)
++		return 0;
++
++	return 1;
++}
++
++/*
++ * Print the property in the best format, a heuristic guess.  Print as
++ * a string, concatenated strings, a byte, word, double word, or (if all
++ * else fails) it is printed as a stream of bytes.
++ */
++static void print_data(const void *data, int len)
++{
++	int j;
++
++	/* no data, don't print */
++	if (len == 0)
++		return;
++
++	/*
++	 * It is a string, but it may have multiple strings (embedded '\0's).
++	 */
++	if (is_printable_string(data, len)) {
++		printf("\"");
++		j = 0;
++		while (j < len) {
++			if (j > 0)
++				printf("\", \"");
++			printf(data);
++			j    += strlen(data) + 1;
++			data += strlen(data) + 1;
++		}
++		printf("\"");
++		return;
++	}
++
++	if ((len %4) == 0) {
++		const unsigned int *p;
++
++		printf("<");
++		for (j = 0, p = data; j < len/4; j ++)
++			printf("0x%x%s", fdt32_to_cpu(p[j]), j < (len/4 - 1) ? " " : "");
++		printf(">");
++	} else { /* anything else... hexdump */
++		const unsigned char *s;
++
++		printf("[");
++		for (j = 0, s = data; j < len; j++)
++			printf("%02x%s", s[j], j < len - 1 ? " " : "");
++		printf("]");
++	}
++}
++
++/*
++ * Recursively print (a portion of) the working_fdt.  The depth parameter
++ * determines how deeply nested the fdt is printed.
++ */
++static int fdt_print(unsigned char *working_fdt, const char *pathp,
++			char *prop, int depth)
++{
++	static char tabs[MAX_LEVEL+1] =
++		"\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t"
++		"\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t";
++	const void *nodep;	/* property node pointer */
++	int  nodeoffset;	/* node offset from libfdt */
++	int  nextoffset;	/* next node offset from libfdt */
++	uint32_t tag;		/* tag */
++	int  len;		/* length of the property */
++	int  level = 0;		/* keep track of nesting level */
++	const struct fdt_property *fdt_prop;
++
++	nodeoffset = fdt_path_offset(working_fdt, pathp);
++	if (nodeoffset < 0) {
++		/*
++		 * Not found or something else bad happened.
++		 */
++		printf ("libfdt fdt_path_offset() returned %s\n",
++			fdt_strerror(nodeoffset));
++		return 1;
++	}
++	/*
++	 * The user passed in a property as well as node path.
++	 * Print only the given property and then return.
++	 */
++	if (prop) {
++		nodep = fdt_getprop(working_fdt, nodeoffset, prop, &len);
++		if (len == 0) {
++			/* no property value */
++			printf("%s %s\n", pathp, prop);
++			return 0;
++		} else if (len > 0) {
++			printf("%s = ", prop);
++			print_data (nodep, len);
++			printf("\n");
++			return 0;
++		} else {
++			printf("libfdt fdt_getprop(): %s\n",
++				fdt_strerror(len));
++			return 1;
++		}
++	}
++
++	/*
++	 * The user passed in a node path and no property,
++	 * print the node and all subnodes.
++	 */
++	while(level >= 0) {
++		tag = fdt_next_tag(working_fdt, nodeoffset, &nextoffset);
++		switch(tag) {
++		case FDT_BEGIN_NODE:
++			pathp = fdt_get_name(working_fdt, nodeoffset, NULL);
++			if (level <= depth) {
++				if (pathp == NULL)
++					pathp = "/* NULL pointer error */";
++				if (*pathp == '\0')
++					pathp = "/";	/* root is nameless */
++				printf("%s%s {\n",
++					&tabs[MAX_LEVEL - level], pathp);
++			}
++			level++;
++			if (level >= MAX_LEVEL) {
++				printf("Nested too deep, aborting.\n");
++				return 1;
++			}
++			break;
++		case FDT_END_NODE:
++			level--;
++			if (level <= depth)
++				printf("%s};\n", &tabs[MAX_LEVEL - level]);
++			if (level == 0) {
++				level = -1;		/* exit the loop */
++			}
++			break;
++		case FDT_PROP:
++			fdt_prop = fdt_offset_ptr(working_fdt, nodeoffset,
++					sizeof(*fdt_prop));
++			pathp    = fdt_string(working_fdt,
++					fdt32_to_cpu(fdt_prop->nameoff));
++			len      = fdt32_to_cpu(fdt_prop->len);
++			nodep    = fdt_prop->data;
++			if (len < 0) {
++				printf ("libfdt fdt_getprop(): %s\n",
++					fdt_strerror(len));
++				return 1;
++			} else if (len == 0) {
++				/* the property has no value */
++				if (level <= depth)
++					printf("%s%s;\n",
++						&tabs[MAX_LEVEL - level],
++						pathp);
++			} else {
++				if (level <= depth) {
++					printf("%s%s = ",
++						&tabs[MAX_LEVEL - level],
++						pathp);
++					print_data (nodep, len);
++					printf(";\n");
++				}
++			}
++			break;
++		case FDT_NOP:
++			printf("%s/* NOP */\n", &tabs[MAX_LEVEL - level]);
++			break;
++		case FDT_END:
++			return 1;
++		default:
++			if (level <= depth)
++				printf("Unknown tag 0x%08X\n", tag);
++			return 1;
++		}
++		nodeoffset = nextoffset;
++	}
++	return 0;
++}
++
++int main (int argc, char **argv)
++{
++	int ifd = -1;
++	struct stat sbuf;
++	unsigned char *working_fdt;
++	int retval = 0;
++	struct mtd_info_user mtd;
++	off_t file_size = 0;
++	int mmap_failed = 0;
++
++	params.cmdname = *argv;
++	params.lflag = 0;
++	params.oflag = 0;
++	params.pflag = 0;
++	params.iflag = 0;
++
++	while (--argc > 0 && **++argv == '-') {
++		while (*++*argv) {
++			switch (**argv) {
++			case 'l':
++				if (argc <= 1)
++					usage();
++				if (argc >= 3) {
++					params.path = *++argv;
++					--argc;
++				} else {
++					params.path = NULL;
++				}
++				if (argc == 3) {
++					params.propname = *++argv;
++					--argc;
++				} else {
++					params.propname = NULL;
++				}
++				params.lflag = 1;
++				goto NXTARG;
++			case 'o':
++				--argc;
++				if (--argc <= 1)
++					usage();
++				params.path = *++argv;
++				params.propname = *++argv;
++				params.oflag = 1;
++				goto NXTARG;
++			case 'p':
++				if (argc <= 1)
++					usage();
++				if (argc >= 3) {
++					params.path = *++argv;
++					--argc;
++				} else {
++					params.path = NULL;
++				}
++				if (argc == 3) {
++					params.propname = *++argv;
++					--argc;
++				} else {
++					params.propname = NULL;
++				}
++				params.pflag = 1;
++				goto NXTARG;
++			case 'i':
++				if (argc <= 1)
++					usage();
++				params.iflag = 1;
++				goto NXTARG;
++			default:
++				usage();
++			}
++		}
++NXTARG:		;
++	}
++
++	if (argc != 1)
++		usage();
++
++	if (!params.lflag && !params.oflag && !params.pflag && !params.iflag)
++		usage();
++
++	params.imagefile = *argv;
++
++	ifd = open(params.imagefile, O_RDONLY|O_BINARY|O_SYNC);
++
++	if (ifd < 0) {
++		fprintf(stderr, "%s: Can't open %s: %s\n",
++			params.cmdname, params.imagefile,
++			strerror(errno));
++		exit(EXIT_FAILURE);
++	}
++
++	if (fstat(ifd, &sbuf) < 0) {
++		fprintf(stderr, "%s: Can't stat %s: %s\n",
++			params.cmdname, params.imagefile,
++			strerror(errno));
++		exit(EXIT_FAILURE);
++	} else {
++		file_size = sbuf.st_size;
++	}
++
++	if((sbuf.st_rdev & 0xFF00) == 0x1F00) {
++		fprintf(stderr, "%s: Can't access the block interface to %s\n",
++			params.cmdname, params.imagefile);
++		exit(EXIT_FAILURE);
++	}
++	if((sbuf.st_rdev & 0xFF00) == 0x5A00) {
++		if (ioctl (ifd, MEMGETINFO, mtd) < 0) {
++			fprintf(stderr, "%s: Can't query mem info for %s: %s\n",
++				params.cmdname, params.imagefile,
++				strerror(errno));
++			exit(EXIT_FAILURE);
++		} else {
++			file_size = mtd.size;
++		}
++	}
++
++	if ((unsigned)file_size < sizeof(struct legacy_img_hdr)) {
++		fprintf(stderr,
++			"%s: Bad size: \"%s\" is not valid image\n",
++			params.cmdname, params.imagefile);
++		exit(EXIT_FAILURE);
++	}
++
++	working_fdt = mmap(0, file_size, PROT_READ, MAP_SHARED, ifd, 0);
++	if (working_fdt == MAP_FAILED) {
++		int readsize;
++		int totalsize;
++		mmap_failed = 1;
++
++		printf("mmap() failed.  Falling back to read.");
++		working_fdt = malloc(sizeof(struct legacy_img_hdr));
++		if (working_fdt == NULL) {
++			fprintf(stderr, "%s: malloc of %d bytes (header) failed: %s\n",
++				params.cmdname, (int) file_size,
++				strerror(errno));
++			retval = 1;
++			goto error;
++		}
++		if ((readsize = read(ifd, working_fdt, sizeof(struct legacy_img_hdr))) < 0) {
++			fprintf(stderr, "%s: Can't read header from %s: %s\n",
++				params.cmdname, params.imagefile,
++				strerror(errno));
++			retval = readsize;
++			goto error;
++		}
++		if ((retval = fdt_check_header((void *)working_fdt)) < 0) {
++			if (!params.iflag || !image_check_magic(
++			    (struct legacy_img_hdr *)working_fdt)) {
++				fprintf(stderr, "%s: Invalid image %s\n",
++					params.cmdname, params.imagefile);
++				goto error;
++			}
++		}
++		totalsize = fdt_totalsize(working_fdt);
++		if (totalsize < 0) {
++			fprintf(stderr, "%s: Invalid image size: %d\n",
++				params.cmdname, totalsize);
++			retval = totalsize;
++			goto error;
++		}
++		if (file_size > totalsize) file_size = totalsize;
++		working_fdt = realloc(working_fdt, file_size);
++		if (working_fdt == NULL) {
++			fprintf(stderr, "%s: malloc of %d bytes failed: %s\n",
++				params.cmdname, (int) file_size,
++				strerror(errno));
++			retval = 1;
++			goto error;
++		}
++		if (read(ifd, working_fdt + readsize, file_size - readsize) < 0) {
++			fprintf(stderr, "%s: Can't read %s: %s\n",
++				params.cmdname, params.imagefile,
++				strerror(errno));
++			retval = readsize;
++			goto error;
++		}
++	}
++
++	if ((retval = fdt_check_header((void *)working_fdt)) < 0) {
++		if (!params.iflag || !image_check_magic(
++		    (struct legacy_img_hdr *)working_fdt)) {
++			fprintf(stderr, "%s: Invalid image %s\n",
++				params.cmdname, params.imagefile);
++			goto error;
++		}
++	}
++
++	if (params.oflag) {
++		int offset;
++		offset = fdt_path_offset(working_fdt, params.path);
++		if (offset > 0) {
++			int propLength = 0;
++			const unsigned char* propData = (const uint8_t*)fdt_getprop(working_fdt, offset, params.propname, &propLength);
++			if (propLength >= 0) {
++				printf("%ld %d\n", propData - working_fdt, propLength);
++			}
++		} else {
++			retval = offset;
++			goto error;
++		}
++	} else if (params.lflag || params.pflag) {
++		int depth = MAX_LEVEL;	/* how deep to print */
++		static char root[2] = "/";
++
++		/*
++		 * list is an alias for print, but limited to 1 level
++		 */
++		if (params.lflag)
++			depth = 1;
++
++		/*
++		 * Get the starting path.  The root node is an oddball,
++		 * the offset is zero and has no name.
++		 */
++		if (params.path == NULL)
++			params.path = root;
++
++		retval = fdt_print(working_fdt, params.path, params.propname, depth);
++	} else if (params.iflag) {
++		if (retval) {
++			void *hdr = working_fdt;
++
++			retval = 0;
++			puts("   Legacy image found\n");
++
++			if (!image_check_hcrc(hdr)) {
++				puts("   Bad Header Checksum\n");
++				retval = 1;
++			} else {
++				image_print_contents(hdr);
++
++				puts("   Verifying Checksum ... ");
++				if (!image_check_dcrc(hdr)) {
++					puts("   Bad Data CRC\n");
++					retval = 1;
++				}
++			}
++		} else {
++			puts("   FIT image found\n");
++
++			if (fit_check_format(working_fdt, IMAGE_SIZE_INVAL)) {
++				puts("Bad FIT image format!\n");
++				retval = 1;
++			} else {
++				fit_print_contents(working_fdt);
++
++				if (!fit_all_image_verify(working_fdt)) {
++					puts("Bad hash in FIT image!\n");
++					retval = 1;
++				}
++			}
++		}
++	} else {
++	/*
++		int depth = 0;
++		int offset;
++		int imagePathOffset = fdt_path_offset(working_fdt, "/images");
++		if (imagePathOffset < 0) {
++			fprintf (stderr, "%s: Invalid FIT blob %s\n",
++				params.cmdname, params.imagefile);
++			exit (EXIT_FAILURE);
++		}
++		offset = fdt_next_node(working_fdt, imagePathOffset, &depth);
++		while ((offset >= 0) && (depth > 0))
++		{
++			if (depth == 1)
++			{
++				const char* imageName = fdt_get_name(working_fdt, offset, NULL);
++				int imageLength = 0;
++				const unsigned char* imageData = (const uint8_t*)fdt_getprop(working_fdt, offset, "data", &imageLength);
++				printf ("Name: %s  Offset: 0x%08X  Size: 0x%08X\n", imageName, imageData - working_fdt, imageLength);
++			}
++			offset = fdt_next_node(working_fdt, offset, &depth);
++		}
++	*/
++	}
++
++error:
++	if (mmap_failed) {
++		free(working_fdt);
++	} else {
++		munmap((void *)working_fdt, file_size);
++	}
++	close (ifd);
++
++	exit (retval);
++}
++
++
++static void usage ()
++{
++	fprintf (stderr, "       %s [-l [path [propname]] | -o path propname | -p [path [propname]] | -i] image\n"
++			 "          -l ==> Print one level starting at <path>\n"
++			 "          -o ==> print the offset and size of a property\n"
++			 "          -p ==> Recursive print starting at <path>\n"
++			 "          -i ==> Print Image Info and validate hashes in u-boot image file\n",
++		params.cmdname);
++
++	exit (EXIT_FAILURE);
++}

--- a/recipes-bsp/u-boot/u-boot-tools_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-tools_%.bbappend
@@ -6,6 +6,11 @@ RCONFLICTS:${PN}-fw-utils = "libubootenv-bin"
 DEPENDS += "niacctbase"
 RDEPENDS:${PN}-fw-utils = "u-boot-env"
 
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI += "file://0001-tools-Add-fdtview-a-tool-to-validate-FIT-images.patch"
+
+PACKAGES:append = " ${PN}-fdtview"
+
 do_compile:append() {
 	oe_runmake -C ${S} envtools NO_SDL=1 O=${B}
 }
@@ -22,6 +27,11 @@ do_install:append() {
 
 	ln -rs ${D}${bindir}/fw_printenv ${D}${base_sbindir}/fw_printenv
 	ln -rs ${D}${bindir}/fw_setenv ${D}${base_sbindir}/fw_setenv
+
+	# fdtview
+	install -m 0755 tools/fdtview ${D}${bindir}/fdtview
+	ln -rs ${D}${bindir}/fdtview ${D}${base_sbindir}/fdtview
 }
 
 FILES:${PN}-fw-utils = "${bindir}/fw_printenv ${bindir}/fw_setenv ${base_sbindir}/fw_printenv ${base_sbindir}/fw_setenv"
+FILES:${PN}-fdtview = " ${bindir}/fdtview ${base_sbindir}/fdtview"

--- a/recipes-core/images/nilrt-safemode-initramfs.bb
+++ b/recipes-core/images/nilrt-safemode-initramfs.bb
@@ -51,6 +51,7 @@ bootimg_fixup () {
 
 	# opkg cleanup
 	opkg -o ${IMAGE_ROOTFS} -f ${IPKGCONF_TARGET} clean
+	rm -rf "${IMAGE_ROOTFS}/var/lib/opkg/lists"
 }
 
 bootimg_fixup_x64 () {

--- a/recipes-core/images/nilrt-safemode-initramfs.bb
+++ b/recipes-core/images/nilrt-safemode-initramfs.bb
@@ -22,7 +22,7 @@ IMAGE_INSTALL_NODEPS += "\
 	${NI_PROPRIETARY_SAFEMODE_PACKAGES} \
 "
 
-BAD_RECOMMENDATIONS:append:pn-${PN} = " shared-mime-info"
+BAD_RECOMMENDATIONS:append:pn-${PN} = " shared-mime-info *-lic"
 
 # Do not allow python to be installed into safemode ramdisk due to size
 PACKAGE_EXCLUDE += "python-core python3-core"

--- a/recipes-core/images/nilrt-safemode-initramfs.bb
+++ b/recipes-core/images/nilrt-safemode-initramfs.bb
@@ -14,8 +14,9 @@ PV = "${DISTRO_VERSION}"
 
 IMAGE_INSTALL += "\
 	packagegroup-ni-safemode \
-	packagegroup-ni-wifi \
 "
+
+IMAGE_INSTALL:append:x64 = " packagegroup-ni-wifi "
 
 IMAGE_INSTALL_NODEPS += "\
 	${NI_PROPRIETARY_COMMON_PACKAGES} \

--- a/recipes-core/images/nilrt-safemode-initramfs.bb
+++ b/recipes-core/images/nilrt-safemode-initramfs.bb
@@ -24,6 +24,8 @@ IMAGE_INSTALL_NODEPS += "\
 
 BAD_RECOMMENDATIONS:append:pn-${PN} = " shared-mime-info *-lic"
 
+IMAGE_LINGUAS:remove = "ja-jp.windows-31j zh-cn.cp936"
+
 # Do not allow python to be installed into safemode ramdisk due to size
 PACKAGE_EXCLUDE += "python-core python3-core"
 

--- a/recipes-core/images/nilrt-safemode-initramfs.bb
+++ b/recipes-core/images/nilrt-safemode-initramfs.bb
@@ -60,7 +60,7 @@ bootimg_fixup_x64 () {
 }
 
 bootimg_fixup_arm () {
-    echo "ubi1:rootfs /mnt/userfs ubifs defaults 0 0" >> "${IMAGE_ROOTFS}/etc/fstab"
+	echo "ubi1:rootfs /mnt/userfs ubifs defaults 0 0" >> "${IMAGE_ROOTFS}/etc/fstab"
 }
 
 IMAGE_PREPROCESS_COMMAND += " bootimg_fixup; "

--- a/recipes-core/images/nilrt-safemode-initramfs.bb
+++ b/recipes-core/images/nilrt-safemode-initramfs.bb
@@ -30,6 +30,9 @@ IMAGE_LINGUAS:remove = "ja-jp.windows-31j zh-cn.cp936"
 # Do not allow python to be installed into safemode ramdisk due to size
 PACKAGE_EXCLUDE += "python-core python3-core"
 
+# Do not allow tzdata to be installed into safemode ramdisk due to size
+PACKAGE_EXCLUDE += "packagegroup-ni-tzdata"
+
 PACKAGE_EXCLUDE += "rauc-mark-good"
 
 bootimg_fixup () {

--- a/recipes-ni/ni-safemode-utils/files/niinstallsafemode.arm
+++ b/recipes-ni/ni-safemode-utils/files/niinstallsafemode.arm
@@ -103,8 +103,9 @@ if [ -x $tmp_dir_new/preinst ]; then
 	$tmp_dir_new/preinst
 fi
 
+# TODO: Enable hash validation in AB#3842951
 # Validate hashes in ITB
-/sbin/fdtview -i $tmp_dir_new/$itb
+# /sbin/fdtview -i $tmp_dir_new/$itb
 
 itb_device_codes=`get_fdt_prop $tmp_dir_new/$itb / DeviceCodes`
 itb_device_codes="$itb_device_codes `get_fdt_prop $tmp_dir_new/$itb / DeviceCode`"

--- a/recipes-ni/ni-safemode-utils/files/niinstallsafemode.arm
+++ b/recipes-ni/ni-safemode-utils/files/niinstallsafemode.arm
@@ -52,8 +52,8 @@ cleanup()
 # Make sure we only replace older firmware with newer firmware
 check_version()
 {
-	cur_ver_string=$(/usr/bin/fdtget $mount_point/.safe/$itb / version)
-	tmp_ver_string=$(/usr/bin/fdtget $tmp_dir_new/$itb / version)
+	cur_ver_string=`/sbin/fdtview -l / version $mount_point/.safe/$itb | awk -F = '{print $2}'`
+	tmp_ver_string=`/sbin/fdtview -l / version $tmp_dir_new/$itb | awk -F = '{print $2}'`
 
 	result=$($ver_cmp "$cur_ver_string" "$tmp_ver_string")
 	if [ "$result" == "older" ]; then
@@ -69,12 +69,12 @@ check_version()
 # Params are: (file, fdt_path, fdt_property)
 get_fdt_prop()
 {
-	value=`/usr/bin/fdtget $1 $2 $3`
+	value=`/sbin/fdtview -l $2 $3 $1`
 	value="${value##*= \"}"
 	echo "${value%\"}"
 }
 
-[ -x /usr/bin/fdtget ]
+[ -x /sbin/fdtview ]
 
 trap cleanup INT TERM EXIT
 
@@ -103,10 +103,8 @@ if [ -x $tmp_dir_new/preinst ]; then
 	$tmp_dir_new/preinst
 fi
 
-# TODO: Enable hash validation in AB#3842951
 # Validate hashes in ITB
-# [ -x /sbin/fdtview ]
-# /sbin/fdtview -i $tmp_dir_new/$itb
+/sbin/fdtview -i $tmp_dir_new/$itb
 
 itb_device_codes=`get_fdt_prop $tmp_dir_new/$itb / DeviceCodes`
 itb_device_codes="$itb_device_codes `get_fdt_prop $tmp_dir_new/$itb / DeviceCode`"
@@ -117,7 +115,9 @@ target_device_code=`/sbin/fw_printenv -n DeviceCode`
 [[ $itb_device_codes =~ (^| )$target_device_code($| ) ]]
 
 # Ensure the bootscript exists
-itb_script_type=$(/usr/bin/fdtget $tmp_dir_new/$itb /images/bootscript type)
+itb_script_type=`/sbin/fdtview -l /images/bootscript type $tmp_dir_new/$itb`
+itb_script_type="${itb_script_type##*= \"}"
+itb_script_type="${itb_script_type%\"}"
 [ "$itb_script_type" = script ]
 
 # Return a different error code if there is a failure while touching the ITB or bitfile

--- a/recipes-ni/ni-safemode-utils/files/nisafemodeversion
+++ b/recipes-ni/ni-safemode-utils/files/nisafemodeversion
@@ -30,8 +30,8 @@ unknown_ver_string=unknown
 
 get_version_itb()
 {
-	if [ -x /usr/bin/uboot-dumpimage ]; then
-		version_string=`/usr/bin/uboot-dumpimage -l $1 2>/dev/null | grep "FIT description" | awk -F ' - ' '{print $2}'`
+	if [ -x /sbin/fdtview ]; then
+		version_string=`/sbin/fdtview -l / version $1 | awk -F = '{print $2}'`
 		if [ $? -ne 0 ]; then
 			version_string=""
 		fi

--- a/recipes-ni/ni-safemode-utils/files/nisafemodeversion
+++ b/recipes-ni/ni-safemode-utils/files/nisafemodeversion
@@ -30,8 +30,8 @@ unknown_ver_string=unknown
 
 get_version_itb()
 {
-	if [ -x /usr/bin/fdtget ]; then
-		version_string=$(/usr/bin/fdtget $1 / version)
+	if [ -x /usr/bin/uboot-dumpimage ]; then
+		version_string=`/usr/bin/uboot-dumpimage -l $1 2>/dev/null | grep "FIT description" | awk -F ' - ' '{print $2}'`
 		if [ $? -ne 0 ]; then
 			version_string=""
 		fi

--- a/recipes-ni/ni-safemode-utils/ni-safemode-utils.bb
+++ b/recipes-ni/ni-safemode-utils/ni-safemode-utils.bb
@@ -24,6 +24,7 @@ FILES:${PN} += "\
 DEPENDS += "shadow-native pseudo-native niacctbase update-rc.d-native"
 
 RDEPENDS:${PN} += "niacctbase bash fw-printenv"
+RDEPENDS:${PN}:append:xilinx-zynq = " u-boot-tools-fdtview "
 
 do_install () {
 	install -d ${D}${natinstbin}

--- a/recipes-ni/ni-safemode-utils/ni-safemode-utils.bb
+++ b/recipes-ni/ni-safemode-utils/ni-safemode-utils.bb
@@ -24,7 +24,7 @@ FILES:${PN} += "\
 DEPENDS += "shadow-native pseudo-native niacctbase update-rc.d-native"
 
 RDEPENDS:${PN} += "niacctbase bash fw-printenv"
-RDEPENDS:${PN}:append:xilinx-zynq = " dtc "
+RDEPENDS:${PN}:append:xilinx-zynq = " u-boot-tools-mkimage "
 
 do_install () {
 	install -d ${D}${natinstbin}

--- a/recipes-ni/ni-safemode-utils/ni-safemode-utils.bb
+++ b/recipes-ni/ni-safemode-utils/ni-safemode-utils.bb
@@ -24,7 +24,6 @@ FILES:${PN} += "\
 DEPENDS += "shadow-native pseudo-native niacctbase update-rc.d-native"
 
 RDEPENDS:${PN} += "niacctbase bash fw-printenv"
-RDEPENDS:${PN}:append:xilinx-zynq = " u-boot-tools-mkimage "
 
 do_install () {
 	install -d ${D}${natinstbin}


### PR DESCRIPTION
### Summary of Changes

256MB RAM ARM targets were not able to update firmware. This PR reduces RAM footprint by removing files/packages and using more memory efficient tools (like `fdtview` instead of `fdtget`).

Although x64 safemode doesn't need to reduce RAM footprint for now, making these changes on x64 as well to keep arch differences to a minimum.

### Justification

[AB#3221312](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3221312), [AB#3842951](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3842951)

### Testing

* [x] `bitbake packagefeed-ni-core && bitbake package-index && bitbake linux-nilrt-arm-safemode`
* [x] cRIO-9066 boots with `linux_safemode.itb`.
* [x] HWCU is able to connect to the target and update firmware.
* [x] Build x64 safemode (`bitbake packagegroup-ni-safemode && bitbake package-index && bitbake nilrt-safemode-rootfs`).
* [x] Boot tested x64 safemode on a VM and verified BSI installation works.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
