### PR TITLE
ni-grpc-device: Update dep from ni-grpc-sideband to ni-grpc-device-dev

### DIFF
--- a/recipes-ni/ni-grpc-device/ni-grpc-device_git.bb
+++ b/recipes-ni/ni-grpc-device/ni-grpc-device_git.bb
@@ -137,7 +137,7 @@ FILES:${PN} += "\
 "
 RDEPENDS:${PN} += "\
 	grpc \
-	ni-grpc-sideband \
+	ni-grpc-sideband-dev \
 	protobuf \
 "
 


### PR DESCRIPTION
ni-grpc-sideband package does not exist as all outputs of the ni-grpc-sideband end up in other packages, ni-grpc-sideband-dev being the one that has the sideband library.

So update dep to ni-grpc-device-dev.

Fixes 932c1de1 ("ni-grpc-device: bump SRCREV to a1830a7a (2026-04-13)").

WI: [AB#3867222](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3867222)

### Testing

* [x] `bitbake ni-grpc-device`
* [x] NI-Sync team verified that 1ni-grpc-device.ipk` can now be installed and works.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
