### PR TITLE
Add nisdbootconfig back

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-safemode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-safemode.bb
@@ -49,3 +49,7 @@ RDEPENDS:${PN}:append:x64 = "\
 	linux-firmware-i915-bxt-dmc \
 	linux-firmware-i915-tgl-dmc \
 "
+
+RDEPENDS:${PN}:append:armv7a = " \
+	nisdbootconfig \
+"

--- a/recipes-ni/nisdbootconfig/files/nisdbootconfig
+++ b/recipes-ni/nisdbootconfig/files/nisdbootconfig
@@ -17,6 +17,3 @@ if ! grep -qs mtd /proc/mtd ; then
     sed -i '/mtd/d' /etc/fw_env.config
     echo /boot/uboot/uboot.env         0x0000         0x20000 >>/etc/fw_env.config
 fi
-
-# we don't need this to run all the time, remove after first boot
-update-rc.d -f nisdbootconfig remove

--- a/recipes-ni/nisdbootconfig/files/nisdbootconfig
+++ b/recipes-ni/nisdbootconfig/files/nisdbootconfig
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+
+# check if target is NOT using ubifs (mtd)
+if ! grep -qs mtd /proc/mtd ; then
+
+    # configure the partitions to mount by label in fstab
+    sed -i '/ubifs/d' /etc/fstab
+    echo LABEL=nibootfs         /boot                ext4       sync           0  0 >>/etc/fstab
+    echo LABEL=niconfig         /etc/natinst/share   ext4       sync           0  0 >>/etc/fstab
+    echo LABEL=nirootfs         /mnt/userfs          ext4       defaults       0  0 >>/etc/fstab
+    mkdir -p /etc/natinst/share
+    mkdir -p /mnt/userfs
+
+    # configure the path for fw_printenv to read environmental variables from u-boot
+    # replace /dev/mtd4 and /dev/mtd5 with /boot/uboot/uboot.env
+    sed -i '/mtd/d' /etc/fw_env.config
+    echo /boot/uboot/uboot.env         0x0000         0x20000 >>/etc/fw_env.config
+fi
+
+# we don't need this to run all the time, remove after first boot
+update-rc.d -f nisdbootconfig remove

--- a/recipes-ni/nisdbootconfig/nisdbootconfig.bb
+++ b/recipes-ni/nisdbootconfig/nisdbootconfig.bb
@@ -1,0 +1,25 @@
+SUMMARY = "NI SDboot Config"
+DESCRIPTION = "Configuration script for safemode to enable arm target to boot from SD Card"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+SECTION = "base"
+
+COMPATIBLE_MACHINE = "xilinx-zynq"
+
+inherit update-rc.d
+
+SRC_URI = "file://nisdbootconfig \
+"
+
+INITSCRIPT_NAME = "nisdbootconfig"
+INITSCRIPT_PARAMS = "start 00 S ."
+
+S = "${WORKDIR}"
+
+do_install () {
+	install -d ${D}${sysconfdir}/init.d/
+
+	# from artemis onwards, using sd card as main disk for arm target is introduced
+	# install nisdbootconfig to configure sd card booting requirement
+	install -m 0755 ${WORKDIR}/nisdbootconfig ${D}${sysconfdir}/init.d
+}


### PR DESCRIPTION
### Summary of Changes

Revert commits that removed `nisdbootconfig` related code as some ARM targets require it.
Removed unnecessary code from `nisdbootconfig`.

### Justification

WI: [AB#3221318](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3221318)

### Testing

* [x] `bitbake packagefeed-ni-core && bitbake package-index && bitbake linux-nilrt-arm-safemode`
* [x] Booted safemode on cRIO-9066.
* [x] Ran commands in script (that would've run on a non-ubifs ARM target - which I don't have access to) and made sure `/etc/fstab`, `/etc/fw_env.config` look as expected.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
