### PR TITLE
meta-nilrt: resolve recipe build failures

### DIFF
--- a/recipes-ni/ni-grpc-device/ni-grpc-device_git.bb
+++ b/recipes-ni/ni-grpc-device/ni-grpc-device_git.bb
@@ -29,8 +29,8 @@ PV = "2.17.0+git${SRCPV}"
 
 SRC_URI = "\
 	git://github.com/ni/grpc-device.git;name=grpc-device;branch=main;protocol=https \
-	git://github.com/ni/grpc-sideband.git;name=grpc-sideband;protocol=https;nobranch=1;destsuffix=git/third_party/grpc-sideband \
-	git://github.com/ni/ni-apis.git;name=ni-apis;protocol=https;nobranch=1;destsuffix=git/third_party/ni-apis \
+	git://github.com/ni/grpc-sideband.git;name=grpc-sideband;protocol=https;nobranch=1;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/third_party/grpc-sideband \
+	git://github.com/ni/ni-apis.git;name=ni-apis;protocol=https;nobranch=1;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/third_party/ni-apis \
 	file://ptest \
 "
 
@@ -38,12 +38,15 @@ SRCREV_grpc-device = "a1830a7ac5274c34f955046cdc719fbf1648ab90"
 SRCREV_grpc-sideband = "e351b75f2df9d932fb7993520429d7c680031864"
 SRCREV_ni-apis = "00356cce09dd61d15f6799a87c27460a7d7a0c24"
 SRCREV_FORMAT = "grpc-device"
-SRCREV_grpc-sideband = "0ce928851df2e335ebdc385cced6d46a662c505e"
+
 inherit cmake python3native
 
 EXTRA_OECMAKE += "-DCMAKE_CROSSCOMPILING=True -DCMAKE_BUILD_TYPE=Release -DUSE_SUBMODULE_LIBS=OFF -DUSE_PYTHON_VIRTUALENV=OFF"
 OECMAKE_TARGET_COMPILE = "ni_grpc_device_server"
 OECMAKE_GENERATOR = "Unix Makefiles"
+
+# Don't error on deprecated declarations warnings
+CXXFLAGS:append = " -Wno-error=deprecated-declarations"
 
 # When USE_SUBMODULE_LIBS=OFF the protoc invocations for driver protos only
 # have imports/protobuf/ on their -I path. Copy the ni-apis proto files there

--- a/recipes-ni/ni-grpc-sideband/ni-grpc-sideband_git.bb
+++ b/recipes-ni/ni-grpc-sideband/ni-grpc-sideband_git.bb
@@ -12,8 +12,6 @@ DEPENDS += "\
 SRC_URI = "git://github.com/ni/grpc-sideband.git;protocol=https;nobranch=1"
 SRCREV = "e351b75f2df9d932fb7993520429d7c680031864"
 
-S = "${WORKDIR}/git"
-
 inherit cmake
 
 EXTRA_OECMAKE += "\

--- a/recipes-ni/ni-safemode-utils/ni-safemode-utils.bb
+++ b/recipes-ni/ni-safemode-utils/ni-safemode-utils.bb
@@ -29,9 +29,9 @@ RDEPENDS:${PN}:append:xilinx-zynq = " u-boot-tools-fdtview "
 do_install () {
 	install -d ${D}${natinstbin}
 
-	install -m 0755   ${WORKDIR}/nicompareversion            ${D}${natinstbin}
-	install -m 0550   ${WORKDIR}/${NIINSTALLSAFEMODE}        ${D}${natinstbin}/niinstallsafemode
-	install -m 0755   ${WORKDIR}/nisafemodeversion           ${D}${natinstbin}
+	install -m 0755   ${UNPACKDIR}/nicompareversion            ${D}${natinstbin}
+	install -m 0550   ${UNPACKDIR}/${NIINSTALLSAFEMODE}        ${D}${natinstbin}/niinstallsafemode
+	install -m 0755   ${UNPACKDIR}/nisafemodeversion           ${D}${natinstbin}
 
 	chown 0:${LVRT_GROUP} ${D}${natinstbin}/niinstallsafemode
 }


### PR DESCRIPTION
### Summary of Changes

There were build failures after cherry picking commits from scarthgap branch.
Ref: [link](https://dev.azure.com/ni/DevCentral/Stratus%20Infrastructure%20(RDSS)/_build/results?buildId=19519224&view=logs&j=3c108210-387a-5e25-97fa-da85b630fc6f&t=a41bbec2-9444-536b-41b3-124eaa2976d9&l=21153)

The issues were mostly related to ni-grpc-device and ni-safemode-utils recipes which needed changes to support upstream changes. This PR resolves all such build failures.

### Justification

[AB#3791450](https://dev.azure.com/ni/DevCentral/_workitems/edit/3791450)


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] `bitbake nilrt-base-system-image`
* [x] `bitbake nilrt-safemode-rootfs`

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
