### PR TITLE
Add env-config-container to packagefeed-ni-core for x64

### DIFF
--- a/recipes-core/packagegroups/packagefeed-ni-core.bb
+++ b/recipes-core/packagegroups/packagefeed-ni-core.bb
@@ -37,4 +37,5 @@ RDEPENDS:${PN}:append:x64 = "\
 	packagegroup-ni-tpm \
 	bolt \
 	onboard \
+	env-config-container \	
 "


### PR DESCRIPTION

### Summary of Changes
- Include env-config-container package in the NI core package feed
- Ensures the container-specific configuration package is available for x64 deployments
- Required for nilrt-slim-container and nilrt-runmode-container builds


### Justification

[AB#3201993](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3201993)

### Testing


* [x] bitbake packagefeed-ni-core
* [x] bitbake nilrt-slim-container
* [x] bitbake nilrt-runmode-container


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
