### PR TITLE
nisystemformat: Add ext4 support on ARM

### DIFF
--- a/recipes-ni/ni-systemformat/files/nisystemformat
+++ b/recipes-ni/ni-systemformat/files/nisystemformat
@@ -25,7 +25,14 @@ declare -r BASENAME=${0##*/}
 
 NINETCFGUTIL=/usr/local/natinst/bin/ninetcfgutil
 
-if [ "$arch" = "x86_64" ]; then
+# check for artemis compatibility from devicetree
+# set mountfs to ext4 if artemis model is detected
+# this allows fstype to return ext4 instead of ubifs
+if grep -qs artemis /sys/firmware/devicetree/base/compatible ; then
+	mountfs=ext4
+fi
+
+if [ "$arch" = "x86_64" ] || [ "$mountfs" = "ext4" ]; then # Adding $mountfs condition to support labelling for Artemis
 	LABEL_TYPE=$(lsblk -lno PARTLABEL | grep -q nirootfs && echo PARTLABEL || echo LABEL)
 	CONFIGFS_DEV=/dev/$(lsblk -l -n -o $LABEL_TYPE,NAME | grep '^niconfig '| tr -s ' ' | cut -d' ' -f2)
 	ROOTFS_DEV=/dev/$(lsblk -l -n -o $LABEL_TYPE,NAME | grep '^nirootfs '| tr -s ' ' | cut -d' ' -f2)
@@ -117,7 +124,13 @@ set_mode()
 
 supported_fstypes()
 {
-	hash /usr/sbin/ubiformat 2>/dev/null && [ "$arch" = "armv7l" ] && echo -n "ubifs," || true
+	if [ "$arch" = "armv7l" ]; then
+		if [ "$mountfs" = "ext4" ]; then # Adding $mountfs condition to properly report fstype for Artemis
+			hash /sbin/mkfs.ext4 2>/dev/null && echo -n "ext4," || true
+		else
+			hash /usr/sbin/ubiformat 2>/dev/null && echo -n "ubifs," || true
+		fi
+	fi
 	hash /sbin/mkfs.ext4 2>/dev/null && [ "$arch" = "x86_64" ] && echo -n "ext4," || true
 }
 


### PR DESCRIPTION
Some ARM targets use ext4 instead of ubifs. So add ext4 support.

WI: [AB#3790114](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3790114)

### Testing

* [x] Copied modified nisystemformat to a roboRIO2 and verified format operation works. It doesn't work without the changes.
* [x] Copied modified nisystemformat to an x64 VM and verified format operation still works.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
