### PR TITLE
nisystemformat: check for necessary privileges before starting format

### DIFF
--- a/recipes-ni/ni-systemformat/files/nisystemformat
+++ b/recipes-ni/ni-systemformat/files/nisystemformat
@@ -56,6 +56,7 @@ declare -Ar EXITCODES=(
 	[ILLTIMED]=5                # Called at an inappropriate time
 	[INVALID_ARCH]=6            # Running an unsupported processor architecture
 	[NO_KEY_BACKUP_DEVICE]=7    # Partition to store backup key could not be found; perhaps it's mislabeled or not plugged in
+	[INSUFFICIENT_PRIVILEGES]=8 # The requested operation requires elevated privileges
 )
 
 # $1: exit code (key from EXITCODES)
@@ -531,6 +532,10 @@ fi
 
 if [ "$MODE" = format -a "$OSMODE" = runmode ]; then
 	die_with_usage INVALID_ARGUMENT "Formatting is not available in runmode."
+fi
+
+if [ "$MODE" = format -a "$EUID" -ne 0 ]; then
+	die INSUFFICIENT_PRIVILEGES "Insufficient privileges for the requested operation; aborting."
 fi
 
 if [ "$RELAUNCH" = yes ]; then


### PR DESCRIPTION
### Summary of Changes

Check for root privileges before starting format operation instead of starting and then failing part way through.

### Justification

[AB#3736061](https://dev.azure.com/ni/DevCentral/_workitems/edit/3736061)

### Testing

Built safemode, installed on a physical target, ran as root and non-root user and confirmed success and failure behavior, including text error output and exit code output. Also replaced script in current running safemode with version in this PR and did a BSI update from MAX and confirmed the BSI installed with no issues.

* [X ] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [X ] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
