### PR TITLE
nilrt-proprietary.inc: add split niauth packages to BSI

### DIFF
--- a/recipes-core/images/includes/nilrt-proprietary.inc
+++ b/recipes-core/images/includes/nilrt-proprietary.inc
@@ -6,7 +6,9 @@ NI_PROPRIETARY_SAFEMODE_PACKAGES = "\
 
 NI_PROPRIETARY_COMMON_PACKAGES = "\
         libnitargetcfg \
+        libnss-niauth \
         ni-auth \
+        ni-auth-networkcontroller \
         ni-auth-webservice \
         ni-avahi-client \
         ni-ca-certs \
@@ -29,6 +31,7 @@ NI_PROPRIETARY_COMMON_PACKAGES = "\
         nicurl \
         nirtcfg \
         nirtmdnsd \
+        pam-plugin-niauth \
 "
 
 NI_PROPRIETARY_COMMON_PACKAGES:append:x64 = "\


### PR DESCRIPTION
### Summary of Changes

`ni-auth` was split into separate packages (`pam-plugin-niauth`, `libnss-niauth`, `ni-auth-networkcontroller`) 
to allow independent removal of PAM/NSS integration. 
Add these packages to the BSI so that authentication continues to work after the split.


### Justification

[AB#3111349](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3111349)
[AB#3894624](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3894624)


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have built the core package feed with this PR in place. (`bitbake nilrt-base-system-image`)
* [x] I have tested on a CRIO target ([More Context](https://dev.azure.com/ni/DevCentral/_workitems/edit/3894624#11143031)).

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).

### Note:
* [x] This should be cherry-picked to `-next` branch.