### PR TITLE
linux-nilrt-arm-safemode_git: Simplify version

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-arm-safemode_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-arm-safemode_git.bb
@@ -7,7 +7,7 @@ require linux-nilrt-alternate.inc
 
 INITRAMFS_IMAGE = "nilrt-safemode-initramfs"
 FIT_DESC = "zynq_safemode - ${BUILDNAME}"
-FIT_VERSION = "${BUILDNAME}"
+FIT_VERSION = "${@d.getVar('BUILDNAME').split('-', 1)[0]}"
 FIT_DEVICECODE = "0x${@d.getVar('NILRT_ARM_DEVICE_CODES').split()[0]}"
 FIT_DEVICECODES = "${@' '.join('0x' + x for x in (d.getVar('NILRT_ARM_DEVICE_CODES')).split())}"
 


### PR DESCRIPTION
### Summary of Changes

Update FIT_VERSION to simplify the version string to exclude everything but the version number.

[AB#3850013](https://dev.azure.com/ni/DevCentral/_workitems/edit/3850013)

### Justification

This change will make the behavior of nisafemodeversion match previous ARM versions.

### Testing

Tested by creating a ni-central PR for rtos_nilinuxrt that points meta-nilrt to this branch:
https://dev.azure.com/ni/DevCentral/_build/results?buildId=19692156&view=logs&j=cb3acf64-16cd-50a6-9c15-1e3f61120cd9&t=388f1a6a-6558-5a7a-1c9c-9656a7b687e5

Copied the .itb file from the nibuildcache to a sbRIO-9651 and confirmed that calling nisafemodeversion returned a version with no machine tag at the end.
<img width="571" height="35" alt="version success" src="https://github.com/user-attachments/assets/4fcb54f6-6a98-4e2b-b2cd-47edc4e76151" />


* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
