### PR TITLE
salt: Add u-boot-tools-mkimage dependency for xilinx-zynq

### DIFF
--- a/recipes-support/salt/salt_3006.13.bb
+++ b/recipes-support/salt/salt_3006.13.bb
@@ -139,6 +139,7 @@ RDEPENDS:${PN}-common = "\
 RRECOMMENDS:${PN}-common = "lsb-release"
 RSUGGESTS:${PN}-common = "python3-mako python3-git"
 RCONFLICTS:${PN}-common = "python3-mako (< 0.7.0)"
+RDEPENDS:${PN}-common:append:xilinx-zynq = " u-boot-tools-mkimage"
 CONFFILES:${PN}-common="${sysconfdir}/logrotate.d/${PN}-common"
 FILES:${PN}-common = "${bindir}/${PN}-call ${PYTHON_SITEPACKAGES_DIR} ${CONFFILES:${PN}-common}"
 


### PR DESCRIPTION
### Summary of Changes
Add a runtime dependency on `u-boot-tools-mkimage` for `xilinx-zynq` through `salt-common`.
Salt `restartcheck` validates runmode kernel images during package installation and invokes `dumpimage` as part of that flow.


### Justification

[AB#3850226](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3850226).


### Testing

[x] `bitbake nilrt-base-system-image`
[x] Re-imaged the target and verified `dumpimage`, `uboot-mkimage` and `uboot-dumpimage` are present.
