### PR TITLE
ARM safemode bootscript fixes

### DIFF
--- a/recipes-bsp/u-boot/files/bootscript.txt
+++ b/recipes-bsp/u-boot/files/bootscript.txt
@@ -23,7 +23,13 @@ if fdt addr ${loadaddr} && fdt get value rd_desc /images/ramdisk-1 description; 
 
   # cRIO-9068 doesn't have USB gadget, so skip it on that device
   if test ${DeviceCode} != 0x76D6; then
-    usb_gadget_args="g_ether.idVendor=${USBVendorID} g_ether.idProduct=${USBProductID} g_ether.iProduct=\"${USBProduct} [${hostname}]\" g_ether.iSerialNumber=${serial#} g_ether.dev_addr=${usbgadgetethaddr} g_ether.bcdDevice=${USBDevice}"
+    # myRIO should use ethaddr for the USB gadget to ensure a persistent address
+    if test ${DeviceCode} == 0x762F || test ${DeviceCode} == 0x76D3; then
+      usb_gadget_addr=${ethaddr}
+    else
+      usb_gadget_addr=${usbgadgetethaddr}
+    fi
+    usb_gadget_args="g_ether.idVendor=${USBVendorID} g_ether.idProduct=${USBProductID} g_ether.iProduct=\"${USBProduct} [${hostname}]\" g_ether.iSerialNumber=${serial#} g_ether.dev_addr=${usb_gadget_addr} g_ether.bcdDevice=${USBDevice}"
   fi
 
   if test -n \"$bootscriptenvsafe\" ; then run bootscriptenvsafe; fi

--- a/recipes-bsp/u-boot/files/bootscript.txt
+++ b/recipes-bsp/u-boot/files/bootscript.txt
@@ -2,9 +2,9 @@ if fdt addr ${loadaddr} && fdt get value rd_desc /images/ramdisk-1 description; 
   # Initramfs present. So this must be safemode
 
   if test ${DeviceCode} -eq 0x7AAE; then
-    setenv set_args 'setenv bootargs ${consoleparam} ramdisk_size=populate-ramdisk-size root=/dev/ram rw ${usb_gadget_args} $othbootargs';
+    setenv set_args 'setenv bootargs ${consoleparam} root=/dev/ram rw ${usb_gadget_args} $othbootargs';
   else
-    setenv set_args 'setenv bootargs ${consoleparam} $mtdparts ubi.mtd=boot-config ubi.mtd=root ramdisk_size=populate-ramdisk-size root=/dev/ram rw ${usb_gadget_args} $othbootargs';
+    setenv set_args 'setenv bootargs ${consoleparam} $mtdparts ubi.mtd=boot-config ubi.mtd=root root=/dev/ram rw ${usb_gadget_args} $othbootargs';
   fi
 
   # usb host or device mode switching


### PR DESCRIPTION
### Summary of Changes

Made following fixes to safemode part of bootscript.txt:
- bootscript.txt: Keep USB gadget network address consistent
- bootscript.txt: Remove unused ramdisk_size kernel cmdline param

### Justification

WI: [AB#3821588](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3821588)

### Testing

* [x] `bitbake linux-nilrt-arm-safemode`.
* [x] Safemode boots on `myRIO-1900` without issues. Verified `cat /proc/cmdline` is as expected.
* [x] Safemode boots on `cRIO-9068` without issues.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
