### PR TITLE
nilrt-runmode-initramfs.bb: Always set INITRAMFS_TYPES

### DIFF
--- a/recipes-core/images/nilrt-runmode-initramfs.bb
+++ b/recipes-core/images/nilrt-runmode-initramfs.bb
@@ -55,14 +55,7 @@ IMAGE_PREPROCESS_COMMAND += " bootimg_fixup; "
 # DEPLOYMENT
 # ==============================================================================
 
-INITRAMFS_FSTYPES ?= "cpio.xz"
+IMAGE_FSTYPES = "cpio.xz"
 IMAGE_NAME_SUFFIX = ""
 XZ_COMPRESSION_LEVEL = "-e -9"
 XZ_INTEGRITY_CHECK = "crc32"
-
-# Some BSPs use IMAGE_FSTYPES:<machine override> which would override
-# a plain assignment to IMAGE_FSTYPES, so derive it from INITRAMFS_FSTYPES
-# via setVar to bypass machine-level overrides on IMAGE_FSTYPES.
-python () {
-    d.setVar("IMAGE_FSTYPES", d.getVar("INITRAMFS_FSTYPES"))
-}


### PR DESCRIPTION
Always set INITRAMFS_TYPES in nilrt-runmode-initramfs.bb to avoid using the default value set in the OE core bitbakeRules file.

### Summary of Changes

Update nilrt-runmode-initramfs.bb to always set INITRAMFS_TYPES. Also remove the python block that sets IMAGE_FSTYPES to match behavior with nilrt-safemode-initramfs.bb.


### Justification

Builds were failing due to INITRAMFS_TYPES taking it's value from OE core, this change unblocks them.


### Testing

ni-central PR build using my local branch containing the change: https://dev.azure.com/ni/DevCentral/_build/results?buildId=19804274&view=results

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
