### PR TITLE
linux-nilrt-next: Update to 6.18 version branch

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-next_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-next_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NILRT linux kernel next development build"
 NI_RELEASE_VERSION = "master"
-LINUX_VERSION = "6.12"
+LINUX_VERSION = "6.18"
 LINUX_KERNEL_TYPE = "next"
 
 require linux-nilrt-alternate.inc


### PR DESCRIPTION
### Summary of Changes

Update the 'next' kernel to the 6.18 version branch.

Note to maintainers: please pull related PR first: https://github.com/ni/openembedded-core/pull/201

### Justification

[AB#3599949](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3599949)

### Testing

* [x] `bitbake virtual/kernel`
* [x] `bitbake linux-nilrt-next`
* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] `bitbake -k packagefeed-ni-extra`. All kernel related packages built successfully
* [x] `bitbake packagegroup-ni-desirable`. No errors.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
