### PR TITLE
Revert "nilrt-proprietary.inc: add split niauth packages to BSI"

### DIFF
--- a/recipes-core/images/includes/nilrt-proprietary.inc
+++ b/recipes-core/images/includes/nilrt-proprietary.inc
@@ -6,9 +6,7 @@ NI_PROPRIETARY_SAFEMODE_PACKAGES = "\
 
 NI_PROPRIETARY_COMMON_PACKAGES = "\
         libnitargetcfg \
-        libnss-niauth \
         ni-auth \
-        ni-auth-networkcontroller \
         ni-auth-webservice \
         ni-avahi-client \
         ni-ca-certs \
@@ -31,7 +29,6 @@ NI_PROPRIETARY_COMMON_PACKAGES = "\
         nicurl \
         nirtcfg \
         nirtmdnsd \
-        pam-plugin-niauth \
 "
 
 NI_PROPRIETARY_COMMON_PACKAGES:append:x64 = "\


### PR DESCRIPTION
This reverts commit 21e43f839646e4039f7115a2ae78f5ebd38d3d2c from https://github.com/ni/meta-nilrt/pull/1011

rtos_nifeed in azdo [can't find libnss-niauth](https://dev.azure.com/ni/DevCentral/Stratus%20Infrastructure%20(RDSS)/_build/results?buildId=19907219&view=logs&j=cb53a2ad-51f9-5617-c17a-c1c1ba8da936&t=90610aa0-dc49-5911-9830-3252d01de8cc&l=933) so revert until rtos workspace can be updated to be able to pull libnss-niauth.


### Justification

WI: [AB#3910152](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3910152)

### Testing

* None

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
