### PR TITLE
env-config-container: Fix build by adding depends on niacctbase

### DIFF
--- a/recipes-ni/env-config-container/env-config-container.bb
+++ b/recipes-ni/env-config-container/env-config-container.bb
@@ -5,6 +5,8 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 SECTION = "base"
 
 
+DEPENDS += "niacctbase"
+
 RDEPENDS:${PN} = "bash"
 
 SRC_URI = "\


### PR DESCRIPTION
### Summary of Changes

`env-config-container` fails to build with error `sbin/fw_printenv.wrapper is owned by uid 0, gid 500, which doesn't match any user/group on target. This may be due to host contamination`

This change adds depends on `niacctbase` which provides gid 500.

### Justification

WI: [AB#3910152](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3910152)

### Testing

* [x] @usercw88 tested that core-feeds, bsi, safemode build.


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
