### PR TITLE
pkggrp-ni-internal-deps: Add minizip

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
@@ -105,6 +105,7 @@ RDEPENDS:${PN} += "\
 RDEPENDS:${PN}:append:x64 = "\
 	libglu \
 "
+
 # Required by PAtools Runtimesystem
 # Team: Transportation BU - Modern Battery Lab
 # Contact: Deborah Bryant
@@ -122,4 +123,9 @@ RDEPENDS:${PN} += "\
 RDEPENDS:${PN} += "\
 	mosquitto \
 	paho-mqtt-cpp \
+"
+
+# Required by multiple product groups
+RDEPENDS:${PN} += "\
+	minizip \
 "


### PR DESCRIPTION
### Summary of Changes

Add `minizip` to `packagegroup-ni-internals-deps`


### Justification

[AB#3886002](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3886002)


### Testing

* [x] I have built the packagegroup-ni-internal-deps with this PR in place (x64). (`bitbake packagegroup-ni-internal-deps`)
* [x] I have built the packagegroup-ni-internal-deps with this PR in place (arm). (`bitbake packagegroup-ni-internal-deps`)

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
