### PR TITLE
root-login: Use local root account instead of NIAuth admin

### DIFF
--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -34,6 +34,11 @@ NILRT_BSI_FSTYPE:x64 = "tar.gz"
 # Use tar.xz on ARM to save space and prevent BSI installation failure.
 NILRT_BSI_FSTYPE:xilinx-zynq = "tar.xz"
 
+# Root home. NIAuth removed in dist-next (was /home/admin); use /root to match
+# the systemd/UAPI convention rather than the OE default /home/root. Legacy
+# /home/admin is preserved via a symlink to /root in niacctbase.
+ROOT_HOME = "/root"
+
 IMAGE_LINGUAS ?= "en-us en-us.iso-8859-1 ja-jp.windows-31j zh-cn.cp936"
 
 require nilrt.inc

--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -34,11 +34,6 @@ NILRT_BSI_FSTYPE:x64 = "tar.gz"
 # Use tar.xz on ARM to save space and prevent BSI installation failure.
 NILRT_BSI_FSTYPE:xilinx-zynq = "tar.xz"
 
-# Needs to change thanks to NIAuth
-# - cf oe-core base-files/base-files/profile
-# - cf oe-core base-files/base-files_3.0.14.bb
-ROOT_HOME = "/home/admin"
-
 IMAGE_LINGUAS ?= "en-us en-us.iso-8859-1 ja-jp.windows-31j zh-cn.cp936"
 
 require nilrt.inc

--- a/recipes-core/images/includes/nilrt-image-base.inc
+++ b/recipes-core/images/includes/nilrt-image-base.inc
@@ -23,6 +23,26 @@ do_image_build_test() {
 	fi
 }
 
+# Guarantee a usable LOCAL root login.
+#
+# Historically the default interactive login was the NIAuth-backed 'admin' user
+# (empty password), which was only visible/usable because NIAuth's NSS and PAM
+# modules were pulled in transitively by ni-auth. As of dist-next, ni-auth no
+# longer installs those modules, so the NIAuth 'admin'/"" login is gone. Make the
+# local root account loginable out of the box (the box ships open and is expected
+# to be secured on first configuration; see FEATURE 3835079):
+#
+#   * empty-root-password  - keep root's /etc/shadow password field empty
+#                            (otherwise the rootfs postprocess zaps it to '*').
+#   * allow-empty-password - rewrite 'pam_unix.so nullok_secure' to plain
+#                            'nullok' in /etc/pam.d/* and set sshd
+#                            PermitEmptyPasswords. nullok_secure only permits
+#                            blank passwords from ttys listed in /etc/securetty,
+#                            which excludes SSH (PAM_TTY=ssh), so without this an
+#                            empty root password could not log in over SSH.
+#
+IMAGE_FEATURES += "empty-root-password allow-empty-password"
+
 python install_additional_feeds() {
     for source_name, uri in d.getVarFlags('PACKAGE_FEED_URIS_ADDITIONAL').items():
         source_conf = os.path.join(d.getVar('IMAGE_ROOTFS'), 'etc', 'opkg', ('%s.conf' % source_name))

--- a/recipes-core/images/includes/nilrt-proprietary.inc
+++ b/recipes-core/images/includes/nilrt-proprietary.inc
@@ -6,7 +6,6 @@ NI_PROPRIETARY_SAFEMODE_PACKAGES = "\
 
 NI_PROPRIETARY_COMMON_PACKAGES = "\
         libnitargetcfg \
-        ni-auth \
         ni-auth-webservice \
         ni-avahi-client \
         ni-ca-certs \

--- a/recipes-kernel/kernel-tests/files/iperf-load
+++ b/recipes-kernel/kernel-tests/files/iperf-load
@@ -1,12 +1,12 @@
 #!/bin/bash
 source "$(dirname "$0")"/common.cfg
-source /home/admin/.iperf.info
+source /root/.iperf.info
 
 case "$1" in
 	check)
 		if [ -z "$IPERF_SERVER" ]; then
 			echo "Warning: iperf server not configured; skipping iperf based network load test."
-			echo "Create/edit /home/admin/.iperf.info file with IPERF_SERVER=<server> and IPERF_PORT=<port> to configure a server to connect to for this test."
+			echo "Create/edit /root/.iperf.info file with IPERF_SERVER=<server> and IPERF_PORT=<port> to configure a server to connect to for this test."
 			echo "SKIP: test_kernel_cyclictest_iperf"
 			exit 77
 		fi

--- a/recipes-kernel/kernel-tests/files/run-cyclictest
+++ b/recipes-kernel/kernel-tests/files/run-cyclictest
@@ -56,7 +56,7 @@ function add_system_info()
 function run_cyclictest()
 {
 	LOG="$LOG_DIR/cyclictest-$1-`date +'%Y_%m_%d-%H_%M_%S'`.log"
-	INFLUXDB_INFO="/home/admin/.influxdb.info"
+	INFLUXDB_INFO="/root/.influxdb.info"
 	cyclictest --smp --priority=98 --mlockall --interval=997 --quiet --duration="$TEST_DURATION" --histofall=1000 --histfile="$LOG" > /dev/null
 	add_system_info "$LOG"
 	if [[ -f "$INFLUXDB_INFO" ]]; then

--- a/recipes-kernel/kernel-tests/files/run-docker-cyclictest
+++ b/recipes-kernel/kernel-tests/files/run-docker-cyclictest
@@ -6,7 +6,7 @@ case "$#" in
 		docker run --privileged --network=host \
 		       -v ${LOG_DIR}:${LOG_DIR} \
 		       -v ${TEST_DIR}:${TEST_DIR} \
-		       -v /home/admin:/home/admin \
+		       -v /root:/root \
 		       -v /usr/share/fw_printenv:/usr/share/fw_printenv \
 		       -v /sbin/fw_printenv:/sbin/fw_printenv \
 		       -v /usr/share/nisysinfo:/usr/share/nisysinfo \
@@ -22,7 +22,7 @@ case "$#" in
 		       --cpuset-cpus "$2" \
 		       -v ${LOG_DIR}:${LOG_DIR} \
 		       -v ${TEST_DIR}:${TEST_DIR} \
-		       -v /home/admin:/home/admin \
+		       -v /root:/root \
 		       -v /usr/share/fw_printenv:/usr/share/fw_printenv \
 		       -v /sbin/fw_printenv:/sbin/fw_printenv \
 		       -v /usr/share/nisysinfo:/usr/share/nisysinfo \

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_fio_containerized.sh
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_fio_containerized.sh
@@ -5,7 +5,7 @@ source "$(dirname "$0")"/common.cfg
 LOAD_CONT=$(docker run -d --privileged --network=host \
 		   -v ${LOG_DIR}:${LOG_DIR} \
 		   -v ${TEST_DIR}:${TEST_DIR} \
-		   -v /home/admin:/home/admin \
+		   -v /root:/root \
 		   -t parallel-container)
 docker exec -d $LOAD_CONT "$TEST_DIR/fio-load" "start"
 

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_hackbench_containerized.sh
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_hackbench_containerized.sh
@@ -12,7 +12,7 @@ fi
 LOAD_CONT=$(docker run -d --privileged --network=host \
 		   -v ${LOG_DIR}:${LOG_DIR} \
 		   -v ${TEST_DIR}:${TEST_DIR} \
-		   -v /home/admin:/home/admin \
+		   -v /root:/root \
 		   -t parallel-container)
 docker exec -d $LOAD_CONT "$TEST_DIR/hackbench-load" "start"
 

--- a/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_iperf_containerized.sh
+++ b/recipes-kernel/kernel-tests/kernel-containerized-performance-tests-files/test_kernel_cyclictest_iperf_containerized.sh
@@ -5,7 +5,7 @@ source "$(dirname "$0")"/common.cfg
 LOAD_CONT=$(docker run -d --privileged --network=host \
 		   -v ${LOG_DIR}:${LOG_DIR} \
 		   -v ${TEST_DIR}:${TEST_DIR} \
-		   -v /home/admin:/home/admin \
+		   -v /root:/root \
 		   -t parallel-container)
 docker exec $LOAD_CONT "$TEST_DIR/iperf-load" "check" || exit $?
 docker exec -d $LOAD_CONT "$TEST_DIR/iperf-load" "start"

--- a/recipes-kernel/kernel-tests/kernel-tests-files/test_exe_cap_support.c
+++ b/recipes-kernel/kernel-tests/kernel-tests-files/test_exe_cap_support.c
@@ -55,7 +55,7 @@ int try_file_capability(const char *exec_file_path, int cap, cap_t *get_caps_chi
 	command_result[0] = '\0';
 	command[0] = '\0';
 
-	//command := "su lvuser -c '/home/root/dist/tested_program 14'"
+	//command := "su lvuser -c '/root/dist/tested_program 14'"
 	sprintf(command, "%s '%s %d'", "su lvuser -c", exec_file_path, cap);
 
 	test_and_fail(execute_linux_command(command, command_result, sizeof(command_result)),

--- a/recipes-kernel/kernel-tests/kernel-tests-files/test_kernel_dmesg_diff.sh
+++ b/recipes-kernel/kernel-tests/kernel-tests-files/test_kernel_dmesg_diff.sh
@@ -4,9 +4,9 @@ source $(dirname "$0")/ptest-format.sh
 
 ptest_change_test $(basename "$0" ".sh") "" "Diff dmesg log with with previous"
 
-source /home/admin/.mongodb.creds
-if [ -e /home/admin/.test.kernel_dmesg_diff.args ]; then
-   source /home/admin/.test.kernel_dmesg_diff.args
+source /root/.mongodb.creds
+if [ -e /root/.test.kernel_dmesg_diff.args ]; then
+   source /root/.test.kernel_dmesg_diff.args
 fi
 
 python3 kernel_dmesg_diff.py --server $MONGO_SERVER --user $MONGO_USER --password $MONGO_PASSWORD "${KERNEL_DMESG_DIFF_TEST_EXTRA_ARGS[@]}"

--- a/recipes-ni/ni-acctsync/files/ni-acctsync
+++ b/recipes-ni/ni-acctsync/files/ni-acctsync
@@ -36,9 +36,19 @@ check_hash_equality()
 hash_sanity_check()
 {
     SHADOW_HASH="$1"
-    
-    if [ -z "$SHADOW_HASH" ] || [ "$SHADOW_HASH" = "*" ] || [ "$SHADOW_HASH" = "!" ]; then
+
+    # Empty (blank root) or bare '!' (deliberate passwd -l of a passwordless
+    # root) are both valid to restore as-is. '!'-prefixed hashes are handled below.
+    if [ -z "$SHADOW_HASH" ] || [ "$SHADOW_HASH" = "!" ]; then
         return 0
+    fi
+
+    # '*' is the zap_empty_root_password artifact for a never-set root, not a
+    # deliberate lock; skip it so a stale '*' on the config partition can't lock
+    # root out.
+    if [ "$SHADOW_HASH" = "*" ]; then
+        log "Shared root hash is '*' (zap artifact); skipping sync to avoid locking root out."
+        return 1
     fi
     
     if [ -f "/etc/login.defs" ]; then
@@ -55,7 +65,8 @@ hash_sanity_check()
     case "$ENCRYPT_METHOD" in
         SHA512)
             log "Checking sanity of SHA512 hash..."
-            if [[ "$SHADOW_HASH" =~ ^\$6\$[A-Za-z0-9./]{1,16}\$[A-Za-z0-9./]{86}$ ]]; then
+            # Optional leading '!' allows a deliberate 'passwd -l' lock (!$6$...) to sync.
+            if [[ "$SHADOW_HASH" =~ ^!?\$6\$[A-Za-z0-9./]{1,16}\$[A-Za-z0-9./]{86}$ ]]; then
                 log "Sanity check passed. Continue to sync."
                 return 0
             else

--- a/recipes-ni/ni-base-system-image-tests/files/fs_permissions_known.py
+++ b/recipes-ni/ni-base-system-image-tests/files/fs_permissions_known.py
@@ -17,10 +17,10 @@ def known_permissions_tree():
             'grub': {
                 '.': system_dir,
                 '*': system_file,
-                'grubenv': permissions(0o664, 'admin', 'ni', FT_REG),
-                'grubenv.bak': permissions(0o664, 'admin', 'ni', FT_REG),
-                'grub-ni-version': permissions(0o0444, 'admin', 'administrators', FT_REG),
-                'recoverytool-ni-version': permissions(0o0444, 'admin', 'administrators', FT_REG)
+                'grubenv': permissions(0o664, 'root', 'ni', FT_REG),
+                'grubenv.bak': permissions(0o664, 'root', 'ni', FT_REG),
+                'grub-ni-version': permissions(0o0444, 'root', 'root', FT_REG),
+                'recoverytool-ni-version': permissions(0o0444, 'root', 'root', FT_REG)
             },
             'runmode': {
                 '.': system_dir,
@@ -34,8 +34,8 @@ def known_permissions_tree():
         'home': {
             '.': system_dir,
             '*': system_dir,
+            'admin': system_link('/root'),
             'lvuser': permissions(0o2775, 'lvuser', 'ni', FT_DIR),
-            'root': system_link('/home/admin'),
             'webserv': permissions(0o2755, 'webserv', 'ni', FT_DIR)
         },
         'lib': {
@@ -119,15 +119,15 @@ def permissions(mode, user, group, file_type):
 
 # Typical system file
 def system_file(path, stats, logger, md5sum):
-    return permissions(0o0644, 'admin', 'administrators', FT_REG)(path, stats, logger, md5sum)
+    return permissions(0o0644, 'root', 'root', FT_REG)(path, stats, logger, md5sum)
 
 # Sys file with executable bit set
 def system_file_exec(path, stats, logger, md5sum):
-    return permissions(0o0755, 'admin', 'administrators', FT_REG)(path, stats, logger, md5sum)
+    return permissions(0o0755, 'root', 'root', FT_REG)(path, stats, logger, md5sum)
 
 # Typical system dir
 def system_dir(path, stats, logger, md5sum):
-    return permissions(0o0755, 'admin', 'administrators', FT_DIR)(path, stats, logger, md5sum)
+    return permissions(0o0755, 'root', 'root', FT_DIR)(path, stats, logger, md5sum)
 
 # Only care about ownership and r/w access not link status, directory status, exec bit, etc
 def system_hier(path, stats, logger, md5sum):
@@ -137,7 +137,7 @@ def system_hier(path, stats, logger, md5sum):
         0o0755 if is_dir or stat.S_IMODE(stats.st_mode) == 0o0755 else 0o0644
     )
     file_type = FT_DIR if is_dir else (FT_LNK if is_link else FT_REG)
-    return permissions(mode, 'admin', 'administrators', file_type)(path, stats, logger, md5sum)
+    return permissions(mode, 'root', 'root', file_type)(path, stats, logger, md5sum)
 
 # What would be a typical system file but is actually a link
 def system_link(target):
@@ -148,7 +148,7 @@ def system_link(target):
         if not correct_link:
             log_mismatch('link', target, real_target, path, logger, md5sum)
         return \
-            permissions(0o0777, 'admin', 'administrators', FT_LNK)(path, stats, logger, md5sum) \
+            permissions(0o0777, 'root', 'root', FT_LNK)(path, stats, logger, md5sum) \
             and correct_link
     return ret
 

--- a/recipes-ni/ni-base-system-image-tests/files/test_fs_permissions_diff.sh
+++ b/recipes-ni/ni-base-system-image-tests/files/test_fs_permissions_diff.sh
@@ -4,9 +4,9 @@ source $(dirname "$0")/ptest-format.sh
 
 ptest_change_test $(basename "$0" ".sh") "" "Diff filesystem permissions with previous"
 
-source /home/admin/.mongodb.creds
-if [ -e /home/admin/.test.fs_permissions_diff.args ]; then
-   source /home/admin/.test.fs_permissions_diff.args
+source /root/.mongodb.creds
+if [ -e /root/.test.fs_permissions_diff.args ]; then
+   source /root/.test.fs_permissions_diff.args
 fi
 
 python3 fs_permissions_diff.py --server $MONGO_SERVER --user $MONGO_USER --password $MONGO_PASSWORD "${FS_PERMISSIONS_DIFF_TEST_EXTRA_ARGS[@]}"

--- a/recipes-ni/ni-test-boot-time/files/run-ptest
+++ b/recipes-ni/ni-test-boot-time/files/run-ptest
@@ -2,7 +2,7 @@
 
 TEST_NAME="test_boot_time"
 TEST_LOG="/var/log/boottime"
-INFLUXDB_INFO="/home/admin/.influxdb.info"
+INFLUXDB_INFO="/root/.influxdb.info"
 
 if [[ -f "$INFLUXDB_INFO" ]]; then
 	source "$INFLUXDB_INFO"

--- a/recipes-ni/ni-tracefs-utils/files/traceextract
+++ b/recipes-ni/ni-tracefs-utils/files/traceextract
@@ -4,5 +4,5 @@ set -e
 
 sudo -u lvuser touch "$1"
 chmod 440 "$1"
-chown admin:administrators "$1"
+chown root:root "$1"
 trace-cmd extract -o "$1"

--- a/recipes-ni/niacctbase/niacctbase.bb
+++ b/recipes-ni/niacctbase/niacctbase.bb
@@ -40,7 +40,6 @@ USERADD_PARAM:${PN} = " \
 useradd_preinst:append () {
 	eval ${PSEUDO} chmod g+sw ${SYSROOT}/home/${LVRT_USER} || true
 	eval ${PSEUDO} chmod g+s ${SYSROOT}/home/webserv || true
-	eval ${PSEUDO} ln -sf /home/admin ${SYSROOT}/home/root || true
 }
 
 

--- a/recipes-ni/niacctbase/niacctbase.bb
+++ b/recipes-ni/niacctbase/niacctbase.bb
@@ -39,6 +39,8 @@ USERADD_PARAM:${PN} = " \
 useradd_preinst:append () {
 	eval ${PSEUDO} chmod g+sw ${SYSROOT}/home/${LVRT_USER} || true
 	eval ${PSEUDO} chmod g+s ${SYSROOT}/home/webserv || true
+	# Keep legacy /home/admin working by pointing it at root's home (/root).
+	eval ${PSEUDO} ln -sf /root ${SYSROOT}/home/admin || true
 }
 
 

--- a/recipes-ni/niacctbase/niacctbase.bb
+++ b/recipes-ni/niacctbase/niacctbase.bb
@@ -8,7 +8,6 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 PV = "1.1"
 
 SRC_URI = "\
-	file://sudoers \
 	file://udev.rules \
 "
 
@@ -44,9 +43,6 @@ useradd_preinst:append () {
 
 
 do_install:append () {
-	install -d ${D}${sysconfdir}/sudoers.d/
-	install --mode=0660 ${S}/sudoers ${D}${sysconfdir}/sudoers.d/${PN}
-
 	install -d ${D}${sysconfdir}/udev/rules.d
 	install --mode=0644 ${S}/udev.rules ${D}${sysconfdir}/udev/rules.d/90-${PN}.rules
 }
@@ -54,18 +50,8 @@ do_install:append () {
 
 ## subpackages
 PACKAGE_BEFORE_PN += " \
-	${PN}-sudo \
 	${PN}-udev \
 "
-# -sudo : sudo integration
-SUMMARY:${PN}-sudo = "${SUMMARY} - sudo integration"
-FILES:${PN}-sudo = "${sysconfdir}/sudoers.d/*"
-CONFFILES:${PN}-sudo = "${sysconfdir}/sudoers.d/*"
-RDEPENDS:${PN}-sudo = "\
-	niacctbase \
-	sudo-lib \
-"
-
 # -udev : udev rules for the `ni` group
 SUMMARY:${PN}-udev = "${SUMMARY} - udev rules"
 FILES:${PN}-udev = "${sysconfdir}/udev/*"
@@ -74,5 +60,4 @@ RDEPENDS:${PN}-udev += " niacctbase udev"
 
 
 RDEPENDS:${PN} += " ${PN}-udev"
-RRECOMMENDS:${PN} += " ${PN}-sudo"
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-ni/niacctbase/niacctbase/sudoers
+++ b/recipes-ni/niacctbase/niacctbase/sudoers
@@ -1,3 +1,0 @@
-
-# Allow the admin user (UID 0) to invoke sudo without a password
-admin ALL=(ALL) NOPASSWD: ALL


### PR DESCRIPTION
### Summary of Changes
In dist-next, `ni-auth` no longer ships its NSS and PAM modules, and BSI only pulls `ni-auth` (not `pam-plugin-niauth` / `libnss-niauth`/`ni-auth-networkcontroller`). The old interactive login was the NIAuth-backed `'admin'` user (empty password), which only worked because those modules were pulled in transitively. With them gone, that login path no longer exists, so make the local `root `account usable out of the box instead.

  * `nilrt-image-base.inc`: add the `'empty-root-password'` and `'allow-empty-password'` image features so root keeps an empty `/etc/shadow` field and pam_unix/sshd accept it (the rootfs postprocess would otherwise zap it and nullok_secure would reject empty passwords over SSH).

  * `nilrt.conf`: drop the NIAuth-era `ROOT_HOME = "/home/admin"` and create new override `ROOT_HOME = /root` to follow systemd convention and latest FHS suggestion ([FYI](https://dev.azure.com/ni/DevCentral/_git/labview/pullRequest/1303859?discussionId=10158552#1782913218)).

  * `niacctbase.bb`: drop the `/home/root -> /home/admin` symlink from useradd_preinst and create new symlink from `/home/admin/` -> `/root` to support backward combability for LabVIEW VIs ([FYI](https://dev.azure.com/ni/DevCentral/_git/labview/pullRequest/1303859?discussionId=10158552#1782772987)).

  * `nilrt-proprietary.inc`: remove `ni-auth` from `NI_PROPRIETARY_COMMON_PACKAGES`; it is pulled in via BSI dependencies and should not be force-installed here.
  * Update all refs of `admin->root` as admin user won't exist in dist-next BSI.
  * `ni-acctsync`: at boot, `insert_root_hash` copies root's password field from the config-partition `.shadow` onto `shadow`. Guard `hash_sanity_check` so a stale locked * (the zap_empty_root_password artifact carried across reflashes on the config partition) is no longer restored — otherwise it re-locks `root `on every boot even though the image ships root blank. Also accept a ` !` -prefixed hash so a deliberately locked password (`passwd -l`) syncs, which the old SHA512 check rejected.


### Justification

[AB#3650235](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3650235)


Posted [Announcement ](https://teams.microsoft.com/l/message/19:0d061f31186241a89957d9b050f28240@thread.tacv2/1782727878691?tenantId=eb06985d-06ca-4a17-81da-629ab99f6505&groupId=e7f1f87e-1a21-4b20-b242-fde2ebf4b8ce&parentMessageId=1782727878691&teamName=RTOS&channelName=Announcements&createdTime=1782727878691)over Teams in multiple channels so that client teams are aware of this major change in Dist-Next.

Note: Don't merge immediately. We have dependency on this [PR](https://dev.azure.com/ni/DevCentral/_git/labview/pullrequest/1313659).

### Testing
* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have built the Safemode image with this PR in place. (`bitbake nilrt-safemode-rootfs`)
* [x] I have built the Base System Image feed with this PR in place. (`bitbake nilrt-base-system-image`)
* [x] I have boot tested Safemode Image & BSI on a `CRIO-9030` target. 
* [x] I have verified that password synchronization works for root user over Safemode & Runmode.
* [x] Verified `snac-configure` is working as expected.
* [x] Updated the [NI-Auth-Removal.md](https://dev.azure.com/ni/DevCentral/_git/AppCentral.wiki?path=/Organizations/Platform-HW-%26-Drivers/Squads/RTOS/Features/NI-Auth-Removal.md&version=GBwikiMaster&_a=preview) with all testing performed.
* [x] I verified a stale `*` in `/etc/natinst/share/.shadow` no longer locks root out on a freshly installed runmode — root stays blank/loginable (previously it re-locked to `root:*`), and the marker self-heals from `.shadow` after a clean reboot.
* [x] I verified a deliberate `passwd -l root` lock persists across reboot and is recoverable from `safemode`.
* [x] Provisioned a fresh VM via `recovery media` (set root password), installed this BSI → password synced to `runmode` and login succeeded.

Note: I have built the images using the custom packages (niauth & other split packages) produced by this [PR](https://dev.azure.com/ni/DevCentral/_git/labview/pullrequest/1313659). Then created a custom feed so they are installed in BSI by default while building.

## Snippets
**Safemode**

<img width="1152" height="686" alt="image" src="https://github.com/user-attachments/assets/f8858735-0a80-4f80-a0fd-c4466a2715f3" />



**Runmode**

<img width="1054" height="706" alt="image" src="https://github.com/user-attachments/assets/11abb3ff-ac74-4c93-a04a-0d0e89718a23" />




**Hardware Manager**:
Safemode
<img width="1919" height="1196" alt="image" src="https://github.com/user-attachments/assets/ce0c7806-a4b2-4e8e-9421-c8894972cd1c" />


Runmode
<img width="1919" height="1198" alt="image" src="https://github.com/user-attachments/assets/860e24ef-4f77-443a-bd7a-5c18419f4fca" />


Note: In Hardware Manager we can't add a fresh target with root user (Dist-next case) directly we need to add it first from terminal using ssh. [Filed Bug](https://dev.azure.com/ni/DevCentral/_workitems/edit/3930353).


**Password Synchronization**
- Set password in runmode. Reboot. Then login with that password in safemode.
<img width="1167" height="614" alt="image" src="https://github.com/user-attachments/assets/7e0d85d7-3533-4f53-8455-fd8dd1850955" />

- Remove password from safemode. Reboot. Then login in runmode.
<img width="1289" height="328" alt="image" src="https://github.com/user-attachments/assets/97496045-2804-4690-80cb-9c34bfe203c0" />


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
