### PR TITLE
env-config-container: Fix build by adding depends on niacctbase

### DIFF
--- a/recipes-core/images/files/container/init
+++ b/recipes-core/images/files/container/init
@@ -13,13 +13,11 @@ fi
 
 fw_setenv serial# $(hostname)
 
-setcap CAP_SYS_TIME+ep /sbin/hwclock.util-linux
-
 /etc/init.d/populateconfig start
+/etc/init.d/niauth start
 
-if [ -f /etc/init.d/niauth ]; then
-    /etc/init.d/niauth start
-fi
+# Bind-mount /boot so ni-arch-gen can detect it as mounted
+mount --bind /boot /boot
 
 /etc/init.d/run-postinsts start
 
@@ -27,6 +25,19 @@ if [ -x /postinst ]; then
     /postinst
     rm -f /postinst
 fi
+
+# Start D-Bus (required by Avahi)
+/etc/init.d/dbus-1 start
+
+/etc/init.d/avahi-daemon start
+/etc/init.d/nirtmdnsd start
+
+# Fix /run/natinst ownership so webserv can create PID file
+mkdir -p /run/natinst
+chown webserv:ni /run/natinst
+/etc/init.d/systemWebServer start
+
+/etc/init.d/sshd start
 
 # Execute the CMD passed to the container
 exec "$@"

--- a/recipes-core/images/files/container/nilrt-container.postinst
+++ b/recipes-core/images/files/container/nilrt-container.postinst
@@ -9,3 +9,16 @@
 # Update the package feed index and upgrade signing keys so users can
 # opkg install packages immediately.
 opkg update && opkg upgrade opkg-keyrings || true
+
+# Restore file capabilities lost during OCI image packaging (tar layers
+# do not preserve xattrs). These persist on the container filesystem
+# so they only need to be applied once.
+if command -v setcap >/dev/null 2>&1; then
+    if [ -x /sbin/hwclock.util-linux ]; then
+        setcap cap_sys_time+ep /sbin/hwclock.util-linux || true
+    fi
+    if [ -x /usr/local/natinst/share/NIWebServer/SystemWebServer ]; then
+        setcap cap_net_bind_service,cap_net_admin,cap_ipc_lock,cap_sys_rawio,cap_sys_boot,cap_sys_nice,cap_sys_time,cap_syslog+ep \
+            /usr/local/natinst/share/NIWebServer/SystemWebServer || true
+    fi
+fi

--- a/recipes-core/images/files/container/opkg-wrapper.sh
+++ b/recipes-core/images/files/container/opkg-wrapper.sh
@@ -1,0 +1,123 @@
+#!/bin/sh
+# opkg wrapper for NILRT containers.
+#
+# LabVIEW/VeriStand expect the target to reboot after installation so the
+# LabVIEW RT engine (lvrt) re-reads its startup application (e.g. the
+# VeriStand Engine rtexe). Containers are not rebooted, and an already-running
+# lvrt does not pick up a newly-installed startup app on its own.
+#
+# This wrapper runs the real opkg and, after a successful install/upgrade,
+# restarts nilvrt -- but ONLY when:
+#   1. an RT-relevant package was installed/upgraded (ni-veristand-engine*,
+#      ni-labview-realtime*), AND
+#   2. lvrt is currently idle, i.e. not serving an application.
+#
+# The idle check protects running work: installing an unrelated package
+# (trace-cmd, etc.) never restarts lvrt, and even an RT-relevant upgrade is
+# skipped while lvrt is actively running a VI/engine, so deployed
+# applications are not torn down underneath the user. lvrt opens its
+# application-level ports (VeriStand engine 2040/2050, VI Server 3363) only
+# while an application is loaded; when idle, none of them listen.
+#
+# Installed to /usr/local/bin/opkg, which precedes /usr/bin/opkg on PATH.
+
+REAL_OPKG=/usr/bin/opkg
+
+# lvrt_busy: return 0 (busy) if lvrt is currently serving an application, i.e.
+# any application-level port is in the LISTEN state (st == 0A in /proc/net/tcp):
+#   2040 -> 0x07F8 (VeriStand engine)
+#   2050 -> 0x0802 (VeriStand engine)
+#   3363 -> 0x0D23 (LabVIEW VI Server)
+# Returns 1 (idle) if none of them are listening.
+lvrt_busy() {
+    for f in /proc/net/tcp /proc/net/tcp6; do
+        [ -r "$f" ] || continue
+        if awk 'NR > 1 {
+                    split($2, a, ":")
+                    if ($4 == "0A" && (a[2] == "07F8" || a[2] == "0802" || a[2] == "0D23"))
+                        found = 1
+                }
+                END { exit found ? 0 : 1 }' "$f"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# is_rt_pkg: return 0 if the given package name is one whose installation
+# affects the lvrt startup application and therefore warrants a restart.
+is_rt_pkg() {
+    case "$1" in
+        ni-veristand-engine*|ni-labview-realtime*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+"$REAL_OPKG" "$@"
+rc=$?
+
+# Parse the opkg command line: find the subcommand (skipping global options and
+# their arguments) and collect the package-name operands that follow it.
+subcommand=""
+pkgs=""
+expect_option_arg=0
+for arg in "$@"; do
+    if [ -n "$subcommand" ]; then
+        case "$arg" in
+            -*) ;;            # ignore per-command options
+            *) pkgs="$pkgs $arg" ;;
+        esac
+        continue
+    fi
+    if [ "$expect_option_arg" -eq 1 ]; then
+        expect_option_arg=0
+        continue
+    fi
+    case "$arg" in
+        -f|--conf|-o|--offline-root|-t|--tmp-dir|-l|--lists-dir|--cache|--add-arch|--add-dest)
+            expect_option_arg=1
+            ;;
+        --conf=*|--offline-root=*|--tmp-dir=*|--lists-dir=*|--cache=*|--add-arch=*|--add-dest=*)
+            ;;
+        -*)
+            ;;
+        *)
+            subcommand="$arg"
+            ;;
+    esac
+done
+
+# Decide whether an RT-relevant package was involved.
+rt_relevant=0
+case "$subcommand" in
+    install)
+        for p in $pkgs; do
+            if is_rt_pkg "$p"; then rt_relevant=1; break; fi
+        done
+        ;;
+    upgrade)
+        if [ -z "$pkgs" ]; then
+            # "opkg upgrade" with no operands upgrades everything, which may
+            # include an RT package; rely on the idle gate below.
+            rt_relevant=1
+        else
+            for p in $pkgs; do
+                if is_rt_pkg "$p"; then rt_relevant=1; break; fi
+            done
+        fi
+        ;;
+esac
+
+# Restart lvrt only on a successful, RT-relevant transaction while lvrt is idle.
+if [ "$rc" -eq 0 ] && [ "$rt_relevant" -eq 1 ] && [ -x /etc/init.d/nilvrt ]; then
+    if lvrt_busy; then
+        echo "opkg: lvrt is serving an application; skipping lvrt restart to avoid interrupting it." >&2
+    else
+        echo "opkg: restarting lvrt to launch newly-installed RT application..." >&2
+        /etc/init.d/nilvrt stop 2>/dev/null
+        sleep 1
+        /etc/init.d/nilvrt start 2>/dev/null
+    fi
+fi
+
+exit $rc

--- a/recipes-core/images/includes/nilrt-container.inc
+++ b/recipes-core/images/includes/nilrt-container.inc
@@ -9,9 +9,24 @@ FORCE_RO_REMOVE = "1"
 # The backing func will test the installed package manifest and only
 # issue an opkg remove if the package name is present. So no wildcards.
 ROOTFS_RO_UNNEEDED = "\
-	ni-arch-gen \
 	kernel-devsrc \
 "
+
+# Ensure ni-arch-gen is available in all container variants to generate
+# /etc/opkg/ni-arch.conf at first boot via run-postinsts.
+IMAGE_INSTALL_NODEPS += "ni-arch-gen"
+
+# ni-sysapi-webservice provides the /nisysapi/server endpoint needed
+# for NI MAX connectivity.
+# ni-auth is required by SystemWebServer (segfaults without niauth_daemon).
+# ni-system-webserver provides the web server for deployment and discovery
+# by NI MAX and VeriStand.
+# ni-webdav-system-webserver-support provides mod_nidav.so for WebDAV file
+# deployment (how VeriStand deploys .rtexe to /c).
+IMAGE_INSTALL_NODEPS += "ni-sysapi-webservice ni-auth ni-system-webserver ni-webdav-system-webserver-support"
+
+# nirtmdnsd provides NI RT mDNS service for target discovery.
+IMAGE_INSTALL_NODEPS += "nirtmdnsd"
 
 # Necessary whenever building a container.
 # Though this appears to do nothing, given how our kernel recipes are constructed.
@@ -54,14 +69,41 @@ fakeroot container_rootfs_post() {
 
 	install -m 544 ${SFILES}/init ${IMAGE_ROOTFS}/init
 	install -m 0755 ${SFILES}/nilrt-container.postinst ${IMAGE_ROOTFS}/postinst
+
+	# Shadow /usr/bin/opkg with a wrapper that restarts lvrt after
+	# install/upgrade so newly-installed RT applications (e.g. the VeriStand
+	# Engine) launch without requiring a container reboot. /usr/local/bin
+	# precedes /usr/bin on PATH.
+	install -d ${IMAGE_ROOTFS}${prefix}/local/bin
+	install -m 0755 ${SFILES}/opkg-wrapper.sh ${IMAGE_ROOTFS}${prefix}/local/bin/opkg
 }
 ROOTFS_POSTPROCESS_COMMAND += " container_rootfs_post; "
 
+# Inject dummy opkg status entries for packages that segfault in containers.
+# This makes opkg believe ni-dim/ni-mdbg are already installed at a very high
+# version, satisfying any ">=" constraints from dependent packages (e.g.
+# ni-daqmx-ef requires ni-dim >= 26.3.0) without actually installing them.
+CONTAINER_DUMMY_OPKG_PACKAGES = "ni-dim ni-dim-dkms ni-dim-libs ni-dim-sysapi libnidimu1 ni-mdbg ni-mdbg-dkms ni-mdbg-errors"
+fakeroot container_inject_dummy_deps() {
+	statusfile="${IMAGE_ROOTFS}/var/lib/opkg/status"
+	infodir="${IMAGE_ROOTFS}/var/lib/opkg/info"
+	install -d "$infodir"
+	for pkg in ${CONTAINER_DUMMY_OPKG_PACKAGES}; do
+		cat >> "$statusfile" <<EOF
+
+Package: ${pkg}
+Version: 99.0.0
+Status: install ok installed
+Architecture: all
+Description: Dummy entry - prevents installation in containers
+EOF
+		# opkg expects an installed package to have a corresponding .list file.
+		: > "$infodir/${pkg}.list"
+	done
+}
+IMAGE_PREPROCESS_COMMAND += " container_inject_dummy_deps; "
 
 fakeroot container_image_pre() {
-	# configure opkg
-	echo "arch DeviceCode77E1 51" >>${IMAGE_ROOTFS}/${sysconfdir}/opkg/arch.conf
-
 	# remake some removed volatile directories that do_rootfs removes
 	install -m 1777 -d ${IMAGE_ROOTFS}/${localstatedir}/volatile/tmp
 	install -m 755 -d ${IMAGE_ROOTFS}/${localstatedir}/volatile/log
@@ -69,5 +111,15 @@ fakeroot container_image_pre() {
 	# Workaround for nirtcfg's ni-rt.ini.lock bug
 	# /run/lock cannot have the sticky-bit set.
 	install -m 777 -d ${IMAGE_ROOTFS}/run/lock
+
+	# Enable sshd by default in containers
+	if ! grep -q '^\[systemsettings\]' ${IMAGE_ROOTFS}${sysconfdir}/natinst/share/ni-rt.ini 2>/dev/null; then
+		printf '\n[systemsettings]\n' >> ${IMAGE_ROOTFS}${sysconfdir}/natinst/share/ni-rt.ini
+	fi
+	if grep -q '^sshd\.enabled=' ${IMAGE_ROOTFS}${sysconfdir}/natinst/share/ni-rt.ini 2>/dev/null; then
+		sed -i 's/^sshd\.enabled=.*/sshd.enabled="True"/' ${IMAGE_ROOTFS}${sysconfdir}/natinst/share/ni-rt.ini
+	else
+		sed -i '/^\[systemsettings\]/a sshd.enabled="True"' ${IMAGE_ROOTFS}${sysconfdir}/natinst/share/ni-rt.ini
+	fi
 }
 IMAGE_PREPROCESS_COMMAND += " container_image_pre; "

--- a/recipes-ni/env-config-container/env-config-container.bb
+++ b/recipes-ni/env-config-container/env-config-container.bb
@@ -5,6 +5,11 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 SECTION = "base"
 
 
+# niacctbase defines the 'ni' group (gid 500) via useradd-staticids and stages
+# it into the pseudo group database, so the do_package output-hash reverse
+# lookup (getgrgid(500)) resolves instead of failing as host contamination.
+DEPENDS += "niacctbase"
+
 RDEPENDS:${PN} = "bash"
 
 SRC_URI = "\
@@ -18,7 +23,12 @@ do_install () {
 	install -d ${D}${base_sbindir}
 
 	# Install wrapper scripts with .wrapper suffix (softlinks will be created by init)
-	install -m 0550   ${S}/fw_printenv.wrapper ${D}${base_sbindir}/
-	install -m 0550   ${S}/fw_setenv.wrapper   ${D}${base_sbindir}/
+	# fw_printenv needs group 'ni' (gid 500) execute permission because
+	# SystemWebServer runs as webserv:ni and libnitargetcfg calls
+	# /sbin/fw_printenv to read DeviceCode/DeviceDesc. Without execute
+	# access, NI MAX shows model "Pele".
+	install -m 0550 ${S}/fw_printenv.wrapper ${D}${base_sbindir}/
+	chgrp ${LVRT_GROUP} ${D}${base_sbindir}/fw_printenv.wrapper
+	install -m 0550 ${S}/fw_setenv.wrapper ${D}${base_sbindir}/
 }
 

--- a/recipes-ni/env-config-container/files/fw_printenv.wrapper
+++ b/recipes-ni/env-config-container/files/fw_printenv.wrapper
@@ -2,6 +2,17 @@
 # Wrapper for fw_printenv that reads from grubenv
 GRUBENV="/boot/grub/grubenv"
 
+# Read the grub environment block directly instead of using grub-editenv.
+# grub-editenv tries to canonicalize the backing block device of the file's
+# filesystem, which fails on a container's overlayfs rootfs with
+# "failed to get canonical path of 'overlay'". The grubenv is a plain-text
+# "GRUB Environment Block": a header comment, name=value lines, then '#'
+# padding. Stripping all '#' lines yields the same output as
+# `grub-editenv list`.
+grubenv_list() {
+    grep -v '^#' "$GRUBENV"
+}
+
 # Parse arguments
 SUPPRESS_NAME=0
 if [[ "$1" == "-n" ]]; then
@@ -13,10 +24,10 @@ VAR_NAME="$1"
 
 if [[ -z "$VAR_NAME" ]]; then
     # List all variables
-    grub-editenv "$GRUBENV" list
+    grubenv_list
 else
     # Get specific variable
-    VALUE=$(grub-editenv "$GRUBENV" list | grep "^${VAR_NAME}=" | cut -d= -f2-)
+    VALUE=$(grubenv_list | grep "^${VAR_NAME}=" | cut -d= -f2-)
     if [[ -n "$VALUE" ]]; then
         if [[ $SUPPRESS_NAME -eq 1 ]]; then
             echo "$VALUE"


### PR DESCRIPTION
### Summary of Changes
`env-config-container` fails to build with error sbin/fw_printenv.wrapper is owned by uid 0, gid 500, which doesn't match any user/group on target. This may be due to host contamination.

[files/group](https://github.com/ni/meta-nilrt/blob/404bf7340c576e21db782b29b08e4e2b03a2399f/files/group#L5) defines 500, `niacctbase` makes the group exist in time for [chgrp](https://github.com/ni/meta-nilrt/blob/404bf7340c576e21db782b29b08e4e2b03a2399f/recipes-ni/env-config-container/env-config-container.bb#L26).



### Justification

[AB#3910152](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3910152).
<img width="1121" height="718" alt="env-config build issue" src="https://github.com/user-attachments/assets/e30701d7-47c9-4d3e-be58-da5dfd3a7e03" />




### Testing

- [x] `bitbake packagefeed-ni-core`
- [x] `bitbake package-index`
- [x] `bitbake nilrt-runmode-container`
- [x] `bitbake nilrt-slim-container`
