### PR TITLE
sysctl.conf: Improve ARP handling for multi-interface setups

### DIFF
--- a/recipes-extended/procps/files/sysctl.conf
+++ b/recipes-extended/procps/files/sysctl.conf
@@ -19,6 +19,14 @@ vm.overcommit_memory=2
 # behavior of their TCP timestamps.
 net.ipv4.tcp_timestamps=0
 
+# Reduce ARP flux on multi-interface systems:
+# - reply only on the incoming interface (arp_ignore=1)
+# - use the best local IP for ARP requests (arp_announce=2)
+net.ipv4.conf.all.arp_ignore=1
+net.ipv4.conf.all.arp_announce=2
+net.ipv4.conf.default.arp_ignore=1
+net.ipv4.conf.default.arp_announce=2
+
 # Reduce vm expire/writeback timeouts to help guarantee that all data is written
 # to disk in a relatively predictable timespan, in case of a power outage
 vm.dirty_expire_centisecs=300


### PR DESCRIPTION
Configure arp_ignore=1 to reply only on the incoming interface and arp_announce=2 to use the best local IP for ARP requests. This helps prevent ARP flux and incorrect source IP usage in multi-homed environments.

Same configuration exists on Ethernet cDAQ.

Suggested-by: Brenda Streiff <brenda.streiff@emerson.com>

### Justification

WI: [AB#3876639](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3876639)

### Testing

* [x] Made these changes on a VM with one interface, no issues noticed.
* [x] These changes were previously tested by Soe, Wai Jon who saw issues without the change on multi-interface system; [ref](https://teams.microsoft.com/l/message/19:nR89bVO-au7JO-aO_nWh1-gD-lWZC379UhRijwW0gKo1@thread.tacv2/1778204694156?tenantId=eb06985d-06ca-4a17-81da-629ab99f6505&groupId=e7f1f87e-1a21-4b20-b242-fde2ebf4b8ce&parentMessageId=1778180762345&teamName=RTOS&channelName=RTOS%20General&createdTime=1778204694156). I did not perform any additional testing on multi-interface systems.
* [x] Verified `net.ipv4.conf.default*` changes by creating new interfaces and validating that they got the right settings (`1` and `2`). Without these changes new interfaces would get `0`s for these settings.

```
ip link add veth0 type veth peer name veth1
ip link set veth0 up
ip link set veth1 up

sysctl net.ipv4.conf.veth0.arp_ignore
sysctl net.ipv4.conf.veth0.arp_announce
sysctl net.ipv4.conf.veth1.arp_ignore
sysctl net.ipv4.conf.veth1.arp_announce
```

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
