### PR TITLE
nilrt-safemode-initramfs: Remove tzdata via IMAGE_INSTALL instead of PACKAGE_EXCLUDE

### DIFF
--- a/recipes-core/images/nilrt-safemode-initramfs.bb
+++ b/recipes-core/images/nilrt-safemode-initramfs.bb
@@ -30,8 +30,8 @@ IMAGE_LINGUAS:remove = "ja-jp.windows-31j zh-cn.cp936"
 # Do not allow python to be installed into safemode ramdisk due to size
 PACKAGE_EXCLUDE += "python-core python3-core"
 
-# Do not allow tzdata to be installed into safemode ramdisk due to size
-PACKAGE_EXCLUDE += "packagegroup-ni-tzdata"
+# Remove tzdata from the safemode ramdisk to save space.
+IMAGE_INSTALL:remove = "packagegroup-ni-tzdata"
 
 PACKAGE_EXCLUDE += "rauc-mark-good"
 


### PR DESCRIPTION
### Summary of Changes
The safemode initramfs build emitted a do_rootfs [warning ](https://dev.azure.com/ni/DevCentral/Stratus%20Infrastructure%20(RDSS)/_build/results?buildId=20106602&view=logs&j=cb3acf64-16cd-50a6-9c15-1e3f61120cd9&t=388f1a6a-6558-5a7a-1c9c-9656a7b687e5&l=39747)because packagegroup-ni-tzdata was both inherited into [IMAGE_INSTALL ](https://github.com/ni/meta-nilrt/blob/0ad457d2356acb705da8228586fa4cbac6a18e9e/recipes-core/images/includes/nilrt-image-base.inc#L14)and listed in [PACKAGE_EXCLUDE](https://github.com/ni/meta-nilrt/blob/0ad457d2356acb705da8228586fa4cbac6a18e9e/recipes-core/images/nilrt-safemode-initramfs.bb#L34). This PR removes it from the install list instead, eliminating the warning while keeping the same size savings.


### Justification

[AB#3738530](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3738530)


### Testing

* [x] I have built the x64 safemode image with this PR in place. (`bitbake nilrt-safemode-rootfs`)
* [x] Boot tested x64 safemode on a target and verified BSI installation works. Also, no tzdata package is present.

<img width="784" height="290" alt="image" src="https://github.com/user-attachments/assets/9f82e60f-28f7-49f9-bb81-4787b11ae619" />

* [x] I have built the arm safemode image with this PR in place. (`bitbake linux-nilrt-arm-safemode`)
* [x] Boot tested arm safemode on a target and verified BSI installation works. Also, no tzdata package is present.

<img width="846" height="314" alt="image" src="https://github.com/user-attachments/assets/e89da0d1-35b5-495a-972a-bf4b1cfe4d30" />




### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).


- [x] This PR should be cherry-picked to [-next](https://github.com/ni/meta-nilrt/tree/nilrt/master/next) and [release](https://github.com/ni/meta-nilrt/tree/nilrt/26.5/scarthgap) branch. 
