### PR TITLE
linux: set NI_RELEASE_VERSION for 26.5 release

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-arm-safemode_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-arm-safemode_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "NILRT safemode itb for ARM targets"
-NI_RELEASE_VERSION = "master"
+NI_RELEASE_VERSION = "26.5"
 LINUX_VERSION:xilinx-zynq = "4.14"
 COMPATIBLE_MACHINE = "xilinx-zynq"
 

--- a/recipes-kernel/linux/linux-nilrt-debug_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-debug_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "NILRT linux kernel debug build"
-NI_RELEASE_VERSION = "master"
+NI_RELEASE_VERSION = "26.5"
 LINUX_VERSION = "6.12"
 LINUX_VERSION:xilinx-zynq = "4.14"
 LINUX_KERNEL_TYPE = "debug"

--- a/recipes-kernel/linux/linux-nilrt-next_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-next_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "NILRT linux kernel next development build"
-NI_RELEASE_VERSION = "master"
+NI_RELEASE_VERSION = "26.5"
 LINUX_VERSION = "6.18"
 LINUX_KERNEL_TYPE = "next"
 

--- a/recipes-kernel/linux/linux-nilrt-nohz_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-nohz_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "NILRT linux kernel full dynamic ticks (NO_HZ_FULL) build"
-NI_RELEASE_VERSION = "master"
+NI_RELEASE_VERSION = "26.5"
 LINUX_VERSION = "6.12"
 LINUX_KERNEL_TYPE = "nohz"
 

--- a/recipes-kernel/linux/linux-nilrt_git.bb
+++ b/recipes-kernel/linux/linux-nilrt_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "Linux kernel based on nilrt branch"
-NI_RELEASE_VERSION = "master"
+NI_RELEASE_VERSION = "26.5"
 LINUX_VERSION = "6.12"
 LINUX_VERSION:xilinx-zynq = "4.14"
 


### PR DESCRIPTION
### Summary of Changes

linux: set NI_RELEASE_VERSION for 26.5 release

### Justification

WI: [AB#3738543](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3738543)

### Testing

None

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
