### PR TITLE
packagegroup-ni-internal-deps: add fwupd and fwupd-efi

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-internal-deps.bb
@@ -129,3 +129,11 @@ RDEPENDS:${PN} += "\
 RDEPENDS:${PN} += "\
 	minizip \
 "
+
+# Required by niControllerDriver
+# Team: Core Software & Drivers
+# Contact: Kevin Khai-Wern Lim
+RDEPENDS:${PN}:append:x64 = "\
+	fwupd \
+	fwupd-efi \
+"


### PR DESCRIPTION
### Summary of Changes

Add required niControllerDriver dependencies: fwupd and fwupd-efi to the core package feed. They will be used for EFI firmware updates on some x64 targets.

### Justification

Requested via email by Core Software & Drivers group. Skipped creating an AZDO work item since it is small request.

### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] Served resulting .ipks from local feed and verified installation works on a cRIO-904x.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).

### Note to maintainers

Please cherry-pick in this cycle's release branch `nilrt/26.5/scarthgap` and `nilrt/master/next`