### PR TITLE
local.conf.sample: Document xilinx-zynq as a supported machine value

### DIFF
--- a/conf/templates/default/local.conf.sample
+++ b/conf/templates/default/local.conf.sample
@@ -16,7 +16,7 @@
 
 #
 # Machine Selection
-#   Supported NILRT machine values are: x64
+#   Supported NILRT machine values are: x64, xilinx-zynq
 MACHINE ?= "x64"
 
 # Distribution selection


### PR DESCRIPTION
### Summary of Changes

local.conf.sample: Document xilinx-zynq as a supported machine value

No WI.

### Testing

None

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).

Needs to be cherry-picked into `nilrt/26.5/scarthgap` and `nilrt/master/next`.