### PR TITLE
Seal LUKS encryption keys against measured boot artifacts

### DIFF
--- a/recipes-bsp/grub/grub-nilrt.inc
+++ b/recipes-bsp/grub/grub-nilrt.inc
@@ -4,6 +4,7 @@ SRC_URI += "\
 	file://cmd-test-Add-bitwise-AND-document-the-feature.patch \
 	file://grub-advertise-NI-NILRT-over-GNU-GRUB.patch \
 	file://add-inbit-command-to-io-module.patch \
+	file://add-pcr15-verifier-for-measured-boot.patch \
 	file://cfg \
 	file://grub.d \
 "

--- a/recipes-bsp/grub/grub/add-pcr15-verifier-for-measured-boot.patch
+++ b/recipes-bsp/grub/grub/add-pcr15-verifier-for-measured-boot.patch
@@ -1,0 +1,131 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jeffrey Pautler <jeffrey.pautler@emerson.com>
+Date: Mon, 22 Jun 2026 17:06:37 -0500
+Subject: [PATCH] grub: add PCR 15 verifier for NILRT measured boot
+
+Add a second TPM verifier that extends PCR 15 with the hashes of
+boot-relevant files. This enables NILRT measured boot, where LUKS
+decryption keys are sealed against a curated set of boot artifacts
+that can be pre-calculated from userspace ahead of a reboot.
+
+Only the following file types are measured into PCR 15:
+  GRUB_FILE_TYPE_CONFIG       grub.cfg, grubvar_readonly, bootmode,
+                              bootimage.cfg, cpu-mitigations.cfg, etc.
+  GRUB_FILE_TYPE_LOADENV      grubenv
+  GRUB_FILE_TYPE_LINUX_KERNEL bzImage
+  GRUB_FILE_TYPE_LINUX_INITRD ramdisk.xz
+
+All other file types (modules, fonts, themes, signature files, etc.)
+are excluded. This keeps PCR 15 small and pre-calculable.
+
+Unlike PCR 8/9, which accumulate ~140 GRUB-internal measurements for
+our config covering every command run and every file read, PCR 15 is
+application-specific (starts at 0x00...00 each boot) and contains only
+the files listed above. NILRT userspace tooling replicates the same
+measurement sequence to pre-calculate the value ahead of a reboot:
+  new_PCR = SHA256(current_PCR || SHA256(file_content))
+
+Upstream-Status: Inappropriate [NI NILRT specific]
+
+---
+ grub-core/commands/tpm.c | 69 ++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 69 insertions(+)
+
+diff --git a/grub-core/commands/tpm.c b/grub-core/commands/tpm.c
+--- a/grub-core/commands/tpm.c
++++ b/grub-core/commands/tpm.c
+@@ -29,6 +29,9 @@
+ 
+ GRUB_MOD_LICENSE ("GPLv3+");
+ 
++/* PCR index used for NILRT measured boot artifact measurements */
++#define GRUB_MEASURED_BOOT_PCR 15
++
+ static grub_err_t
+ grub_tpm_verify_init (grub_file_t io,
+ 		      enum grub_file_type type __attribute__ ((unused)),
+@@ -104,6 +107,70 @@
+   .verify_string = grub_tpm_verify_string,
+ };
+ 
++/*
++ * PCR 15 verifier for NILRT measured boot.
++ *
++ * Extends PCR 15 with the hashes of boot-relevant files. Only the
++ * following file types are measured; all others are skipped:
++ *   GRUB_FILE_TYPE_CONFIG, GRUB_FILE_TYPE_LOADENV,
++ *   GRUB_FILE_TYPE_LINUX_KERNEL, GRUB_FILE_TYPE_LINUX_INITRD
++ *
++ * The measurement formula is identical to PCR 8/9:
++ *   new_PCR = SHA256(current_PCR || SHA256(file_content))
++ *
++ * PCR 15 starts at 0x00...00 on each boot (application-specific PCR;
++ * not extended by UEFI firmware or GRUB internals before this verifier
++ * runs). NILRT userspace tooling replicates this same sequence
++ * to pre-calculate the expected PCR 15 before resealing LUKS keys.
++ */
++static grub_err_t
++grub_tpm_pcr15_verify_init (grub_file_t io,
++			     enum grub_file_type type,
++			     void **context,
++			     enum grub_verify_flags *flags)
++{
++  enum grub_file_type t = type & GRUB_FILE_TYPE_MASK;
++
++  /*
++   * Measure only boot-relevant file types into PCR 15. Skip modules,
++   * fonts, themes, signature files, and all other file types.
++   */
++  if (t != GRUB_FILE_TYPE_CONFIG &&
++      t != GRUB_FILE_TYPE_LOADENV &&
++      t != GRUB_FILE_TYPE_LINUX_KERNEL &&
++      t != GRUB_FILE_TYPE_LINUX_INITRD)
++    {
++      *flags |= GRUB_VERIFY_FLAGS_SKIP_VERIFICATION;
++      return GRUB_ERR_NONE;
++    }
++
++  *context = io->name;
++  *flags |= GRUB_VERIFY_FLAGS_SINGLE_CHUNK;
++  return GRUB_ERR_NONE;
++}
++
++static grub_err_t
++grub_tpm_pcr15_verify_write (void *context, void *buf, grub_size_t size)
++{
++  grub_err_t status = grub_tpm_measure (buf, size, GRUB_MEASURED_BOOT_PCR,
++					context);
++
++  if (status == GRUB_ERR_NONE)
++    return GRUB_ERR_NONE;
++
++  grub_dprintf ("tpm", "PCR 15 measuring failed for %s: %d\n",
++		(char *) context, status);
++  return grub_is_tpm_fail_fatal () ? status : GRUB_ERR_NONE;
++}
++
++/* No .verify_string: only files (not strings, e.g. the kernel cmdline)
++ * are measured into PCR 15, keeping the value reproducible. */
++static struct grub_file_verifier grub_tpm_pcr15_verifier = {
++  .name = "tpm-pcr15",
++  .init = grub_tpm_pcr15_verify_init,
++  .write = grub_tpm_pcr15_verify_write,
++};
++
+ GRUB_MOD_INIT (tpm)
+ {
+   /*
+@@ -115,6 +168,7 @@
+   if (!grub_tpm_present())
+     return;
+   grub_verifier_register (&grub_tpm_verifier);
++  grub_verifier_register (&grub_tpm_pcr15_verifier);
+ }
+ 
+ GRUB_MOD_FINI (tpm)
+@@ -122,4 +176,5 @@
+   if (!grub_tpm_present())
+     return;
+   grub_verifier_unregister (&grub_tpm_verifier);
++  grub_verifier_unregister (&grub_tpm_pcr15_verifier);
+ }

--- a/recipes-ni/ni-device-encryption/ni-device-encryption.bb
+++ b/recipes-ni/ni-device-encryption/ni-device-encryption.bb
@@ -18,6 +18,7 @@ SRC_URI = "\
 	file://bin/ \
 	file://init/ \
 	file://share/ \
+	file://src/ \
 "
 
 S = "${UNPACKDIR}"
@@ -31,6 +32,14 @@ S = "${UNPACKDIR}"
 inherit update-rc.d
 INITSCRIPT_PARAMS = "start 30 S ."
 INITSCRIPT_NAME = "ni-cryptdisks.sh"
+
+
+# ==============================================================================
+# BUILD DEPENDENCIES
+# ==============================================================================
+
+# openssl: required to build ni-pcr-precalc (links against -lcrypto)
+DEPENDS += "openssl"
 
 
 # ==============================================================================
@@ -52,9 +61,15 @@ do_install () {
 	install -d ${D}${datadir}
 	ln -sf ${libdir}/${BPN}/share ${D}${datadir}/${BPN}
 
-	# Install sbin symlink
+	# Install sbin symlinks
 	install -d ${D}${sbindir}
 	ln -sf ${libdir}/${BPN}/bin/ni-reseal-luks.sh ${D}${sbindir}/ni-reseal-luks
+	ln -sf ${libdir}/${BPN}/bin/ni-pcr-precalc ${D}${sbindir}/ni-pcr-precalc
+
+	# Install PCR artifact lists to the package share directory, where they
+	# are reachable from both the safemode initramfs and the runmode rootfs.
+	install -m 0644 ${S}/share/ni-pcr-runmode-artifacts.list ${D}${libdir}/${BPN}/share/ni-pcr-runmode-artifacts.list
+	install -m 0644 ${S}/share/ni-pcr-safemode-artifacts.list ${D}${libdir}/${BPN}/share/ni-pcr-safemode-artifacts.list
 
 	# Install initscript
 	install -d ${D}${sysconfdir}/init.d
@@ -76,3 +91,5 @@ RDEPENDS:${PN} = "\
 	util-linux-blkid \
 	util-linux-logger \
 "
+
+FILES:${PN} += "${libdir}/${BPN}/share/ni-pcr-runmode-artifacts.list ${libdir}/${BPN}/share/ni-pcr-safemode-artifacts.list"

--- a/recipes-ni/ni-device-encryption/ni-device-encryption.bb
+++ b/recipes-ni/ni-device-encryption/ni-device-encryption.bb
@@ -86,6 +86,8 @@ RDEPENDS:${PN} = "\
 	bash \
 	clevis \
 	cryptsetup \
+	jose \
+	jq \
 	libdevmapper \
 	lvm2 \
 	util-linux-blkid \

--- a/recipes-ni/ni-device-encryption/ni-device-encryption/.gitignore
+++ b/recipes-ni/ni-device-encryption/ni-device-encryption/.gitignore
@@ -1,2 +1,3 @@
 share/pkg.sh
 init/ni-cryptdisks.sh
+bin/ni-pcr-precalc

--- a/recipes-ni/ni-device-encryption/ni-device-encryption/Makefile
+++ b/recipes-ni/ni-device-encryption/ni-device-encryption/Makefile
@@ -4,11 +4,23 @@ DESCRIPTION := Tools for encrypting NI devices.
 VERSION ?= dev
 
 
+# TOOLCHAIN
+
+CC  ?= gcc
+CFLAGS  ?= -Wall -Wextra -O2
+LDFLAGS ?=
+LDLIBS  += -lcrypto
+
+
 # SOURCE FILES
 
 srcdir = .
 srcdatadir = $(srcdir)/share
 srcbindir = $(srcdir)/bin
+srcsrcdir = $(srcdir)/src
+
+# Compiled binaries
+ni_pcr_precalc = $(srcbindir)/ni-pcr-precalc
 
 SRC = \
 	$(wildcard $(srcbindir)/*) \
@@ -34,6 +46,9 @@ pkglibdir = $(libdir)/$(PACKAGE)
 # ==============================================================================
 # REAL TARGETS
 # ==============================================================================
+
+$(ni_pcr_precalc) : $(srcsrcdir)/ni-pcr-precalc.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< $(LDLIBS)
 
 $(PACKAGE).pc :
 	@{ \
@@ -67,7 +82,7 @@ init/ni-cryptdisks.sh : init/ni-cryptdisks.sh.in
 # PHONY TARGETS
 # ==============================================================================
 
-all : $(SRC) $(PACKAGE).pc
+all : $(SRC) $(PACKAGE).pc $(ni_pcr_precalc)
 .PHONY : all
 
 
@@ -75,6 +90,7 @@ clean :
 	rm -f $(PACKAGE).pc
 	rm -f $(srcdatadir)/pkg.sh
 	rm -f init/ni-cryptdisks.sh
+	rm -f $(ni_pcr_precalc)
 .PHONY : clean
 
 

--- a/recipes-ni/ni-device-encryption/ni-device-encryption/bin/ni-reseal-luks.sh
+++ b/recipes-ni/ni-device-encryption/ni-device-encryption/bin/ni-reseal-luks.sh
@@ -36,6 +36,19 @@ source "$SCRIPT_DIR/../share/const_luks.sh" || exit ${EXITCODES[IMPORT_ERROR]}
 # ==============================================================================
 
 
+# Shreds any temporary key/PCR material recorded in _cleanup_files. Registered
+# as the EXIT trap so that secrets are never left behind in /dev/shm if the
+# script aborts partway through (e.g. via 'set -e').
+function _cleanup() {
+	set +e
+	local f
+	for f in "${_cleanup_files[@]}"; do
+		[ -n "$f" ] && [ -e "$f" ] && shred -u "$f"
+	done
+	_cleanup_files=()
+}
+
+
 # Checks that the script is being run in a suitable environment.
 function _check_env() {
 	if [[ "$EUID" -ne 0 ]]; then
@@ -123,7 +136,7 @@ function _reseal_device_keyslot() {
 	if [ -z "$master_keyfile" ]; then
 		local keyfile=$(mktemp -p /dev/shm ni-reseal-luks.XXXXXX.keyfile)
 		chmod 0600 "$keyfile"
-		trap "shred -u $keyfile" EXIT
+		_cleanup_files+=("$keyfile")
 
 		clevis luks pass -d "$device" -s "$keyslot" >"$keyfile" || {
 			echo >&2 "ERROR: No master keyfile provided, but no existing clevis bind policy on $device, slot $keyslot. Unable to make an original seal without the master keyfile."
@@ -135,7 +148,7 @@ function _reseal_device_keyslot() {
 
 	if $opt_dry_run; then
 		echo >&2 "Dry run. Skipping."
-		test -z "$master_keyfile" && shred -u "$keyfile" && trap - EXIT || :
+		test -z "$master_keyfile" && shred -u "$keyfile" || :
 		return
 	fi
 
@@ -163,7 +176,7 @@ function _reseal_device_keyslot() {
 	fi
 	
 	# Clean up the tempkey, if we're using one
-	test -z "$master_keyfile" && shred -u "$keyfile" && trap - EXIT || :
+	test -z "$master_keyfile" && shred -u "$keyfile" || :
 }
 
 
@@ -239,6 +252,9 @@ opt_yes=false
 arg_keyfile=""
 arg_label=""
 
+# Temporary state cleaned up by the EXIT trap (_cleanup).
+_cleanup_files=()
+
 
 # ==============================================================================
 # MAIN
@@ -246,6 +262,9 @@ arg_label=""
 
 _check_env || exit ${EXITCODES[BADENV]}
 parse_args "$@" || exit ${EXITCODES[BADARGS]}
+
+# Ensure temporary secrets are cleaned up on any exit.
+trap _cleanup EXIT
 
 # Determine which LUKS devices to reseal.
 if [[ -n "$arg_label" ]]; then

--- a/recipes-ni/ni-device-encryption/ni-device-encryption/bin/ni-reseal-luks.sh
+++ b/recipes-ni/ni-device-encryption/ni-device-encryption/bin/ni-reseal-luks.sh
@@ -6,6 +6,14 @@
 # and runmode boot components (kernel, initramfs, grub config, et c.), and
 # enrolls the new hashes as valid values to release the LUKS decryption keys
 # for the niconfig and userfs partitions.
+#
+# PCR 15 is pre-calculated from the artifact lists and sealed together with
+# PCR 7 (Secure Boot state) using Clevis's pcr_digest parameter. This allows
+# the keys to be resealed before rebooting, eliminating the vulnerability window
+# that would otherwise exist if we decrypted, rebooted, and then resealed. Also,
+# rebooting to get the new PCR values would be difficult because we would have
+# to reboot to both safemode and runmode since the PCR values are different for
+# each boot mode.
 set -e
 
 # ==============================================================================
@@ -21,7 +29,6 @@ declare -A EXITCODES=(
 )
 
 PCR_BANK="sha256"
-PCR_INDEXES="7"
 
 # ==============================================================================
 # IMPORTS
@@ -36,9 +43,52 @@ source "$SCRIPT_DIR/../share/const_luks.sh" || exit ${EXITCODES[IMPORT_ERROR]}
 # ==============================================================================
 
 
-# Shreds any temporary key/PCR material recorded in _cleanup_files. Registered
-# as the EXIT trap so that secrets are never left behind in /dev/shm if the
-# script aborts partway through (e.g. via 'set -e').
+# Prints the LUKS2 metadata of $device as JSON on stdout.
+function _luks_json() {
+	local device="$1"
+	cryptsetup luksDump --dump-json-metadata "$device" 2>/dev/null
+}
+
+
+# Prints the numbers of all active LUKS keyslots on $device, one per line, in
+# ascending numeric order.
+function _luks_active_keyslots() {
+	local device="$1"
+	_luks_json "$device" | jq -r '.keyslots | keys_unsorted[]' | sort -n
+}
+
+
+# Prints the ids of all clevis tokens bound to keyslot $keyslot on $device, one
+# per line. LUKS2 tokens reference keyslots via a "keyslots" array and a token
+# id is independent of the keyslot number, so this correctly handles both the
+# id != slot case and a keyslot carrying more than one clevis token.
+function _clevis_token_ids_for_slot() {
+	local device="$1"
+	local keyslot="$2"
+	_luks_json "$device" \
+		| jq -r --arg ks "$keyslot" \
+			'.tokens | to_entries[]
+			 | select(.value.type == "clevis" and (.value.keyslots | index($ks)))
+			 | .key'
+}
+
+
+# Prints the numbers of all keyslots bound to a clevis token on $device, one
+# per line, in ascending numeric order and de-duplicated.
+function _clevis_keyslots() {
+	local device="$1"
+	_luks_json "$device" \
+		| jq -r '.tokens | to_entries[]
+			 | select(.value.type == "clevis")
+			 | .value.keyslots[]' \
+		| sort -nu
+}
+
+
+# Shreds any temporary key/PCR material recorded in _cleanup_files and unmounts
+# the temporary nigrub mount recorded in _cleanup_mount. Registered as the EXIT
+# trap so that secrets are never left behind in /dev/shm and nigrub is never
+# left mounted if the script aborts partway through (e.g. via 'set -e').
 function _cleanup() {
 	set +e
 	local f
@@ -46,6 +96,11 @@ function _cleanup() {
 		[ -n "$f" ] && [ -e "$f" ] && shred -u "$f"
 	done
 	_cleanup_files=()
+	if [ -n "$_cleanup_mount" ]; then
+		umount "$_cleanup_mount" 2>/dev/null
+		rmdir "$_cleanup_mount" 2>/dev/null
+		_cleanup_mount=""
+	fi
 }
 
 
@@ -61,6 +116,18 @@ function _check_env() {
 	fi
 	if ! tpm2_pcrread sha256 >/dev/null 2>&1; then
 		echo "Unable to read PCR values from the TPM. Please ensure that the TPM is properly initialized and try again." >&2
+		exit ${EXITCODES[BADENV]}
+	fi
+	if ! type jose >/dev/null 2>&1; then
+		echo "jose is not installed. Please install jose and try again." >&2
+		exit ${EXITCODES[BADENV]}
+	fi
+	if ! type jq >/dev/null 2>&1; then
+		echo "jq is not installed. Please install jq and try again." >&2
+		exit ${EXITCODES[BADENV]}
+	fi
+	if ! blkid --label "nigrub" >/dev/null 2>&1; then
+		echo "nigrub partition not found. Cannot access GRUB artifacts for PCR 15 pre-calculation." >&2
 		exit ${EXITCODES[BADENV]}
 	fi
 }
@@ -123,65 +190,56 @@ function parse_args() {
 }
 
 
-# Reseals a single LUKS keyslot with new PCR policies.
+# Reseals a single LUKS keyslot with new PCR 7+15 policies using pcr_digest.
 function _reseal_device_keyslot() {
 	local device="$1"
 	local keyslot="$2"
-	local master_keyfile="$3"
+	local keyfile="$3"  # a keyfile that can open the LUKS volume
+	local pcr_digest="$4"  # base64-encoded PCR7[32]||PCR15[32] for Clevis
 
 	echo "Resealing PCR state to LUKS keyslot $keyslot on device $device."
 
-	# If the user has not provided a keyfile, try to reuse the clevis key in
-	# the keyslot. If there isn't one, we'll have to bail since we have no key.
-	if [ -z "$master_keyfile" ]; then
-		local keyfile=$(mktemp -p /dev/shm ni-reseal-luks.XXXXXX.keyfile)
-		chmod 0600 "$keyfile"
-		_cleanup_files+=("$keyfile")
-
-		clevis luks pass -d "$device" -s "$keyslot" >"$keyfile" || {
-			echo >&2 "ERROR: No master keyfile provided, but no existing clevis bind policy on $device, slot $keyslot. Unable to make an original seal without the master keyfile."
-			exit ${EXITCODES[ERR]}
-		}
-	else
-		local keyfile="$master_keyfile"
-	fi
-
-	if $opt_dry_run; then
-		echo >&2 "Dry run. Skipping."
-		test -z "$master_keyfile" && shred -u "$keyfile" || :
-		return
-	fi
-
-
-	if [ -n "$master_keyfile" ]; then
-		# Remove the old TPM2 policy, if it exists. Clevis complains otherwise.
-		clevis luks unbind \
-			-f \
-			-d "$device" \
-			-s "$keyslot" \
-			tpm2 2>/dev/null || :
-		# Assign a new TPM2 policy to the keyslot.
-		clevis luks bind \
+	# Remove the old TPM2 policy, if it exists. Clevis complains otherwise.
+	# Calling "clevis luks unbind" when TPM PCR values don't match the seal
+	# (which is always the case here: we are sealing against *future* PCR values)
+	# causes clevis to fall back to prompting for a passphrase on stdin which hangs.
+	# Instead, use cryptsetup directly with the master key file to avoid this.
+	# Identify any clevis tokens bound to this keyslot *before* killing it, then
+	# kill the keyslot and remove its now-orphaned tokens. A keyslot may carry
+	# more than one clevis token, so remove them all.
+	local _toks _tok
+	mapfile -t _toks < <(_clevis_token_ids_for_slot "$device" "$keyslot")
+	cryptsetup luksKillSlot -q --key-file "$keyfile" "$device" "$keyslot" 2>/dev/null || :
+	for _tok in "${_toks[@]}"; do
+		[ -n "$_tok" ] && cryptsetup token remove --token-id "$_tok" "$device" 2>/dev/null || :
+	done
+	# Bind a new TPM2 policy sealed against PCR 7 + PCR 15 using the
+	# pre-calculated pcr_digest. The pcr_digest encodes the expected state
+	# of both PCRs at the time of the next boot, allowing pre-calculation
+	# before rebooting.
+	#
+	# A failure here is consequential: the old keyslot has already been killed
+	# above, so if the bind does not complete the slot is left unpolicied. Catch
+	# it explicitly (rather than letting 'set -e' abort silently) and tell the
+	# operator how to recover.
+	if ! clevis luks bind \
 			-d "$device" \
 			-s "$keyslot" \
 			-k "$keyfile" \
 			-y \
 			tpm2 \
-			"{ \"pcr_bank\": \"$PCR_BANK\", \"pcr_ids\": \"$PCR_INDEXES\" }"
-	else
-		clevis luks regen \
-			-q \
-			-d "$device" \
-			-s "$keyslot"
+			"{ \"pcr_bank\": \"$PCR_BANK\", \"pcr_ids\": \"7,15\", \"pcr_digest\": \"$pcr_digest\" }"; then
+		echo >&2 "ERROR: Failed to bind new TPM policy to keyslot $keyslot on $device."
+		echo >&2 "       Keyslot $keyslot has been cleared and is now unpolicied. Re-run"
+		echo >&2 "       ni-reseal-luks while another keyslot is still TPM-unlockable"
+		echo >&2 "       to restore it."
+		exit ${EXITCODES[ERR]}
 	fi
-	
-	# Clean up the tempkey, if we're using one
-	test -z "$master_keyfile" && shred -u "$keyfile" || :
 }
 
 
-# Reseals the specified LUKS device by enrolling new PCR policies for both the
-# safemode and runmode keyslots.
+# Reseals the specified LUKS device by enrolling new PCR 7+15 policies for
+# both the safemode and runmode keyslots.
 function reseal_device() {
 	local device="$1"  # e.g. the LUKS device path to encrypt
 	local keyfile="$2"  # File path to a keyfile that can open the LUKS volume.
@@ -204,8 +262,210 @@ function reseal_device() {
 			;;
 	esac
 
-	_reseal_device_keyslot "$device" "$LUKS_KEYSLOT_SAFEMODE" "$keyfile"
-	_reseal_device_keyslot "$device" "$LUKS_KEYSLOT_RUNMODE" "$keyfile"
+	# Mount nigrub so we can measure artifacts on that partition.
+	# Register the mount and temp files with the EXIT trap (_cleanup) so secrets
+	# in /dev/shm are shredded and nigrub is unmounted even if we abort below.
+	local nigrub_mount
+	nigrub_mount=$(mktemp -d /tmp/ni-reseal-nigrub.XXXXXX)
+	_cleanup_mount="$nigrub_mount"
+	mount -L nigrub "$nigrub_mount" || {
+		echo "ERROR: Could not mount nigrub partition." >&2
+		exit ${EXITCODES[ERR]}
+	}
+
+	# Read current PCR 7 (Secure Boot state; stable across boots while Secure
+	# Boot policy is unchanged)
+	local pcr7_file
+	pcr7_file=$(mktemp -p /dev/shm ni-reseal-pcr7.XXXXXX.bin)
+	chmod 0600 "$pcr7_file"
+	_cleanup_files+=("$pcr7_file")
+
+	if ! tpm2_pcrread "${PCR_BANK}:7" --output "$pcr7_file"; then
+		echo "ERROR: Failed to read PCR 7 from TPM." >&2
+		exit ${EXITCODES[ERR]}
+	fi
+
+	# Pre-calculate PCR 15 for safemode and compute pcr_digest = base64(PCR7||PCR15)
+	local pcr_digest_safemode_file pcr_digest_safemode
+	pcr_digest_safemode_file=$(mktemp -p /dev/shm ni-reseal-pcr-digest.XXXXXX.bin)
+	chmod 0600 "$pcr_digest_safemode_file"
+	_cleanup_files+=("$pcr_digest_safemode_file")
+
+	echo "Pre-calculating PCR 15 for safemode..."
+	if ! ni-pcr-precalc \
+			--artifact-list /usr/lib/ni-device-encryption/share/ni-pcr-safemode-artifacts.list \
+			--nigrub-mount "$nigrub_mount" \
+			--pcr7 "$pcr7_file" \
+			--output-pcr-digest "$pcr_digest_safemode_file"; then
+		echo "ERROR: ni-pcr-precalc failed for safemode." >&2
+		exit ${EXITCODES[ERR]}
+	fi
+	# Keep the variable declaration and assignment separate. Combining them like
+	# 'local pcr_digest_safemode=$(...)' would mask jose's exit status behind
+	# 'local' and defeat 'set -e'.
+	pcr_digest_safemode=$(jose b64 enc -I "$pcr_digest_safemode_file" -o -)
+
+	# Pre-calculate PCR 15 for runmode and compute pcr_digest = base64(PCR7||PCR15)
+	local pcr_digest_runmode_file pcr_digest_runmode
+	pcr_digest_runmode_file=$(mktemp -p /dev/shm ni-reseal-pcr-digest.XXXXXX.bin)
+	chmod 0600 "$pcr_digest_runmode_file"
+	_cleanup_files+=("$pcr_digest_runmode_file")
+
+	echo "Pre-calculating PCR 15 for runmode..."
+	if ! ni-pcr-precalc \
+			--artifact-list /usr/lib/ni-device-encryption/share/ni-pcr-runmode-artifacts.list \
+			--nigrub-mount "$nigrub_mount" \
+			--pcr7 "$pcr7_file" \
+			--output-pcr-digest "$pcr_digest_runmode_file"; then
+		echo "ERROR: ni-pcr-precalc failed for runmode." >&2
+		exit ${EXITCODES[ERR]}
+	fi
+	# Keep the declaration and assignment separate (see the safemode note above).
+	pcr_digest_runmode=$(jose b64 enc -I "$pcr_digest_runmode_file" -o -)
+
+	# nigrub and the PCR/digest temp files are no longer needed; clean up now
+	# rather than waiting for the EXIT trap so the next reseal_device call starts
+	# fresh.
+	_cleanup
+	# _cleanup runs 'set +e' internally and does not restore it; re-enable
+	# 'set -e' so the rest of this function keeps aborting on error.
+	set -e
+
+	# When no master keyfile is provided, extract the passphrase from whichever
+	# slot is currently unlockable via the TPM.
+	# Any valid LUKS passphrase can authenticate against any slot for kill/rebind.
+	# Hold the extracted passphrase in an unlinked tmpfs file referenced only by
+	# an fd: the data lives in the kernel page cache and is freed automatically
+	# when the fd is closed (function return, process exit, or any abort path), so
+	# it never persists as a named file and needs no shred or EXIT-trap cleanup.
+	# We pass /proc/$$/fd/$fd (script PID expanded here) so the path stays valid
+	# for subprocesses such as clevis.
+	local _extracted_keyfile="" _extracted_key_fd=""
+	if [ -z "$keyfile" ]; then
+		local _extracted_tmp
+		_extracted_tmp=$(mktemp -p /dev/shm ni-reseal-luks.XXXXXX.keyfile)
+		chmod 0600 "$_extracted_tmp"
+		exec {_extracted_key_fd}<>"$_extracted_tmp"
+		rm -f "$_extracted_tmp"
+		_extracted_keyfile="/proc/$$/fd/$_extracted_key_fd"
+		local _found=false
+		# Try every clevis-bound slot. At best, if the reserved safemode/
+		# runmode slot matching the current boot mode has not already been sealed
+		# against a future PCR state during the current boot, then that reserved slot
+		# might unlock. Otherwise, we expect the special "current-boot" slot to unlock
+		# since it was sealed against the current PCR state just for this situation.
+		local _all_clevis_slots
+		mapfile -t _all_clevis_slots < <(_clevis_keyslots "$device")
+		for _slot in "${_all_clevis_slots[@]}"; do
+			# Redirect stdin from /dev/null so that this stays non-interactive.
+			# 'clevis luks pass' gets its secret from the TPM (not stdin) and
+			# returns the passphrase on stdout, so /dev/null does not affect the
+			# success path. It future-proofs against a clevis version that falls
+			# back to prompting for a passphrase on stdin: instead of hanging, the
+			# call hits EOF and fails fast, and the loop moves on to the next slot.
+			# This is not entirely speculative, as we hit a case where "clevis luks
+			# unbind" would prompt for a passphrase on stdin if the TPM PCRs did not
+			# match the seal.
+			if clevis luks pass -d "$device" -s "$_slot" \
+					</dev/null >"$_extracted_keyfile" 2>/dev/null; then
+				echo "Unlocked slot $_slot via TPM for live-reseal."
+				keyfile="$_extracted_keyfile"
+				_found=true
+				break
+			fi
+		done
+		if ! $_found; then
+			exec {_extracted_key_fd}>&-
+			echo "ERROR: No master keyfile and no TPM-unlockable slot found." >&2
+			exit ${EXITCODES[ERR]}
+		fi
+	fi
+
+	# Everything above this point is read-only with respect to the on-disk LUKS
+	# header (nigrub has already been unmounted, and passphrase extraction only
+	# releases an existing key). Under --dry-run, report what a real reseal would
+	# do and stop here, before the first header-modifying operation (the bridge
+	# luksAddKey below).
+	if $opt_dry_run; then
+		echo "Dry run: validated inputs for $device; no changes were made."
+		echo "  safemode pcr_digest (PCR 7+15): $pcr_digest_safemode"
+		echo "  runmode  pcr_digest (PCR 7+15): $pcr_digest_runmode"
+		echo "  Would reseal keyslot $LUKS_KEYSLOT_SAFEMODE (safemode) and keyslot $LUKS_KEYSLOT_RUNMODE (runmode) to PCR 7+15."
+		local _plan_slot
+		while IFS= read -r _plan_slot; do
+			[[ "$_plan_slot" == "$LUKS_KEYSLOT_SAFEMODE" ]] && continue
+			[[ "$_plan_slot" == "$LUKS_KEYSLOT_RUNMODE" ]] && continue
+			echo "  Would remove extra keyslot $_plan_slot."
+		done < <(_luks_active_keyslots "$device")
+		if [ -n "$_extracted_keyfile" ]; then
+			echo "  Would add and then remove a temporary bridge keyslot for live-reseal."
+		fi
+		# Close (and thereby free) the extracted passphrase now; process exit would
+		# also close it, but release it as soon as it is no longer needed.
+		[ -n "$_extracted_key_fd" ] && exec {_extracted_key_fd}>&- && _extracted_key_fd=""
+		return 0
+	fi
+
+	# In the keyfile-less path we extracted the passphrase above; add a bridge
+	# keyslot with that same passphrase so it remains valid throughout all
+	# kill+rebind operations. Without this, killing the original slot (which
+	# provided the passphrase) would invalidate the only auth key before the
+	# second slot is rebound.
+	local _bridge_slot=""
+	if [ -n "$_extracted_keyfile" ]; then
+		# Snapshot the active keyslots before adding the bridge so we can identify
+		# which slot the bridge landed in by diffing afterward.
+		local _slots_before
+		_slots_before="$(_luks_active_keyslots "$device")"
+		if ! cryptsetup luksAddKey --batch-mode \
+				--key-file "$keyfile" "$device" "$keyfile" 2>/dev/null; then
+			exec {_extracted_key_fd}>&-
+			echo "ERROR: Could not add bridge keyslot for live-reseal." >&2
+			exit ${EXITCODES[ERR]}
+		fi
+		# The bridge slot is whichever slot became active as a result of the
+		# luksAddKey above. Diffing the before/after active-slot sets is robust
+		# regardless of which physical slot cryptsetup chose and keeps us from
+		# mistakenly selecting a dead master slot 0 or the special "current-boot"
+		# slot.
+		_bridge_slot="$(_luks_active_keyslots "$device" \
+			| grep -vxF "$_slots_before" | head -1)"
+		echo "Added bridge keyslot ${_bridge_slot} for live-reseal."
+	fi
+
+	_reseal_device_keyslot "$device" "$LUKS_KEYSLOT_SAFEMODE" "$keyfile" "$pcr_digest_safemode"
+	_reseal_device_keyslot "$device" "$LUKS_KEYSLOT_RUNMODE" "$keyfile" "$pcr_digest_runmode"
+
+	# Remove any remaining keyslots that are neither safemode nor runmode:
+	# the dead master-key slot (slot 0) left over from initial luksFormat,
+	# and the current-boot slot added by nisystemformat for same-session
+	# re-opening (sealed to current-boot PCRs, now superseded).
+	# IMPORTANT: Do this BEFORE removing the bridge so that the bridge
+	# provides an alternate slot accepting $keyfile.  cryptsetup luksKillSlot
+	# requires at least one OTHER active slot that matches the supplied
+	# keyfile; without the bridge, killing the current-boot slot would fail.
+	while IFS= read -r _extra_slot; do
+		[[ "$_extra_slot" == "$LUKS_KEYSLOT_SAFEMODE" ]] && continue
+		[[ "$_extra_slot" == "$LUKS_KEYSLOT_RUNMODE" ]] && continue
+		[[ -n "${_bridge_slot:-}" && "$_extra_slot" == "$_bridge_slot" ]] && continue
+		cryptsetup luksKillSlot -q --key-file "$keyfile" "$device" "$_extra_slot" 2>/dev/null \
+			&& echo "Removed extra keyslot ${_extra_slot}." || :
+	done < <(_luks_active_keyslots "$device")
+
+	# Remove the bridge keyslot now that all extra slots have been cleaned up.
+	# Use luksRemoveKey (passphrase-based) instead of luksKillSlot (slot-number-
+	# based): after the current-boot slot is gone the bridge is the only slot
+	# that accepts $keyfile, and luksKillSlot would then fail its own
+	# "other-slot authentication" requirement.
+	if [ -n "${_bridge_slot:-}" ]; then
+		cryptsetup luksRemoveKey -q --key-file "$keyfile" "$device" 2>/dev/null || :
+		echo "Removed bridge keyslot ${_bridge_slot}."
+	fi
+
+	# Close (and thereby free) the extracted passphrase as soon as it is no longer
+	# needed rather than waiting for process exit, to minimize the window the key
+	# material is resident. Closing the fd releases the unlinked tmpfs inode.
+	[ -n "$_extracted_key_fd" ] && exec {_extracted_key_fd}>&- && _extracted_key_fd=""
 
 	clevis luks list -d "$device"
 }
@@ -227,7 +487,8 @@ Usage:
 
 Options:
 	-h, --help         Show this help message and exit.
-	-n, --dry-run      Perform a dry run without enrolling new PCR values.
+	-n, --dry-run      Validate the reseal (PCR pre-calculation and TPM unlock)
+	                   and print the plan without modifying any LUKS keyslots.
 	-y, --yes          Automatically confirm enrollment of new PCR values without
 	                   prompting.
 	-l, --label LABEL  Only reseal the LUKS partition with this filesystem label.
@@ -253,6 +514,7 @@ arg_keyfile=""
 arg_label=""
 
 # Temporary state cleaned up by the EXIT trap (_cleanup).
+_cleanup_mount=""
 _cleanup_files=()
 
 
@@ -263,7 +525,7 @@ _cleanup_files=()
 _check_env || exit ${EXITCODES[BADENV]}
 parse_args "$@" || exit ${EXITCODES[BADARGS]}
 
-# Ensure temporary secrets are cleaned up on any exit.
+# Ensure temporary secrets and mounts are cleaned up on any exit.
 trap _cleanup EXIT
 
 # Determine which LUKS devices to reseal.

--- a/recipes-ni/ni-device-encryption/ni-device-encryption/bin/ni-reseal-luks.sh
+++ b/recipes-ni/ni-device-encryption/ni-device-encryption/bin/ni-reseal-luks.sh
@@ -69,6 +69,24 @@ function parse_args() {
 			-y|--yes)
 				opt_yes=true
 				;;
+			-l|--label)
+				if [[ ${#argv[@]} -lt 2 ]]; then
+					echo "--label requires an argument" >&2
+					usage 2
+					exit ${EXITCODES[BADARGS]}
+				fi
+				case "${argv[1]}" in
+					niconfig-luks|nirootfs-luks)
+						arg_label="${argv[1]}"
+						;;
+					*)
+						echo "Invalid label '${argv[1]}'. Must be 'niconfig-luks' or 'nirootfs-luks'." >&2
+						usage 2
+						exit ${EXITCODES[BADARGS]}
+						;;
+				esac
+				argv=("${argv[@]:1}")
+				;;
 			-*|--*)
 				echo "Unknown option: ${argv[0]}" >&2
 				usage 2
@@ -192,13 +210,16 @@ Usage:
 	Print usage information and exit:
 		$(basename "$0") [-h]
 	Reseal LUKS keys:
-		$(basename "$0") [-n] [-y] [KEYFILE]
+		$(basename "$0") [-n] [-y] [-l LABEL] [KEYFILE]
 
 Options:
-	-h, --help     Show this help message and exit.
-	-n, --dry-run  Perform a dry run without enrolling new PCR values.
-	-y, --yes      Automatically confirm enrollment of new PCR values without
-	               prompting.
+	-h, --help         Show this help message and exit.
+	-n, --dry-run      Perform a dry run without enrolling new PCR values.
+	-y, --yes          Automatically confirm enrollment of new PCR values without
+	                   prompting.
+	-l, --label LABEL  Only reseal the LUKS partition with this filesystem label.
+	                   Must be 'niconfig-luks' or 'nirootfs-luks'. If omitted, all
+	                   such partitions are resealed.
 
 Arguments:
 	KEYFILE        Path to a keyfile that can open the LUKS volume.
@@ -216,6 +237,7 @@ EOF
 opt_dry_run=false
 opt_yes=false
 arg_keyfile=""
+arg_label=""
 
 
 # ==============================================================================
@@ -225,12 +247,27 @@ arg_keyfile=""
 _check_env || exit ${EXITCODES[BADENV]}
 parse_args "$@" || exit ${EXITCODES[BADARGS]}
 
-# Find the device paths for the config and userfs LUKS partitions, if they exist.
-path_niconfig_luks=$(blkid --label "niconfig-luks" --output device || :)
-path_userfs_luks=$(blkid --label "nirootfs-luks" --output device || :)
+# Determine which LUKS devices to reseal.
+if [[ -n "$arg_label" ]]; then
+	# --label was specified: operate only on that single labeled partition.
+	# (parse_args has already restricted it to a known LUKS filesystem label.)
+	label_device=$(blkid --label "$arg_label" --output device || :)
+	if [[ -z "$label_device" ]]; then
+		echo "ERROR: No LUKS partition with label '$arg_label' was found." >&2
+		exit ${EXITCODES[BADARGS]}
+	fi
+	luks_devices=("$label_device")
+else
+	# No --label: discover all known LUKS partitions by label.
+	path_niconfig_luks=$(blkid --label "niconfig-luks" --output device || :)
+	path_userfs_luks=$(blkid --label "nirootfs-luks" --output device || :)
+	luks_devices=()
+	[[ -n "$path_niconfig_luks" ]] && luks_devices+=("$path_niconfig_luks")
+	[[ -n "$path_userfs_luks" ]] && luks_devices+=("$path_userfs_luks")
+fi
 
 # NOOP if there are no LUKS partitions (that we care about).
-if [[ -z "$path_niconfig_luks" && -z "$path_userfs_luks" ]]; then
+if [[ ${#luks_devices[@]} -eq 0 ]]; then
 	echo "No LUKS partitions found. Nothing to reseal."
 	exit ${EXITCODES[OK]}
 fi
@@ -239,8 +276,7 @@ fi
 # This part is mostly to defend against accidental script execution.
 if ! $opt_yes; then
 	echo "This will enroll new PCR values for the safemode and runmode boot components to release the LUKS keys for the following partitions:"
-	test -n "$path_niconfig_luks" && echo -e "\t$path_niconfig_luks"
-	test -n "$path_userfs_luks" && echo -e "\t$path_userfs_luks"
+	for _dev in "${luks_devices[@]}"; do echo -e "\t$_dev"; done
 	read -p "To continue, type 'RESEAL': " -r
 	if [[ ! $REPLY =~ ^RESEAL$ ]]; then
 		echo "Aborting."
@@ -248,14 +284,9 @@ if ! $opt_yes; then
 	fi
 fi
 
-# Reseal the niconfig partition.
-if [[ -n "$path_niconfig_luks" ]]; then
-	reseal_device "$path_niconfig_luks" "$arg_keyfile"
-fi
-
-# Reseal the userfs partition.
-if [[ -n "$path_userfs_luks" ]]; then
-	reseal_device "$path_userfs_luks" "$arg_keyfile"
-fi
+# Reseal each device.
+for _dev in "${luks_devices[@]}"; do
+	reseal_device "$_dev" "$arg_keyfile"
+done
 
 exit ${EXITCODES[OK]}

--- a/recipes-ni/ni-device-encryption/ni-device-encryption/init/ni-cryptdisks.sh.in
+++ b/recipes-ni/ni-device-encryption/ni-device-encryption/init/ni-cryptdisks.sh.in
@@ -4,7 +4,7 @@
 #
 ### BEGIN INIT INFO
 # Provides:          ni-cryptdisks
-# Required-Start:    mountall sysfs
+# Required-Start:    mountall sysfs udev
 # Required-Stop:
 # Default-Start:     S
 # Default-Stop:
@@ -54,16 +54,45 @@ function check_env() {
 }
 
 
-# Populates the following global variables:
-#   - userfs_path
-#   - userfs_luks_path
-#   - niconfig_path
-#   - niconfig_luks_path
+# Prints the given device only if it currently holds a LUKS header; otherwise
+# prints nothing.
+function _luks_device_for() {
+	local dev="${1:-}"
+	[ -n "$dev" ] || return 0
+	if [ "$(blkid --match-tag TYPE --output value "$dev" 2>/dev/null || :)" = crypto_LUKS ]; then
+		printf '%s\n' "$dev"
+	fi
+}
+
+
+# Populates userfs_path, userfs_luks_path, niconfig_path, niconfig_luks_path.
+#
+# Locate the data partitions by GPT PARTLABEL via a direct scan, which reflects
+# the kernel/devtmpfs view immediately. Retry (wall-clock bounded) as insurance
+# for a still-enumerating disk.
 function find_partitions() {
+	local deadline=$((SECONDS + 30)) userfs_dev niconfig_dev
+	while true; do
+		userfs_dev=$(blkid --match-token PARTLABEL="$USERFS_PARTLABEL" --output device 2>/dev/null || :)
+		niconfig_dev=$(blkid --match-token PARTLABEL="$NICONFIG_PARTLABEL" --output device 2>/dev/null || :)
+
+		if { [ -n "$userfs_dev" ] && [ -n "$niconfig_dev" ]; } \
+			|| [ "$SECONDS" -ge "$deadline" ]; then
+			break
+		fi
+		# A data partition is not visible yet; give udev/the kernel a moment to
+		# finish enumerating the disk, then re-scan.
+		type udevadm >/dev/null 2>&1 && udevadm settle --timeout=5 || :
+		sleep 1
+	done
+
+	[ -n "$userfs_dev" ] && [ -n "$niconfig_dev" ] \
+		|| log WARN "Timed out waiting for data partitions to appear"
+
+	userfs_luks_path=$(_luks_device_for "$userfs_dev")
+	niconfig_luks_path=$(_luks_device_for "$niconfig_dev")
 	userfs_path=$(blkid --label "$USERFS_PARTLABEL" --output device || :)
-	userfs_luks_path=$(blkid --label "$USERFS_PARTLABEL-luks" --output device || :)
 	niconfig_path=$(blkid --label "$NICONFIG_PARTLABEL" --output device || :)
-	niconfig_luks_path=$(blkid --label "$NICONFIG_PARTLABEL-luks" --output device || :)
 }
 
 

--- a/recipes-ni/ni-device-encryption/ni-device-encryption/share/ni-pcr-runmode-artifacts.list
+++ b/recipes-ni/ni-device-encryption/ni-device-encryption/share/ni-pcr-runmode-artifacts.list
@@ -1,0 +1,21 @@
+# PCR 15 artifact list for runmode boot
+#
+# Lists the boot artifacts that GRUB measures into PCR 15 during a runmode
+# boot, in measurement order. This file is read by ni-pcr-precalc to
+# pre-calculate the expected PCR 15 value before resealing LUKS keys.
+#
+# Format:
+#   nigrub:<path>   file on the nigrub partition (relative to mount point)
+#   /<path>         absolute filesystem path (nibootfs files are under /boot/)
+#   # comment       ignored
+#   Paths with * or ? are expanded as sorted globs; missing files are skipped.
+#
+# The order must exactly match GRUB's execution sequence in grub.cfg.
+nigrub:efi/boot/grub.cfg
+nigrub:grubvar_readonly
+/boot/grub/grubenv
+/boot/bootmode
+/boot/runmode/bootimage.cfg
+/boot/runmode/cpu-mitigations.cfg
+/boot/runmode/bzImage
+/boot/runmode/ramdisk.xz

--- a/recipes-ni/ni-device-encryption/ni-device-encryption/share/ni-pcr-safemode-artifacts.list
+++ b/recipes-ni/ni-device-encryption/ni-device-encryption/share/ni-pcr-safemode-artifacts.list
@@ -1,0 +1,21 @@
+# PCR 15 artifact list for safemode boot
+#
+# Lists the boot artifacts that GRUB measures into PCR 15 during a safemode
+# boot, in measurement order. This file is read by ni-pcr-precalc to
+# pre-calculate the expected PCR 15 value before resealing LUKS keys.
+#
+# Format:
+#   nigrub:<path>   file on the nigrub partition (relative to mount point)
+#   /<path>         absolute filesystem path (nibootfs files are under /boot/)
+#   # comment       ignored
+#   Paths with * or ? are expanded as sorted globs; missing files are skipped.
+#
+# The order must exactly match GRUB's execution sequence in grub.cfg.
+# Safemode does not use cpu-mitigations.cfg or bootimage.cfg.d/.
+nigrub:efi/boot/grub.cfg
+nigrub:grubvar_readonly
+/boot/grub/grubenv
+/boot/bootmode
+/boot/.safe/bootimage.cfg
+/boot/.safe/bzImage
+/boot/.safe/ramdisk.xz

--- a/recipes-ni/ni-device-encryption/ni-device-encryption/src/ni-pcr-precalc.c
+++ b/recipes-ni/ni-device-encryption/ni-device-encryption/src/ni-pcr-precalc.c
@@ -1,0 +1,475 @@
+/*
+ * ni-pcr-precalc.c - Pre-calculate an expected TPM PCR value for NILRT
+ *                    measured boot
+ *
+ * Simulates the PCR extensions that GRUB performs during boot by reading
+ * boot artifacts in the same order and using the same formula as GRUB's
+ * verifier framework. The result is the PCR value the TPM is expected to
+ * hold after the next boot, allowing LUKS keys to be resealed beforehand.
+ *
+ * PCR extend formula (per TPM2 spec):
+ *   new_PCR = SHA256(current_PCR[32] || SHA256(file_content))
+ * Starting PCR value: 0x00...00 (32 zero bytes, confirmed on NILRT hardware).
+ *
+ * Artifact list format (one entry per line):
+ *   # comment lines and blank lines are ignored
+ *   nigrub:<path>    file at <path> relative to --nigrub-mount root
+ *   /<path>          absolute filesystem path (use for nibootfs files)
+ *   Paths containing * or ? are expanded as glob patterns (sorted).
+ *   Missing or non-regular files are skipped (logged to stderr), mirroring
+ *   GRUB's "if [ -f ... ]" guards.
+ *
+ * Copyright (c) 2026 Emerson T&M (NI). LICENSE: MIT
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <errno.h>
+#include <glob.h>
+#include <sys/stat.h>
+
+#include <openssl/evp.h>
+
+/* ============================================================================
+ * CONSTANTS
+ * ============================================================================ */
+
+#define PCR_SIZE   32     /* SHA256 output size in bytes */
+#define MAX_PATH   4096
+#define MAX_LINE   8192
+
+
+/* ============================================================================
+ * PCR SIMULATION STATE
+ * ============================================================================ */
+
+/* Simulated PCR value; initialized to all zeros in main() */
+static uint8_t g_pcr[PCR_SIZE];
+
+
+/* ============================================================================
+ * CRYPTO HELPERS
+ * ============================================================================ */
+
+/* Compute SHA256(in[len]) and store 32 bytes in out[]. Returns 0 on success. */
+static int sha256_buf(const uint8_t *in, size_t len, uint8_t out[PCR_SIZE])
+{
+    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+    unsigned int outlen = PCR_SIZE;
+    int ret = -1;
+
+    if (!ctx)
+        goto done;
+    if (!EVP_DigestInit_ex(ctx, EVP_sha256(), NULL))
+        goto done;
+    if (!EVP_DigestUpdate(ctx, in, len))
+        goto done;
+    if (!EVP_DigestFinal_ex(ctx, out, &outlen))
+        goto done;
+    ret = 0;
+done:
+    EVP_MD_CTX_free(ctx);
+    return ret;
+}
+
+/*
+ * Extend g_pcr with the measurement of data buffer buf[len]:
+ *   event_digest = SHA256(buf)
+ *   new_pcr      = SHA256(g_pcr || event_digest)
+ *
+ * Returns 0 on success.
+ */
+static int pcr_extend(const uint8_t *buf, size_t len)
+{
+    uint8_t event_digest[PCR_SIZE];
+    uint8_t combined[PCR_SIZE * 2];
+
+    if (sha256_buf(buf, len, event_digest) != 0)
+        return -1;
+
+    memcpy(combined,            g_pcr,        PCR_SIZE);
+    memcpy(combined + PCR_SIZE, event_digest, PCR_SIZE);
+
+    return sha256_buf(combined, sizeof(combined), g_pcr);
+}
+
+
+/* ============================================================================
+ * FILE MEASUREMENT
+ * ============================================================================ */
+
+/*
+ * Read entire file at path and extend g_pcr.
+ * Returns:
+ *    0  file measured successfully
+ *    1  file missing or not a regular file (skipped, logged to stderr;
+ *       mirrors GRUB's "if [ -f ... ]" guard)
+ *   -1  I/O or other error (message printed to stderr)
+ */
+static int measure_file(const char *path)
+{
+    struct stat st;
+
+    if (stat(path, &st) != 0) {
+        if (errno == ENOENT) {
+            fprintf(stderr, "ni-pcr-precalc: skipping missing artifact '%s'\n", path);
+            return 1;  /* missing: skip */
+        }
+        fprintf(stderr, "ni-pcr-precalc: stat '%s': %s\n", path, strerror(errno));
+        return -1;
+    }
+
+    if (!S_ISREG(st.st_mode)) {
+        fprintf(stderr, "ni-pcr-precalc: skipping non-regular artifact '%s'\n", path);
+        return 1;  /* not a regular file: skip */
+    }
+
+    /*
+     * st_size is off_t (signed, 64-bit under large-file support). Compare in
+     * unsigned space after the < 0 guard: casting SIZE_MAX to off_t would be
+     * wrong on LP64 (SIZE_MAX exceeds off_t's max), so widen st_size instead.
+     */
+    if (st.st_size < 0 || (uintmax_t)st.st_size > SIZE_MAX) {
+        fprintf(stderr, "ni-pcr-precalc: artifact '%s' too large to hash in-memory (%jd bytes)\n",
+                path, (intmax_t)st.st_size);
+        return -1;
+    }
+
+    size_t size = (size_t)st.st_size;
+    uint8_t *buf = NULL;
+
+    if (size > 0) {
+        buf = malloc(size);
+        if (!buf) {
+            fprintf(stderr, "ni-pcr-precalc: out of memory reading '%s' (%zu bytes)\n",
+                    path, size);
+            return -1;
+        }
+
+        FILE *f = fopen(path, "rb");
+        if (!f) {
+            fprintf(stderr, "ni-pcr-precalc: fopen '%s': %s\n", path, strerror(errno));
+            free(buf);
+            return -1;
+        }
+
+        size_t nr = fread(buf, 1, size, f);
+        fclose(f);
+
+        if (nr != size) {
+            fprintf(stderr, "ni-pcr-precalc: short read on '%s' (%zu/%zu bytes)\n",
+                    path, nr, size);
+            free(buf);
+            return -1;
+        }
+    }
+
+    /* Hash the content (empty file: hash of zero bytes) */
+    int ret = pcr_extend(buf ? buf : (const uint8_t *)"", size);
+    free(buf);
+
+    if (ret != 0) {
+        fprintf(stderr, "ni-pcr-precalc: PCR extend failed for '%s'\n", path);
+        return -1;
+    }
+    return 0;
+}
+
+/* Sort comparator for glob path arrays */
+static int path_strcmp(const void *a, const void *b)
+{
+    return strcmp(*(const char *const *)a, *(const char *const *)b);
+}
+
+/*
+ * Expand glob pattern and measure each matching file in sorted (alphabetical)
+ * order. A pattern that matches nothing is skipped (logged to stderr); a real
+ * glob error (out of memory, read error) is fatal.
+ * Returns 0 on success, -1 on error.
+ */
+static int measure_glob(const char *pattern)
+{
+    glob_t g;
+
+    int rc = glob(pattern, GLOB_NOSORT, NULL, &g);
+    if (rc == GLOB_NOMATCH) {
+        fprintf(stderr, "ni-pcr-precalc: skipping unmatched glob '%s'\n", pattern);
+        return 0;
+    }
+    if (rc != 0) {
+        fprintf(stderr, "ni-pcr-precalc: glob('%s') failed (error %d)\n", pattern, rc);
+        return -1;
+    }
+
+    /* Sort results alphabetically */
+    if (g.gl_pathc > 1)
+        qsort(g.gl_pathv, g.gl_pathc, sizeof(char *), path_strcmp);
+
+    int ret = 0;
+    for (size_t i = 0; i < g.gl_pathc; i++) {
+        int r = measure_file(g.gl_pathv[i]);
+        if (r < 0) {
+            ret = -1;
+            break;
+        }
+        /* r == 1: file disappeared between glob and open; skip */
+    }
+
+    globfree(&g);
+    return ret;
+}
+
+
+/* ============================================================================
+ * PATH RESOLUTION
+ * ============================================================================ */
+
+/*
+ * Resolve an artifact list entry to an OS filesystem path.
+ *
+ * "nigrub:<rel>"  ->  nigrub_mount + "/" + <rel>
+ * "/<abs>"        ->  "/<abs>" as-is
+ *
+ * Returns a malloc'd string that the caller must free. Returns NULL on error.
+ */
+static char *resolve_path(const char *entry, const char *nigrub_mount)
+{
+    char *result = malloc(MAX_PATH);
+    if (!result)
+        return NULL;
+
+    int n;
+    if (strncmp(entry, "nigrub:", 7) == 0) {
+        n = snprintf(result, MAX_PATH, "%s/%s", nigrub_mount, entry + 7);
+    } else if (entry[0] == '/') {
+        n = snprintf(result, MAX_PATH, "%s", entry);
+    } else {
+        /*
+         * Artifact list format only permits "nigrub:<rel>" or an absolute
+         * "/<path>". Otherwise it is invalid.
+         */
+        free(result);
+        errno = EINVAL;
+        return NULL;
+    }
+
+    /*
+     * snprintf returns the length it would have written (excluding the NUL);
+     * a value >= MAX_PATH means the path was truncated. Fail rather than
+     * silently hashing the wrong path; a negative value is an encoding error.
+     * Set errno so the caller can report the cause (vs. malloc's ENOMEM).
+     */
+    if (n < 0 || n >= MAX_PATH) {
+        free(result);
+        errno = ENAMETOOLONG;
+        return NULL;
+    }
+
+    return result;
+}
+
+
+/* ============================================================================
+ * OUTPUT HELPERS
+ * ============================================================================ */
+
+static void print_hex(const uint8_t *buf, size_t len)
+{
+    for (size_t i = 0; i < len; i++)
+        printf("%02x", buf[i]);
+    printf("\n");
+}
+
+static int write_raw(const char *path, const uint8_t *buf, size_t len)
+{
+    FILE *f = fopen(path, "wb");
+    if (!f) {
+        fprintf(stderr, "ni-pcr-precalc: fopen '%s' for write: %s\n",
+                path, strerror(errno));
+        return -1;
+    }
+    size_t nw = fwrite(buf, 1, len, f);
+    fclose(f);
+    if (nw != len) {
+        fprintf(stderr, "ni-pcr-precalc: short write to '%s'\n", path);
+        return -1;
+    }
+    return 0;
+}
+
+
+/* ============================================================================
+ * MAIN
+ * ============================================================================ */
+
+static void usage(const char *prog, FILE *out)
+{
+    fprintf(out,
+        "Usage: %s --artifact-list <path> [OPTIONS]\n"
+        "\n"
+        "Pre-calculate an expected TPM PCR value for NILRT measured boot.\n"
+        "Outputs the PCR value as 64 hex characters on stdout.\n"
+        "\n"
+        "Required:\n"
+        "  --artifact-list <path>        File listing boot artifacts to measure,\n"
+        "                                in measurement order\n"
+        "\n"
+        "Options:\n"
+        "  --nigrub-mount <path>         Mount point for nigrub partition\n"
+        "                                Default: /mnt/nigrub\n"
+        "  --output-pcr <file>           Write raw 32-byte PCR value to file\n"
+        "  --pcr7 <file>                 Raw 32-byte PCR 7 input (from tpm2_pcrread)\n"
+        "  --output-pcr-digest <file>    Write raw 64-byte PCR7||PCR to file\n"
+        "                                (for Clevis pcr_digest; requires --pcr7)\n"
+        "  -h, --help                    Show this help and exit\n"
+        "\n"
+        "Artifact list format:\n"
+        "  nigrub:<path>   file on nigrub partition (relative to --nigrub-mount)\n"
+        "  /<path>         absolute filesystem path\n"
+        "  # ...           comment (ignored)\n"
+        "  Paths with * or ? are expanded as sorted globs.\n"
+        "  Missing or non-regular files are skipped (logged to stderr).\n",
+        prog);
+}
+
+int main(int argc, char *argv[])
+{
+    const char *artifact_list     = NULL;
+    const char *nigrub_mount      = "/mnt/nigrub";
+    const char *output_pcr        = NULL;
+    const char *pcr7_file         = NULL;
+    const char *output_pcr_digest = NULL;
+
+    /* --- Argument parsing --- */
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--artifact-list") == 0 && i + 1 < argc) {
+            artifact_list = argv[++i];
+        } else if (strcmp(argv[i], "--nigrub-mount") == 0 && i + 1 < argc) {
+            nigrub_mount = argv[++i];
+        } else if (strcmp(argv[i], "--output-pcr") == 0 && i + 1 < argc) {
+            output_pcr = argv[++i];
+        } else if (strcmp(argv[i], "--pcr7") == 0 && i + 1 < argc) {
+            pcr7_file = argv[++i];
+        } else if (strcmp(argv[i], "--output-pcr-digest") == 0 && i + 1 < argc) {
+            output_pcr_digest = argv[++i];
+        } else if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
+            usage(argv[0], stdout);
+            return 0;
+        } else {
+            fprintf(stderr, "ni-pcr-precalc: unknown argument '%s'\n", argv[i]);
+            usage(argv[0], stderr);
+            return 2;
+        }
+    }
+
+    /* --- Validate arguments --- */
+    if (!artifact_list) {
+        fprintf(stderr, "ni-pcr-precalc: --artifact-list is required\n");
+        usage(argv[0], stderr);
+        return 2;
+    }
+
+    if (output_pcr_digest && !pcr7_file) {
+        fprintf(stderr, "ni-pcr-precalc: --output-pcr-digest requires --pcr7\n");
+        return 2;
+    }
+
+    /* --- Initialize PCR to all zeros --- */
+    memset(g_pcr, 0, PCR_SIZE);
+
+    /* --- Process artifact list --- */
+    FILE *listf = fopen(artifact_list, "r");
+    if (!listf) {
+        fprintf(stderr, "ni-pcr-precalc: cannot open artifact list '%s': %s\n",
+                artifact_list, strerror(errno));
+        return 1;
+    }
+
+    char line[MAX_LINE];
+    int ret = 0;
+
+    while (fgets(line, sizeof(line), listf)) {
+        /* Strip trailing newline/carriage-return */
+        size_t len = strlen(line);
+        while (len > 0 && (line[len-1] == '\n' || line[len-1] == '\r'))
+            line[--len] = '\0';
+
+        /* Skip empty lines and comments */
+        if (len == 0 || line[0] == '#')
+            continue;
+
+        char *path = resolve_path(line, nigrub_mount);
+        if (!path) {
+            fprintf(stderr, "ni-pcr-precalc: failed to resolve path for entry '%s': %s\n",
+                    line, strerror(errno));
+            ret = 1;
+            break;
+        }
+
+        int r;
+        if (strchr(path, '*') || strchr(path, '?'))
+            r = measure_glob(path);
+        else
+            r = measure_file(path);
+
+        free(path);
+
+        if (r < 0) {
+            ret = 1;
+            break;
+        }
+        /* r == 1: file missing or non-regular, skipped (already logged) */
+    }
+
+    fclose(listf);
+
+    if (ret != 0)
+        return ret;
+
+    /* --- Output PCR hex to stdout --- */
+    print_hex(g_pcr, PCR_SIZE);
+
+    /* --- Optionally write raw PCR to file --- */
+    if (output_pcr) {
+        if (write_raw(output_pcr, g_pcr, PCR_SIZE) != 0)
+            return 1;
+    }
+
+    /* --- Optionally compute pcr_digest = PCR7 || PCR and write to file --- */
+    if (output_pcr_digest) {
+        uint8_t pcr7[PCR_SIZE];
+
+        FILE *f = fopen(pcr7_file, "rb");
+        if (!f) {
+            fprintf(stderr, "ni-pcr-precalc: cannot open PCR7 file '%s': %s\n",
+                    pcr7_file, strerror(errno));
+            return 1;
+        }
+        size_t nr = fread(pcr7, 1, PCR_SIZE, f);
+        fclose(f);
+
+        if (nr != PCR_SIZE) {
+            fprintf(stderr,
+                    "ni-pcr-precalc: PCR7 file '%s' must be exactly %d bytes "
+                    "(got %zu)\n",
+                    pcr7_file, PCR_SIZE, nr);
+            return 1;
+        }
+
+        /*
+         * pcr_digest for Clevis is the concatenation of PCR values in index
+         * order: PCR7[32] || PCR[32]  (64 bytes total).
+         * The caller base64-encodes this before passing to clevis luks bind.
+         */
+        uint8_t pcr_digest[PCR_SIZE * 2];
+        memcpy(pcr_digest,            pcr7,  PCR_SIZE);
+        memcpy(pcr_digest + PCR_SIZE, g_pcr, PCR_SIZE);
+
+        if (write_raw(output_pcr_digest, pcr_digest, sizeof(pcr_digest)) != 0)
+            return 1;
+    }
+
+    return 0;
+}

--- a/recipes-ni/ni-systemformat/ni-systemformat/src/lib/format.sh
+++ b/recipes-ni/ni-systemformat/ni-systemformat/src/lib/format.sh
@@ -88,6 +88,11 @@ function _convert_to_luks() {
 	dd if=/dev/urandom of="$_keyfile_path" bs=512 count=1 2>/dev/null \
 		|| die UNKNOWN_ERROR "Failed to generate random master key"
 
+	# --luks2-metadata-size 16k: 16k is the current LUKS2 default; pin it so a
+	#   future default increase cannot silently grow the header.
+	# --luks2-keyslots-size 1m: the default keyslots area (~16 MiB) is too large
+	#   for the ~15 MB configfs partition, so reduce it to 1m, which is still
+	#   sufficient for all the keyslots we currently need with a little headroom.
 	cryptsetup luksFormat \
 		--encrypt \
 		--label "$fslabel-luks" \
@@ -96,6 +101,8 @@ function _convert_to_luks() {
 		--key-size 256 \
 		--cipher aes-xts-plain64 \
 		--batch-mode \
+		--luks2-metadata-size 16k \
+		--luks2-keyslots-size 1m \
 		--key-file "$_keyfile_path" \
 		"$dev" \
 		|| die UNKNOWN_ERROR "Failed to luksFormat $dev"

--- a/recipes-ni/ni-systemformat/ni-systemformat/src/lib/format.sh
+++ b/recipes-ni/ni-systemformat/ni-systemformat/src/lib/format.sh
@@ -22,6 +22,13 @@ NICONFIG_LABEL=niconfig
 CONFIGFS_DEV=
 ROOTFS_DEV=
 
+# Current-boot keyslot: sealed to current-boot PCR state (no pcr_digest).
+# Added by _convert_to_luks to allow same-session re-open; removed by
+# ni-reseal-luks on the next reseal call. This must not collide with the
+# runtime keyslots assigned in const_luks.sh (ni-device-encryption) — slot 0
+# is the master key, and slots 1 (safemode) and 2 (runmode) are reserved there.
+LUKS_KEYSLOT_CURRENT_BOOT=3
+
 # check for artemis compatibility from devicetree
 # set mountfs to ext4 if artemis model is detected
 # this allows fstype to return ext4 instead of ubifs
@@ -92,12 +99,30 @@ function _convert_to_luks() {
 		--key-file "$_keyfile_path" \
 		"$dev" \
 		|| die UNKNOWN_ERROR "Failed to luksFormat $dev"
-	ni-reseal-luks --yes "$_keyfile_path" \
+	ni-reseal-luks --yes --label "$fslabel-luks" "$_keyfile_path" \
 		|| die UNKNOWN_ERROR "Failed to reseal LUKS keys on $dev"
-	clevis luks unlock \
+	# Open the LUKS volume using the master keyfile (not the TPM policy).
+	# The TPM policy is pre-sealed for the *next* boot's PCR values, so it
+	# will not unseal correctly during the same current-boot session.
+	cryptsetup open \
+		--key-file "$_keyfile_path" \
+		"$dev" \
+		"$fslabel" \
+		|| die UNKNOWN_ERROR "Failed to unlock $dev with master keyfile"
+
+	# Add a current-boot keyslot sealed to the *current* TPM PCR state
+	# (omitting pcr_digest causes clevis to seal to current PCR values).
+	# This allows the LUKS mapping to be re-opened within the same boot
+	# session — e.g. by a subsequent nisystemformat or ni-reseal-luks call —
+	# without keeping the master key in any named file.
+	# ni-reseal-luks removes this slot automatically when it next reseals.
+	clevis luks bind \
 		-d "$dev" \
-		-n "$fslabel" \
-		|| die UNKNOWN_ERROR "Failed to unlock $dev with clevis"
+		-s $LUKS_KEYSLOT_CURRENT_BOOT \
+		-k "$_keyfile_path" \
+		-y \
+		tpm2 '{"pcr_bank":"sha256","pcr_ids":"7,15"}' \
+		|| die UNKNOWN_ERROR "Failed to add current-boot keyslot to $dev; reseal before reboot is now impossible."
 
 	exec {_key_fd}>&-
 }
@@ -403,6 +428,27 @@ function targetinfo_restore()
 
 function _mount_volumes() {
 	local ret=0
+	# Re-open any LUKS mappings that were closed by _unmount_volumes.
+	# Uses the current-boot keyslot (sealed to current-boot PCR values) so
+	# no raw key material needs to be kept in any named file.
+	if type cryptsetup >/dev/null 2>&1 && type clevis >/dev/null 2>&1; then
+		local _fslabel _blkdev
+		for _fslabel in "$NICONFIG_LABEL" "$USERFS_LABEL"; do
+			# Already open?
+			dmsetup ls --target crypt 2>/dev/null | grep -q "^${_fslabel}[[:space:]]" && continue
+			# Find the underlying LUKS block device (labelled "<fslabel>-luks").
+			_blkdev=$(blkid --label "${_fslabel}-luks" --output device 2>/dev/null) || continue
+			cryptsetup isLuks "$_blkdev" 2>/dev/null || continue
+			log INFO "Re-opening LUKS $_fslabel via TPM keyslot"
+			# 'clevis luks unlock' probes every clevis-bound keyslot until one
+			# unseals. Slots that don't match the live PCR state fail their unseal
+			# and emit noisy 'Esys_Unseal policy check failed' / 'Unsealing jwk
+			# from TPM failed' chatter before a matching slot succeeds. Suppress
+			# it; the exit status still gates the WARN below.
+			clevis luks unlock -d "$_blkdev" -n "$_fslabel" 2>/dev/null || \
+				log WARN "Could not re-open LUKS $_fslabel; mountconfig may fail"
+		done
+	fi
 	# Mount volumes in the rcS.d order.
 	with_retry /etc/init.d/mountconfig start || ret=$?
 	with_retry /etc/init.d/populateconfig start || ret=$?


### PR DESCRIPTION
### Summary of Changes

- Modifies grub to measure input artifacts that can effect boot, including config files, loadenv files, kernel, and initrd into PCR 15
- Creates a userspace tool to pre-calculate the PCR 15 value grub calculates at boot-time from an artifact list for safemode and runmode
- Seals LUKS encryption keys to PCR 15 in addition to PCR 7 (the secure boot state register)

### Justification

[AB#3752803](https://dev.azure.com/ni/DevCentral/_workitems/edit/3752803)

### Testing

- Built OE core feeds, safemode, runmode BSI, recovery media, and qemu VMs.
- Booted updated safemode.
- Installed and booted updated runmode.
- Tested nisystemformat with both encrypted and nonencrypted workflows.
- Tested encrypted workflows against cases were PCR values match (encrypted partitions are unlocked) and cases were PCR values do not match (encrypted partitions remain locked).
- Tested various combinations of encrypted and unencrypted partitions, safemode and runmode boots, 

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
