### PR TITLE
usbguard: authorize admin user to control usbguard

### DIFF
--- a/recipes-security/usbguard/usbguard/IPCAccessControl.d/admin
+++ b/recipes-security/usbguard/usbguard/IPCAccessControl.d/admin
@@ -1,0 +1,5 @@
+# Give 'admin' user (UID 0) all permissions.
+Devices=list,listen,modify
+Exceptions=listen
+Parameters=list,listen,modify
+Policy=list,modify

--- a/recipes-security/usbguard/usbguard_1.%.bbappend
+++ b/recipes-security/usbguard/usbguard_1.%.bbappend
@@ -33,4 +33,4 @@ do_install:append() {
 # PACKAGING
 # ==============================================================================
 
-CONFFILES:${PN} += "${sysconfdir}/${BPN}/IPCAccessControl.d"
+CONFFILES:${PN} += "${sysconfdir}/${BPN}/IPCAccessControl.d/*"

--- a/recipes-security/usbguard/usbguard_1.%.bbappend
+++ b/recipes-security/usbguard/usbguard_1.%.bbappend
@@ -1,6 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += "file://usbguard.init \
+    file://IPCAccessControl.d/ \
 "
 
 inherit update-rc.d
@@ -19,4 +20,17 @@ do_install:append() {
         # Remove /etc/volatile.cache if it exists in the target image
         rm -f ${D}${sysconfdir}/volatile.cache
     fi
+
+    install -d ${D}${sysconfdir}/${BPN}/IPCAccessControl.d
+    install \
+        -t ${D}${sysconfdir}/${BPN}/IPCAccessControl.d \
+        --mode 0600 \
+        ${WORKDIR}/IPCAccessControl.d/*
 }
+
+
+# ==============================================================================
+# PACKAGING
+# ==============================================================================
+
+CONFFILES:${PN} += "${sysconfdir}/${BPN}/IPCAccessControl.d"


### PR DESCRIPTION
### Summary of Changes

USBGuard uses role-based access control policies, governed by settings in the ``/etc/usbguard/IPCAccessControl.d`` runparts directory. By default, only the 'root' user is permitted to access policies. Since we use 'admin' in most NILRT runtime configurations as the root user, we need to give that username equivalent permissions.


### Justification

[AB#3866818](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3866818)


### Testing


* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] Installed the new package version to a NILRT VM and confirmed that the new 'admin' permissions file is installed, that it is tracked as a CONFFILE, and that (after starting/restarting the usbguard daemon) the 'admin' user can now call commands like ``usbguard list-devices`` without getting an IPC permissions error.


### Procedure

**This PR should get cherry-picked to master/next.**

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
