### PR TITLE
Add ptests to verify installation of required NIAUTH packages

### DIFF
--- a/recipes-ni/niauth-tests/files/ptest-format.sh
+++ b/recipes-ni/niauth-tests/files/ptest-format.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+# Version 1.3
+# Utility script containing common functions for ptest-compatible test scripts.
+# USAGE:
+# 1) Source this file at the top of your ptest script.
+# 2) Set ptest_test to the name of your test; recommended:
+#    $(basename -s ".sh" "$0")
+# 3) Define your subtests in functions, which call ptest_pass when they pass and
+#    ptest_fail otherwise (FAIL is DEFAULT)
+# 4) Prior to calling your test function, call ptest_change_subtest
+# 5) Call your test function.
+# 6) Call ptest_report immediately after the function returns.
+
+exec 2>&1  # redirect all stderr to stdout to maintain ordering of output
+
+declare -irx PTEST_RC_PASS=0
+declare -irx PTEST_RC_FAIL=1
+declare -irx PTEST_RC_SKIP=77
+
+function ptest_report () {
+	local result='FAIL'
+	case $ptest_rc in
+		0)
+			result='PASS'
+			;;
+		77)
+			result='SKIP'
+			;;
+		*)
+			result='FAIL'
+			;;
+	esac
+
+	if [ "$#" -gt 0 ]; then
+		echo "$@"
+	fi
+
+	printf "${result}: %s" "${ptest_test}"
+	if [ -n "${ptest_subtest}" ]; then
+		printf " %d" "${ptest_subtest}"
+		if [ -n "${ptest_subtest_desc}" ]; then
+			printf " - %s" "${ptest_subtest_desc}"
+		fi
+	fi
+	printf "\n"
+}
+
+function ptest_pass () {
+	ptest_rc=0
+}
+
+function ptest_skip () {
+	ptest_rc=77
+}
+
+function ptest_fail () {
+	ptest_rc=1
+}
+
+# 1 - new test name
+# 2 - new subtest number
+# 3 - new subtest description
+function ptest_change_test () {
+	ptest_test="$1"
+	ptest_subtest="$2"
+	ptest_subtest_desc="$3"
+	ptest_fail
+}
+
+# 1 - new subtest number
+# 2 - new subtest description
+function ptest_change_subtest () {
+	ptest_subtest="$1"
+	ptest_subtest_desc="$2"
+	ptest_fail
+}
+
+ptest_test=''
+ptest_subtest=''
+ptest_subtest_desc=''
+ptest_fail  # set ptest_rc to FAIL

--- a/recipes-ni/niauth-tests/files/run-ptest
+++ b/recipes-ni/niauth-tests/files/run-ptest
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./test_niauth_packages.sh
+
+exit 0

--- a/recipes-ni/niauth-tests/files/test_niauth_packages.sh
+++ b/recipes-ni/niauth-tests/files/test_niauth_packages.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Verifies that niauth-related packages and niacctbase-sudo are not installed.
+
+source "$(dirname "$0")/ptest-format.sh"
+
+ptest_test=$(basename "$0" ".sh")  # test_niauth_packages
+
+
+# TEST: pam-plugin-niauth is not installed
+function test_pam_plugin_niauth_not_installed() {
+    ptest_pass
+    if opkg list-installed | grep -q "^pam-plugin-niauth "; then
+        ptest_fail
+    fi
+}
+
+# TEST: ni-auth-networkcontroller is not installed
+function test_ni_auth_networkcontroller_not_installed() {
+    ptest_pass
+    if opkg list-installed | grep -q "^ni-auth-networkcontroller "; then
+        ptest_fail
+    fi
+}
+
+# TEST: libnss-niauth is not installed
+function test_libnss_niauth_not_installed() {
+    ptest_pass
+    if opkg list-installed | grep -q "^libnss-niauth "; then
+        ptest_fail
+    fi
+}
+
+
+ptest_change_subtest 1 "pam-plugin-niauth not installed"
+test_pam_plugin_niauth_not_installed
+ptest_report
+
+ptest_change_subtest 2 "ni-auth-networkcontroller not installed"
+test_ni_auth_networkcontroller_not_installed
+ptest_report
+
+ptest_change_subtest 3 "libnss-niauth not installed"
+test_libnss_niauth_not_installed
+ptest_report
+
+# TEST: niacctbase-sudo is not installed
+function test_niacctbase_sudo_not_installed() {
+    ptest_pass
+    if opkg list-installed | grep -q "^niacctbase-sudo "; then
+        ptest_fail
+    fi
+}
+
+ptest_change_subtest 4 "niacctbase-sudo not installed"
+test_niacctbase_sudo_not_installed
+ptest_report

--- a/recipes-ni/niauth-tests/niauth-tests.bb
+++ b/recipes-ni/niauth-tests/niauth-tests.bb
@@ -1,0 +1,33 @@
+SUMMARY = "Ptests confirming niauth-related packages are not installed"
+DESCRIPTION = "\
+Installs ptests that verify pam-plugin-niauth, ni-auth-networkcontroller, \
+libnss-niauth, and niacctbase-sudo packages are not present on the system."
+
+SECTION = "tests"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI = "\
+    file://run-ptest \
+    file://ptest-format.sh \
+    file://test_niauth_packages.sh \
+"
+
+S = "${UNPACKDIR}"
+
+inherit ptest
+
+do_install_ptest() {
+    install -m 0755 ${S}/run-ptest              ${D}${PTEST_PATH}
+    install -m 0644 ${S}/ptest-format.sh        ${D}${PTEST_PATH}
+    install -m 0755 ${S}/test_niauth_packages.sh ${D}${PTEST_PATH}
+}
+
+ALLOW_EMPTY:${PN} = "1"
+
+# Only build the base (empty) and -ptest packages
+PACKAGES:remove = "${PN}-dev ${PN}-staticdev ${PN}-dbg"
+
+RDEPENDS:${PN}-ptest:append = " bash opkg"


### PR DESCRIPTION
## Justification

[AB#3650248](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3650248)

## Changes

- Add `recipes-ni/niauth-tests/niauth-tests.bb` ptest recipe
- Add `test_niauth_packages.sh` with 4 subtests
- Add `ptest-format.sh` shared ptest utilities
- Add `run-ptest` entry point

## Testing

### **Manual Testing:**

- Built and deployed IPKs manually to NI-cRIO-9045

1. pam-plugin-niauth not installed - PASS
    ni-auth-networkcontroller not installed - PASS
    libnss-niauth not installed - PASS
    niacctbase-sudo not installed - PASS

<img width="1855" height="437" alt="Screenshot 2026-07-07 164733" src="https://github.com/user-attachments/assets/d4df3e21-67e4-431d-a0c4-5c95eaa77c6f" />


Suggested Reviewers:
@rajendra-desai-ni 
@ni/rtos 