### PR TITLE
container: Remove nilrt-xfce.inc from the runmode container recipe

### DIFF
--- a/recipes-core/images/README
+++ b/recipes-core/images/README
@@ -10,7 +10,7 @@ c     = nilrt-core-image.inc       # NI-specific modifications to the core-image
 ## Images
       | nilrt-base-system-image.bb  # NILRT base system image archive and CDF
 c     | nilrt-recovery-media.bb     # NILRT installation/recovery media ISO
-cbnxp | nilrt-runmode-container.bb  # The runmode rootfs, installed into an OCI container.
+cbn p | nilrt-runmode-container.bb  # The runmode rootfs, installed into an OCI container.
 cb xp | nilrt-runmode-rootfs.bb
 cb  p | nilrt-safemode-initramfs.bb
       | nilrt-safemode-rootfs.bb

--- a/recipes-core/images/nilrt-runmode-container.bb
+++ b/recipes-core/images/nilrt-runmode-container.bb
@@ -9,7 +9,6 @@ IMAGE_INSTALL = "\
 	"
 
 require includes/nilrt-image-base.inc
-require includes/nilrt-xfce.inc
 require includes/nilrt-proprietary.inc
 
 IMAGE_INSTALL_NODEPS += "\


### PR DESCRIPTION
-Remove nilrt-xfce.inc from the runmode container recipe.
-Exclude GUI/X11 package groups from runmode container builds.
Size change 
 nilrt-runmode-container   previous -873MB   Now-684MB
 nilrt-slim-container          No change


### Justification

 [AB#3202011](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3202011)


### Testing



* [x] Bitbake nilrt-runmode-container
* [x]  Bitbake nilrt-slim-container
 * [x] opkg install ni-labview-realtime 
 * [x] opkg install ni-veristand-engine


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
