### PR TITLE
aide: integrate host file-integrity monitoring into the NILRT base image

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-runmode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-runmode.bb
@@ -6,6 +6,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 inherit packagegroup
 
 RDEPENDS:${PN} = "\
+	aide \
 	cpp \
 	cpp-symlinks \
 	dosfstools \

--- a/recipes-ids/aide/aide/aide-check
+++ b/recipes-ids/aide/aide/aide-check
@@ -1,0 +1,132 @@
+#!/bin/sh
+# Periodic AIDE file-integrity check. A one-line summary of each run is sent to
+# syslog (syslog-ng via /dev/log) for alerting; the full per-run report is
+# written under /var/log/aide/ for detail.
+#
+# Exit status:
+#   0      no differences
+#   1|2|4  aide(1) difference bitmask (new|removed|changed); e.g. 7 = all three
+#   8      baseline could not be verified (checksum missing or mismatch); no scan run
+#   9      IO/setup error (cannot create or secure the log dir/report); no scan run
+#   >=14   aide(1) error (e.g. 18 = IO error) - details are in the per-run report
+
+# Set an explicit PATH so aide, sha256sum, mktemp, grep, tail, etc.
+# resolve for manual invocations too, not just the cron entry which sets PATH.
+PATH=/usr/sbin:/usr/bin:/sbin:/bin
+
+DB=/var/lib/aide/aide.db.gz
+LOGDIR=/var/log/aide
+TAG=aide-check
+INITLOCK=/run/aide-init.lock
+CHECKLOCK=/run/aide-check.lock
+
+# Reports can contain file paths and hashes -> keep them root-only. Fail closed
+# if the log directory cannot be created or secured, so we never run a scan we
+# cannot record.
+umask 077
+if ! mkdir -p "$LOGDIR" || ! chmod 700 "$LOGDIR"; then
+	logger -t "$TAG" -p daemon.err "cannot create or secure $LOGDIR; skipping check (IO error)"
+	exit 9
+fi
+
+# Prevent concurrent aide-check runs (e.g. a manual run during the daily cron
+# job). flock holds the advisory lock via fd 9 for the lifetime of this process;
+# the kernel releases it automatically on process death, so no PID-based
+# stale recovery is needed.
+if ! exec 9>"$CHECKLOCK" 2>/dev/null; then
+	logger -t "$TAG" -p daemon.err "cannot open lock file $CHECKLOCK; skipping check (IO error)"
+	exit 9
+fi
+flock -n 9; _rc=$?
+if [ "$_rc" -eq 1 ]; then
+	logger -t "$TAG" -p daemon.info "another aide-check is running; skipping"
+	exit 0
+elif [ "$_rc" -ne 0 ]; then
+	logger -t "$TAG" -p daemon.err "flock failed on $CHECKLOCK (rc=$_rc); skipping check (IO error)"
+	exit 9
+fi
+
+# No baseline database present. Distinguish three cases:
+#  - aide-init is mid-build (its lock is held): the checksum is written before
+#    the DB is promoted, so "checksum present, DB missing" is expected -> skip.
+#  - checksum exists with no build running: the DB was removed after
+#    provisioning (deletion/tampering) -> fail closed.
+#  - neither DB nor checksum: benign first boot before the baseline exists.
+if [ ! -f "$DB" ]; then
+	# flock -n fails when aide-init's background scan holds the lock (build in
+	# progress) and succeeds when nobody holds it. Stale locks are impossible:
+	# the kernel releases flock automatically when the holding process dies.
+	flock -n "$INITLOCK" true 2>/dev/null; _rc=$?
+	if [ "$_rc" -eq 1 ]; then
+		logger -t "$TAG" -p daemon.info "baseline build in progress; skipping integrity check"
+		exit 0
+	elif [ "$_rc" -ne 0 ]; then
+		logger -t "$TAG" -p daemon.err "cannot probe baseline-build lock $INITLOCK (rc=$_rc); skipping check (IO error)"
+		exit 9
+	fi
+	if [ -f "$DB.sha256" ]; then
+		logger -t "$TAG" -p daemon.crit "baseline database $DB missing but checksum present - possible deletion/tampering; refusing to run (run: /etc/init.d/aide-init reinit)"
+		exit 8
+	fi
+	logger -t "$TAG" -p daemon.info "no baseline database yet; skipping integrity check"
+	exit 0
+fi
+
+# Verify the baseline database itself has not been tampered with before we trust
+# it (the runmode rootfs is writable, so the DB is a target too). Fail closed: if
+# the baseline cannot be trusted, do NOT emit a (potentially false) "OK" - alert
+# and stop so an operator re-initialises the baseline (aide-init).
+if [ ! -f "$DB.sha256" ]; then
+	logger -t "$TAG" -p daemon.warning "baseline checksum missing; cannot verify baseline integrity - skipping check (run: /etc/init.d/aide-init reinit)"
+	exit 8
+fi
+want=$(cat "$DB.sha256" 2>/dev/null)
+have=$(sha256sum "$DB" 2>/dev/null)
+have=${have%% *}
+if [ -z "$want" ] || [ -z "$have" ]; then
+	# Could not read the checksum or hash the DB -> IO error, not tampering.
+	logger -t "$TAG" -p daemon.err "cannot read baseline checksum or hash the database (IO error); skipping check"
+	exit 9
+fi
+if [ "$want" != "$have" ]; then
+	logger -t "$TAG" -p daemon.crit "BASELINE DATABASE CHECKSUM MISMATCH - possible tampering; refusing to run check; investigate then run: /etc/init.d/aide-init reinit (want=$want have=$have)"
+	exit 8
+fi
+
+# Create a unique per-run report. mktemp guarantees uniqueness (so two runs in
+# the same second cannot overwrite each other's report) and fails closed: if the
+# log volume is full or read-only we skip rather than run a scan whose output
+# cannot be recorded, which would make the exit status meaningless. Keep XXXXXX
+# at the very end of the template (BusyBox mktemp requires it there), then rename
+# to add the .log suffix.
+tmp=$(mktemp "$LOGDIR/aide-check.$(date +%Y%m%d-%H%M%S).XXXXXX" 2>/dev/null) || {
+	logger -t "$TAG" -p daemon.err "cannot create report file in $LOGDIR; skipping check (IO error)"
+	exit 9
+}
+report="$tmp.log"
+if ! mv "$tmp" "$report" 2>/dev/null; then
+	logger -t "$TAG" -p daemon.err "cannot rename report file ($tmp -> $report); skipping check (IO error)"
+	rm -f "$tmp" 2>/dev/null
+	exit 9
+fi
+
+aide --check >> "$report" 2>&1
+rc=$?
+
+if [ "$rc" -eq 0 ]; then
+	logger -t "$TAG" -p daemon.info "integrity check OK: no differences"
+elif [ "$rc" -ge 1 ] && [ "$rc" -le 7 ]; then
+	# aide(1) difference bitmask (new|removed|changed).
+	summary=$(grep -E "(Added|Removed|Changed) entries:[[:space:]]+[0-9]+" "$report" | tr -s ' ' | tr '\n' ' ')
+	logger -t "$TAG" -p daemon.warning "integrity check FOUND DIFFERENCES (rc=$rc): ${summary:-see report} [report: $report]"
+else
+	# aide(1) error status (>=14) - not a difference result.
+	logger -t "$TAG" -p daemon.err "aide --check ERROR (rc=$rc); see $report"
+fi
+
+# Bound retained per-run reports so /var/log/aide cannot grow without limit.
+ls -1t "$LOGDIR"/aide-check.*.log 2>/dev/null | tail -n +31 | while read -r old; do
+	rm -f "$old"
+done
+
+exit "$rc"

--- a/recipes-ids/aide/aide/aide-check.cron
+++ b/recipes-ids/aide/aide/aide-check.cron
@@ -1,0 +1,5 @@
+# Daily AIDE file-integrity check. Logs a one-line summary to syslog and writes
+# the full per-run report under /var/log/aide/.
+SHELL=/bin/sh
+PATH=/usr/sbin:/usr/bin:/sbin:/bin
+0 0 * * * root /usr/sbin/aide-check

--- a/recipes-ids/aide/aide/aide-init
+++ b/recipes-ids/aide/aide/aide-init
@@ -1,0 +1,149 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          aide-init
+# Required-Start:    $local_fs $remote_fs $syslog
+# Required-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:
+# Short-Description: Initialize the AIDE baseline database on first boot
+# Description:       On the first boot after provisioning (when no baseline
+#                    database exists yet), build the AIDE file-integrity
+#                    baseline and promote it to the active database. Runs once;
+#                    subsequent boots are a no-op while the baseline exists.
+#                    Use the 'reinit' action to force a rebuild after a
+#                    legitimate change or a failed/tampered baseline.
+### END INIT INFO
+
+# The init environment does not guarantee a usable PATH; set one explicitly so
+# aide and sha256sum resolve during first-boot baseline creation.
+PATH=/usr/sbin:/usr/bin:/sbin:/bin
+
+DBDIR=/var/lib/aide
+DB=$DBDIR/aide.db.gz
+NEWDB=$DBDIR/aide.db.new.gz
+LOGDIR=/var/log/aide
+LOCK=/run/aide-init.lock
+
+# The baseline, its checksum and the init log can expose scanned paths/hashes ->
+# keep everything created here root-only.
+umask 077
+
+build_baseline() {
+	# $1 = "reinit" -> clear any existing baseline before rebuilding.
+	# flock holds the advisory lock via fd 9 for the lifetime of the background
+	# build process; the kernel releases it on process death, so no PID-based
+	# stale recovery is needed. /run is tmpfs -> no stale file post-reboot.
+	if ! exec 9>"$LOCK" 2>/dev/null; then
+		logger -t aide-init -p daemon.err "cannot open lock file $LOCK; baseline init skipped"
+		return 0
+	fi
+	flock -n 9; _rc=$?
+	if [ "$_rc" -eq 1 ]; then
+		logger -t aide-init -p daemon.info "baseline build already in progress; skipping"
+		exec 9>&-
+		return 0
+	elif [ "$_rc" -ne 0 ]; then
+		logger -t aide-init -p daemon.err "flock failed on $LOCK (rc=$_rc); baseline init skipped"
+		exec 9>&-
+		return 0
+	fi
+	# Ensure the working directories exist AND are root-only (reports/baseline
+	# metadata can expose scanned paths/hashes). chmod enforces the mode even if
+	# a directory pre-existed with broader permissions. On failure, release the
+	# lock and bail so a filesystem problem cannot wedge baseline init this boot.
+	if ! mkdir -p "$DBDIR" "$LOGDIR" 2>/dev/null || ! chmod 700 "$DBDIR" "$LOGDIR" 2>/dev/null; then
+		logger -t aide-init -p daemon.err "cannot create or secure $DBDIR or $LOGDIR; baseline init skipped"
+		exec 9>&-
+		return 0
+	fi
+	# Remove the current baseline only after the lock is held, so we never delete
+	# it without immediately starting the rebuild below.
+	if [ "$1" = "reinit" ]; then
+		command -v chattr >/dev/null 2>&1 && chattr -i "$DB" "$DB.sha256" 2>/dev/null
+		rm -f "$DB" "$DB.sha256"
+	fi
+	# Clear an orphan checksum (DB deleted/tampered while the immutable
+	# aide.db.gz.sha256 survived): left in place it would block the rebuild
+	# below, since the immutable checksum cannot be overwritten, and the build
+	# would fail on every boot with no recovery path. Drop it so start can
+	# self-heal into a fresh baseline.
+	if [ ! -f "$DB" ] && [ -f "$DB.sha256" ]; then
+		command -v chattr >/dev/null 2>&1 && chattr -i "$DB.sha256" 2>/dev/null
+		rm -f "$DB.sha256"
+	fi
+	rm -f "$NEWDB"
+	logger -t aide-init -p daemon.info "building AIDE baseline database in background"
+	# Run in the background so a fresh scan does not block system boot.
+	(
+		# fd 9 is inherited; release it when the build finishes (or the process
+		# dies) so the lock is freed and aide-check can proceed.
+		trap 'exec 9>&-' EXIT
+		initlog="$LOGDIR/aide-init.log"
+		aide --init > "$initlog" 2>&1
+		rc=$?
+		if [ "$rc" -ne 0 ]; then
+			logger -t aide-init -p daemon.err "AIDE --init failed (exit $rc); see $initlog"
+		elif [ ! -f "$NEWDB" ]; then
+			logger -t aide-init -p daemon.err "AIDE --init reported success but produced no database ($NEWDB missing); see $initlog"
+		else
+			# Protect the baseline (runmode rootfs is writable):
+			#  - record a sha256 so tampering with the DB is detectable
+			#  - emit the hash to syslog as an off-box audit record
+			#  - make BOTH the DB and its checksum immutable, so neither can be
+			#    silently rewritten together to defeat the tamper check
+			# Compute the checksum from the staged DB and write it into place
+			# BEFORE moving the DB, so the active DB is never present without its
+			# checksum. Every step is checked: a failure must not log a false
+			# "baseline created" or leave a stray checksum without an active DB.
+			sum=$(sha256sum "$NEWDB" 2>/dev/null)
+			sum=${sum%% *}
+			if [ -z "$sum" ]; then
+				logger -t aide-init -p daemon.err "failed to compute baseline checksum for $NEWDB; aborting"
+				rm -f "$NEWDB"
+			elif ! printf '%s\n' "$sum" > "$DB.sha256"; then
+				logger -t aide-init -p daemon.err "failed to write $DB.sha256; aborting"
+				rm -f "$DB.sha256" "$NEWDB"
+			elif ! mv -f "$NEWDB" "$DB"; then
+				logger -t aide-init -p daemon.err "failed to promote baseline DB ($NEWDB -> $DB); aborting"
+				rm -f "$DB.sha256" "$NEWDB"
+			else
+				chmod 600 "$DB" "$DB.sha256"
+				logger -t aide-init -p daemon.notice "AIDE baseline created: $DB sha256=$sum"
+				if command -v chattr >/dev/null 2>&1; then
+					if ! chattr +i "$DB" "$DB.sha256" 2>/dev/null; then
+						logger -t aide-init -p daemon.warning "failed to make baseline DB/checksum immutable (chattr +i); baseline protection is reduced"
+					fi
+				fi
+			fi
+		fi
+	) &
+	# Parent closes fd 9 so only the background child holds the lock.
+	exec 9>&-
+}
+
+case "$1" in
+	start)
+		# Already initialized: nothing to do - but if the DB exists without its
+		# checksum, the baseline cannot be verified (aide-check will refuse) ->
+		# surface it at boot so the tamper/misconfiguration is visible.
+		if [ -f "$DB" ]; then
+			[ -f "$DB.sha256" ] || logger -t aide-init -p daemon.warning "baseline DB present but checksum $DB.sha256 missing; aide-check will refuse - run '/etc/init.d/aide-init reinit'"
+			exit 0
+		fi
+		build_baseline
+		;;
+	reinit|force-reinit)
+		# Rebuild the baseline from the current filesystem state (after a
+		# legitimate update, or to recover from a failed/tampered baseline). The
+		# old baseline is cleared inside build_baseline, only once the lock is
+		# held, so a concurrent build is never left half-removed.
+		build_baseline reinit
+		;;
+	stop|restart|force-reload|status)
+		;;
+	*)
+		echo "Usage: $0 {start|reinit|force-reinit|stop|restart|force-reload|status}" >&2
+		exit 1
+		;;
+esac
+exit 0

--- a/recipes-ids/aide/aide/aide.conf
+++ b/recipes-ids/aide/aide/aide.conf
@@ -1,0 +1,57 @@
+# NI baseline AIDE policy for NILRT
+# Host file-integrity monitoring (FIM) for security-relevant, normally-immutable
+# system paths. Satisfies CRA Annex I (2)(g)/(2)(j).
+#
+# The database is stored under /var/lib/aide, OUTSIDE every monitored directory,
+# so writing the database or its log never trips the next --check. NILRT runmode
+# is a WRITABLE ext4 rootfs (not a read-only squashfs at runtime), so the
+# baseline DB must be protected out-of-band (checksum/off-box), not relied on as
+# immutable.
+@@define DBDIR /var/lib/aide
+@@define LOGDIR /var/log/aide
+
+database_in=file:@@{DBDIR}/aide.db.gz
+database_out=file:@@{DBDIR}/aide.db.new.gz
+gzip_dbout=yes
+
+log_level=warning
+report_url=file:@@{LOGDIR}/aide.log
+report_url=stdout
+
+# ---- attribute rule groups ----
+# One strong content hash (sha256) is sufficient for tamper detection; adding a
+# second digest (e.g. sha512) would hash every file twice, enlarging the DB and
+# lengthening each scan for no security gain - avoided to limit RT impact.
+FIPSR  = p+u+g+s+acl+xattrs+sha256
+NORMAL = FIPSR
+DIR    = p+u+g+acl+xattrs
+
+# ---- monitored: security-relevant, normally-immutable system directories ----
+/bin    NORMAL
+/sbin   NORMAL
+/lib    NORMAL
+/lib64  NORMAL
+/usr    NORMAL
+/boot   NORMAL
+/etc    NORMAL
+
+# ---- excluded: AIDE's own state + volatile / runtime paths ----
+# (/var, /tmp, /proc, /sys, /run, /dev are simply not in the monitored set above)
+!/usr/lib/aide
+# Kernel modules (.ko) ARE monitored (tamper -> root); exclude only the
+# depmod-regenerated index files (modules.dep/.alias/.symbols/.builtin.* etc.)
+# which are rewritten every boot/update and would otherwise cause false positives.
+!/lib/modules/.*/modules\..*$
+!/etc/natinst/share
+!/etc/mtab$
+!/etc/machine-id$
+!/etc/resolv\.conf.*
+!/etc/adjtime$
+!/etc/hostname$
+!/etc/issue.*
+!/etc/random-seed$
+!/etc/ssh/ssh_host_.*
+!/etc/salt/minion_id$
+!/etc/salt/pki/.*
+!/etc/.*\.lock$
+!/etc/.*-$

--- a/recipes-ids/aide/aide/aide.logrotate
+++ b/recipes-ids/aide/aide/aide.logrotate
@@ -1,0 +1,16 @@
+# Rotate the persistent AIDE report logs so they cannot grow without bound:
+#  - aide.log      : written/appended by AIDE itself (report_url in /etc/aide.conf)
+#  - aide-init.log : stdout/stderr captured by aide-init on each baseline (re)build
+# (Per-run timestamped reports under /var/log/aide are pruned by aide-check.)
+# These logs contain scanned file paths and hashes, so recreate rotated files
+# root-only (create 0600) and run rotation as root regardless of umask.
+/var/log/aide/aide.log /var/log/aide/aide-init.log {
+	su root root
+	create 0600 root root
+	weekly
+	rotate 4
+	missingok
+	notifempty
+	compress
+	maxsize 1M
+}

--- a/recipes-ids/aide/aide_%.bbappend
+++ b/recipes-ids/aide/aide_%.bbappend
@@ -1,0 +1,58 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+# Ship the NI-maintained AIDE policy as /etc/aide.conf, replacing the upstream
+# sample. FILESEXTRAPATHS:prepend already makes the base recipe's own
+# "file://aide.conf" resolve to our copy, but we list it here (and install it
+# below) so the override is explicit and cannot silently regress if a future
+# upstream bump drops that SRC_URI entry. The monitored/excluded rules are inline
+# in our aide.conf, so blank the class-appended include/skip lists to avoid
+# duplicate entries.
+SRC_URI += "file://aide.conf"
+AIDE_INCLUDE_DIRS = ""
+AIDE_SKIP_DIRS = ""
+
+# First-boot baseline initialization (sysvinit).
+SRC_URI += "file://aide-init"
+inherit update-rc.d
+INITSCRIPT_NAME = "aide-init"
+INITSCRIPT_PARAMS = "defaults 99"
+
+# Scheduled integrity checks via cron -> syslog.
+SRC_URI += "file://aide-check file://aide-check.cron file://aide.logrotate"
+
+# Runtime deps for the shipped scripts:
+#  - cronie schedules aide-check
+#  - logrotate rotates the persistent report log (ships /etc/logrotate.d/aide)
+#  - coreutils provides sha256sum and nice, which the NILRT BusyBox config
+#    disables (CONFIG_SHA256SUM/CONFIG_NICE). Both utilities live in the main
+#    coreutils package (they are NOT among NI's per-binary coreutils-* splits),
+#    so the full package is the correct dependency. coreutils is already part of
+#    the runmode base image, so this makes the dependency explicit and does not
+#    add image footprint.
+RDEPENDS:${PN} += "cronie coreutils logrotate"
+
+# Database lives outside every monitored directory (see aide.conf); install the
+# NI policy as /etc/aide.conf, create the database dir, and install the
+# first-boot init script + scheduled-check wrapper, cron job and logrotate rule.
+do_install:append () {
+	install -d -m 0700 ${D}${localstatedir}/lib/aide
+	install -d ${D}${sysconfdir}
+	install -m 0644 ${UNPACKDIR}/aide.conf ${D}${sysconfdir}/aide.conf
+	install -d ${D}${sysconfdir}/init.d
+	install -m 0755 ${UNPACKDIR}/aide-init ${D}${sysconfdir}/init.d/aide-init
+	install -d ${D}${sbindir}
+	install -m 0755 ${UNPACKDIR}/aide-check ${D}${sbindir}/aide-check
+	install -d ${D}${sysconfdir}/cron.d
+	install -m 0644 ${UNPACKDIR}/aide-check.cron ${D}${sysconfdir}/cron.d/aide-check
+	install -d ${D}${sysconfdir}/logrotate.d
+	install -m 0644 ${UNPACKDIR}/aide.logrotate ${D}${sysconfdir}/logrotate.d/aide
+}
+
+FILES:${PN} += "\
+	${sysconfdir}/aide.conf \
+	${localstatedir}/lib/aide \
+	${sysconfdir}/init.d/aide-init \
+	${sbindir}/aide-check \
+	${sysconfdir}/cron.d/aide-check \
+	${sysconfdir}/logrotate.d/aide \
+"


### PR DESCRIPTION
### Summary of Changes

Add AIDE (Advanced Intrusion Detection Environment) as the host file-integrity monitoring (FIM) capability for NILRT, baked into the base system image (BSI):

- **Packaging:** add aide to packagegroup-ni-runmode so it ships on every device.
- **NI monitoring policy:** ship a managed /etc/aide.conf (overrides the upstream sample) monitoring the security-relevant, normally-immutable trees (/bin /sbin /lib /lib64 /usr /boot /etc) and kernel modules (.ko), excluding only volatile/runtime paths (incl. depmod-regenerated modules.* indices, /etc/natinst/share, DHCP/salt first-boot artifacts).
- **First-boot baseline:** sysvinit one-shot aide-init (S99, idempotent, backgrounded) builds the baseline on first boot; adds a reinit action for controlled rebuilds.
- **Scheduled checks:** aide-check wrapper runs via cron daily at 00:00 UTC, reporting a one-line summary to syslog (daemon.info clean / daemon.warning on differences) with per-run reports under /var/log/aide (logrotate + self-pruned).
- **Tamper-evident baseline:** DB stored outside monitored dirs (/var/lib/aide, 0700), sha256 sidecar, both made immutable (chattr +i), hash audited to syslog; checks fail closed (distinct exit codes) if the baseline can't be verified.
- **Runtime deps:** cronie, coreutils (for sha256sum, which the NILRT BusyBox config disables).
- **Review-driven hardening:**
  - Explicit PATH in aide-init and aide-check for boot-time/manual reliability.
  - Concurrent-run prevention via flock in both aide-init and aide-check; lockfile-open failures (e.g. run not writable) and flock error codes (rc=1 contention vs rc≥2 error) are distinguished and logged explicitly — no silent skips.
  - BusyBox-compatible unique report creation using mktemp template ending with XXXXXX, then rename to .log.
  - Removed awk dependency from checksum parsing (POSIX shell parsing only).
  - aide-init unknown action now prints usage and exits non-zero.
  - Orphan checksum handling when DB is missing.
  - Logrotate covers both aide.log and aide-init.log with root-only recreate policy.
  - Policy tightened for RT impact by using NORMAL = FIPSR (no redundant second content hash pass).

### Justification

https://dev.azure.com/ni/DevCentral/_workitems/edit/3470293

### Testing

**Build**

- nilrt-base-system-image builds for x64 and ARM32 (xilinx-zynq) via standard pipeline (build.core-feeds.sh and build.core-images.sh). No new build/QA warnings attributable to AIDE.
- AIDE packaging/layout checks pass: aide and aide-lic appear in nilrt-runmode-rootfs manifest; /etc/aide.conf ships NI policy override; /etc/init.d/aide-init (S99), /usr/sbin/aide-check, /etc/cron.d/aide-check, /etc/logrotate.d/aide, and /var/lib/aide (0700) are installed.
- ARM (xilinx-zynq): applicable to both x64 and ARM (no arch-specific code).

**On-target validation (x64, cRIO-9045, kernel 6.12.94-rt18 PREEMPT_RT)**

- Image reinstalled and validated on device.
- First boot: aide-init auto-builds baseline; DB and checksum created and protected.
- Permissions validated: /var/lib/aide 0700, /var/log/aide 0700, aide.db.gz 0600, aide.db.gz.sha256 0600.
- Clean check: /usr/sbin/aide-check returns exit 0 on clean image; per-run report created with unique mktemp-based name.
- Concurrency: concurrent aide-check invocation skips cleanly with syslog message; aide-init invalid action prints usage and returns exit 1.
- Persistent logging: aide.log written by AIDE via report_url; aide-init.log captures baseline build output; logrotate config present for both.
- Daily cron check confirmed running; sample report verified correct detection — post-baseline package install (rt-tests) flagged with 32 added entries including full filenames, hashes, and old vs new attribute diffs.
- RT impact: ran cyclictest at RT priority 80 (100k loops) with and without aide --check running concurrently; max latency 33 µs, no change under AIDE load. AIDE runs at normal priority and cannot preempt RT threads.

**On-target validation (ARM32, cRIO-9068, Cortex-A9, kernel 4.14.146-rt67-ni PREEMPT_RT)**

- BSI flashed and AIDE verified on device.
- aide --init: 2m21s wall time; aide --check: 2m20s — expected for single-core UBIFS-backed storage.
- Peak RSS ~59 MiB on 512 MiB device.
- RT cyclictest stress run — Min: 10 µs / Avg: 16 µs / Max: 60 µs  
(100,000 iterations, SCHED_FIFO prio 80, CPU0, concurrent aide --check, kernel 4.14.146-rt67-ni PREEMPT_RT)

**Footprint**

- AIDE installed size ~290 KiB (/usr/bin/aide ~253 KiB + aide-lic ~35 KiB); runtime libs already in base.
- Baseline DB aide.db.gz ~4.75 MiB for monitored system trees and kernel modules.
- Observed peak RSS ~45 MiB during --init and ~59 MiB during --check.

**Known gap / follow-up**

opkg 0.9.0 has no global post-transaction hook. A package install or update via opkg will cause AIDE to flag changed files as violations until the baseline is manually updated (run /etc/init.d/aide-init reinit after any opkg operation). Automatic rebaseline on package operations will be addressed in a successor feature: the team has decided to patch opkg to add a post-invoke hook, with a follow-up AIDE integration work item to wire the hook into aide-init reinit.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).