### PR TITLE
niacctbase: new group datacomm

### DIFF
--- a/files/group
+++ b/files/group
@@ -5,6 +5,7 @@ nogroup:x:65534:
 ni:x:500:
 openvpn:x:499:
 niwscerts:x:498:
+datacomm:x:497:
 # free space
 clevis:x:405:
 krill:x:404:

--- a/recipes-ni/niacctbase/niacctbase.bb
+++ b/recipes-ni/niacctbase/niacctbase.bb
@@ -28,12 +28,13 @@ GROUPADD_PARAM:${PN} = " \
 	--system ${LVRT_GROUP}; \
 	--system openvpn; \
 	--system niwscerts; \
-	--system network"
+	--system network; \
+	--system datacomm"
 
 # add parameter -m if you want home directories created with default files (.profile, .bashrc)
 USERADD_PARAM:${PN} = " \
-	-m -N -g ${LVRT_GROUP} -G network,niwscerts,plugdev,tty,video -c 'LabVIEW user' ${LVRT_USER}; \
-	-m -N -g ${LVRT_GROUP} -G niwscerts,plugdev,adm,tty -c 'Web services user' webserv; \
+	-m -N -g ${LVRT_GROUP} -G network,niwscerts,plugdev,tty,video,datacomm -c 'LabVIEW user' ${LVRT_USER}; \
+	-m -N -g ${LVRT_GROUP} -G niwscerts,plugdev,adm,tty,datacomm -c 'Web services user' webserv; \
 	-N -g openvpn -G network -c 'OpenVPN' -r openvpn; \
 "
 


### PR DESCRIPTION
The datacomm group controls access to distributed communication technologies such as fieldbuses, industrial communications protocols, audio protocols, etc. The security domain of these facilities is relatively tightly constrained, but does not cleanly fit into an exclusively application-layer security model. One example of a resource which could be protected by the datacomm group is a UNIX socket which exposes reconfiguration of LabVIEW network shared variables. Another example might be /dev/ttyS0, replacing the tty group, if the serial port were connected exclusively to a Modbus-over-Serial-Line device.

The ultimate goal of this group is to grant access to fieldbus configuration facilities to user-defined accounts, when PAM-based authentication is a better fit than X.509.

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
