### PR TITLE
linux-nilrt: update alternate kernels (debug , nohz) to 6.18

### DIFF
--- a/recipes-kernel/linux/linux-nilrt-debug_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-debug_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NILRT linux kernel debug build"
 NI_RELEASE_VERSION = "master"
-LINUX_VERSION = "6.12"
+LINUX_VERSION = "6.18"
 LINUX_VERSION:xilinx-zynq = "4.14"
 LINUX_KERNEL_TYPE = "debug"
 

--- a/recipes-kernel/linux/linux-nilrt-nohz_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-nohz_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NILRT linux kernel full dynamic ticks (NO_HZ_FULL) build"
 NI_RELEASE_VERSION = "master"
-LINUX_VERSION = "6.12"
+LINUX_VERSION = "6.18"
 LINUX_KERNEL_TYPE = "nohz"
 
 require linux-nilrt-alternate.inc


### PR DESCRIPTION
[AB#3958505](https://dev.azure.com/ni/DevCentral/_workitems/edit/3958505)
### Summary of Changes

Updated the alternate NILRT kernel recipes (`linux-nilrt-debug` and `linux-nilrt-nohz`) to use Linux kernel version 6.18.This updates the debug and nohz kernel variants to Linux 6.18 as part of the ongoing 6.18 migration effort.

### Justification

As part of the ongoing Linux 6.18 migration effort, the alternate debug and nohz kernel variants need to be validated on Linux 6.18. This change enables build and hardware validation of the alternate kernel variants ahead of the default kernel migration.

### Testing
- **`linux-nilrt-debug`**
<img width="589" height="160" alt="Screenshot 2026-07-21 120843" src="https://github.com/user-attachments/assets/90c98952-5511-42b8-bdac-787c7d7f5d15" />


- **`linux-nilrt-nohz`**
<img width="863" height="160" alt="Screenshot 2026-07-21 121712" src="https://github.com/user-attachments/assets/6dafa83b-4e71-4c1b-a286-704b695c12fd" />


Validation performed on PXI-8881 target


* [ ] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

1. Build `linux-nilrt-debug` and `linux-nilrt-nohz` after updating the kernel version to 6.18.
2. Deploy the generated `bzImage` and module tarball to an x64 target using the documented kernel deployment procedure.
3. Extract the module package, generate module dependency metadata using `depmod`, and update the boot symlink to reference the new kernel image.
4. Reboot the target and verify successful boot into the 6.18 kernel using `uname -r`, confirming module availability and network functionality.

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
