### PR TITLE
meta-nilrt: add static nftables firewall for safemode(x64)

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-safemode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-safemode.bb
@@ -20,6 +20,10 @@ RDEPENDS:${PN} = " \
 	ni-systemimage \
 "
 
+# The safemode nftables firewall is x64-only for now; it has not yet been
+# validated on arm targets.
+RDEPENDS:${PN}:append:x64 = " ni-safemode-firewall"
+
 # GPU firmware, included as split packages to conserve space
 #
 # Intel Valleyview family, no i915 firmware in use

--- a/recipes-ni/ni-safemode-firewall/files/ni-safemode-firewall
+++ b/recipes-ni/ni-safemode-firewall/files/ni-safemode-firewall
@@ -1,0 +1,63 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          ni-safemode-firewall
+# Required-Start:
+# Required-Stop:
+# Default-Start:     S
+# Default-Stop:
+# Short-Description: ni-safemode-firewall
+# Description:       Load the static default-deny nftables firewall used
+#                    while a target is in safe mode.
+### END INIT INFO
+#
+# Copyright (c) 2026 National Instruments.
+# All rights reserved.
+#
+# NI Linux Real-Time safemode static firewall.
+#
+# Loads a default-deny nftables ruleset that permits only the minimal set
+# of services expected while a target is in safemode. Uses the nft
+# userspace tool only (no daemon), so it is safe for the size-constrained
+# safemode initramfs.
+
+RULESET=/etc/nftables/safemode.nft
+TABLE="inet safemode_firewall"
+
+case "$1" in
+	start)
+		printf "Enabling firewall: "
+		if nft -f "$RULESET"; then
+			echo "OK"
+		else
+			echo "FAILED"
+			exit 1
+		fi
+		;;
+	stop)
+		printf "Disabling firewall: "
+		if nft list table $TABLE >/dev/null 2>&1; then
+			nft delete table $TABLE && echo "OK" || { echo "FAILED"; exit 1; }
+		else
+			echo "OK"
+		fi
+		;;
+	restart)
+		"$0" stop
+		"$0" start
+		;;
+	reload|force-reload)
+		"$0" start
+		;;
+	status)
+		if nft list table $TABLE >/dev/null 2>&1; then
+			echo "firewall: active"
+		else
+			echo "firewall: inactive"
+			exit 3
+		fi
+		;;
+	*)
+		echo "Usage: $0 {start|stop|restart|reload|force-reload|status}" >&2
+		exit 1
+		;;
+esac

--- a/recipes-ni/ni-safemode-firewall/files/safemode.nft
+++ b/recipes-ni/ni-safemode-firewall/files/safemode.nft
@@ -1,0 +1,65 @@
+#!/usr/sbin/nft -f
+#
+# Copyright (c) 2026 National Instruments.
+# All rights reserved.
+#
+# NI Linux Real-Time safemode static firewall ruleset.
+#
+# Default-deny (drop) for inbound traffic. Only the minimal set of
+# services expected while a controller is in safemode is permitted:
+#   - SSH (remote management / recovery)
+#   - NI System Web Server (MAX and web UI, HTTP 80 + HTTPS 443)
+#   - NI Service Locator (3580)
+#   - mDNS device discovery (5353)
+#   - DHCP client replies (IPv4 68, IPv6 546)
+#
+# Outbound traffic is allowed, so client connections such as opkg feed
+# access work; their replies return via the established connection state.
+
+# Replace only our own table, leaving any other nftables state intact.
+# The empty table declaration ensures the delete succeeds on first load.
+table inet safemode_firewall
+delete table inet safemode_firewall
+
+table inet safemode_firewall {
+	chain input {
+		type filter hook input priority filter; policy drop;
+
+		# Loopback and already-accepted connections.
+		iif "lo" accept
+		ct state established,related accept
+		ct state invalid drop
+
+		# ICMPv6 is required for core IPv6 operation (neighbor
+		# discovery, path MTU); allow all types. Allow ICMPv4 too
+		# (ping, unreachable, etc.).
+		meta l4proto ipv6-icmp accept
+		ip protocol icmp accept
+
+		# DHCP client replies, restricted to the server source port.
+		udp sport 67 udp dport 68 accept
+		udp sport 547 udp dport 546 accept
+
+		# SSH - remote management / recovery.
+		tcp dport 22 accept
+
+		# NI System Web Server (MAX, web UI).
+		tcp dport { 80, 443 } accept
+
+		# NI Service Locator.
+		tcp dport 3580 accept
+
+		# mDNS - link-local multicast device discovery. Restrict to the
+		# mDNS multicast groups rather than accepting any destination.
+		ip daddr 224.0.0.251 udp dport 5353 accept
+		ip6 daddr ff02::fb udp dport 5353 accept
+	}
+
+	chain forward {
+		type filter hook forward priority filter; policy drop;
+	}
+
+	chain output {
+		type filter hook output priority filter; policy accept;
+	}
+}

--- a/recipes-ni/ni-safemode-firewall/ni-safemode-firewall.bb
+++ b/recipes-ni/ni-safemode-firewall/ni-safemode-firewall.bb
@@ -1,0 +1,34 @@
+SUMMARY = "NI Linux RT safemode static nftables firewall"
+DESCRIPTION = "Default-deny nftables ruleset and SysV init script that \
+permit only the minimal set of services expected while a target is in \
+safemode. Uses the nft userspace tool only (no daemon, no Python), so it \
+is suitable for the size-constrained safemode initramfs."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+SECTION = "base"
+
+S = "${UNPACKDIR}"
+
+SRC_URI = "\
+	file://ni-safemode-firewall \
+	file://safemode.nft \
+"
+
+FILES:${PN} = "\
+	${sysconfdir}/init.d/ni-safemode-firewall \
+	${sysconfdir}/nftables/safemode.nft \
+"
+
+RDEPENDS:${PN} += "nftables"
+
+INITSCRIPT_NAME = "ni-safemode-firewall"
+INITSCRIPT_PARAMS = "start 39 S ."
+
+inherit update-rc.d
+
+do_install () {
+	install -d ${D}${sysconfdir}/init.d
+	install -d ${D}${sysconfdir}/nftables
+	install -m 0755 ${S}/ni-safemode-firewall ${D}${sysconfdir}/init.d
+	install -m 0644 ${S}/safemode.nft         ${D}${sysconfdir}/nftables
+}


### PR DESCRIPTION
### Summary of Changes

Adds ni-safemode-firewall, a static nftables default-deny firewall for the NILRT safemode initramfs, loaded by a small SysV init script. It uses the nft userspace tool only (no daemon, no Python), so it fits the size-constrained, RAM-resident safemode image (~2 KB package + nftables).

- New recipe recipes-ni/ni-safemode-firewall/ni-safemode-firewall.bb — installs the ruleset + init script, RDEPENDS nftables, registered via update-rc.d at start 39 S.
- files/safemode.nft — inet filter table with input policy drop; permits loopback, established/related, essential ICMP/ICMPv6, DHCP client replies, SSH (22), NI System Web Server (80/443), NI Service Locator (3580), and mDNS (5353, restricted to the link-local multicast groups). Outbound is allowed so client traffic (e.g. opkg) works via connection tracking.
- files/ni-safemode-firewall — SysV init script (start/stop/restart/reload/status).
- Wires ni-safemode-firewall into packagegroup-ni-safemode, scoped to x64 only for now. The ruleset itself is arch agnostic (plain inet filter, no NAT), but arm is deferred until the arm kernel enables nftables and arm safemode is validated.

### Justification

https://dev.azure.com/ni/DevCentral/_workitems/edit/3975675


### Testing

Built for x64 and validated on a cRIO-9045 in an actual safemode boot:

- ni-safemode-firewall, nftables, and nft present in the safemode initramfs; no Python packages pulled.
- Firewall auto-loads at boot (S39) with input policy drop — confirmed across two safemode boots.
- Allowed port (22) reachable; non-allowed port (9999) dropped; SSH never lost (no lockout).
- Reboot-persistence: ruleset auto-loads after reboot.

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] Built the full safemode image (bitbake nilrt-safemode-rootfs, which builds nilrt-safemode-initramfs).


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
