### PR TITLE
bblayer.conf: Add meta-secure-core layers

### DIFF
--- a/conf/templates/default/bblayers.conf.sample
+++ b/conf/templates/default/bblayers.conf.sample
@@ -5,6 +5,10 @@ LCONF_VERSION = "5"
 BBPATH = "${TOPDIR}"
 BBFILES ?= ""
 
+# meta-security and meta-secure-core both provide tpm2 and ima-evm-utils recipes.
+# Prefer the meta-security versions (via layer priority), and avoid bringing in
+# the meta-secure-core variants by not adding meta-secure-core/meta-tpm2 or
+# meta-secure-core/meta-integrity to BBLAYERS.
 BBLAYERS ?= " \
 	${GIT_REPODIR}/meta-cloud-services \
 	${GIT_REPODIR}/meta-cloud-services/meta-openstack \
@@ -26,6 +30,9 @@ BBLAYERS ?= " \
 	${GIT_REPODIR}/meta-sdr \
 	${GIT_REPODIR}/meta-security \
 	${GIT_REPODIR}/meta-security/meta-tpm \
+	${GIT_REPODIR}/meta-secure-core/meta-efi-secure-boot \
+	${GIT_REPODIR}/meta-secure-core/meta-secure-core-common \
+	${GIT_REPODIR}/meta-secure-core/meta-signing-key \
 	${GIT_REPODIR}/meta-selinux \
 	${GIT_REPODIR}/meta-virtualization \
 	${GIT_REPODIR}/openembedded-core/meta \


### PR DESCRIPTION
### Summary of Changes
Enable  `meta-efi-secure-boot`, `meta-secure-core-common` and `meta-signing-key` layers 


### Justification

[AB#3781428](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3781428)

### Testing

* [x] I have built `shim`  (available in `meta-efi-secure-boot`) with this PR in place. (`bitbake shim`)
* [x] I have built `key-store` (available in `meta-signing-key`) with this PR in place. (`bitbake key-store`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
