### PR TITLE
perf: suppress unsupported source probes

### DIFF
--- a/recipes-kernel/perf/perf.bbappend
+++ b/recipes-kernel/perf/perf.bbappend
@@ -3,3 +3,7 @@
 # scripting using python3. Disable `scripting` PACKAGECONFIG in that case, to
 # keep python3 out of the perf config.
 PACKAGECONFIG:remove:xilinx-zynq = "scripting"
+
+# Older xilinx-zynq kernels do not ship the arm64-only perf source fragments
+# listed by the upstream recipe, so avoid probing for them during configure.
+PERF_SRC:remove:xilinx-zynq = "arch/arm64/tools include/uapi/asm-generic/Kbuild"


### PR DESCRIPTION
### Summary of Changes

The upstream perf recipe copies kernel source fragments listed in PERF_SRC during do_configure. 
NILRT's xilinx-zynq kernel does not provide the arm64-only paths arch/arm64/tools and
include/uapi/asm-generic/Kbuild, which causes noisy warnings even though the build succeeds.

Remove those entries for xilinx-zynq so perf configure no longer probes missing kernel-source paths.


### Justification
[AB#3918188](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3918188).

https://dev.azure.com/ni/DevCentral/_build/results?buildId=20975830&view=logs&j=0a193208-2924-5e55-06a9-443a0d06402c&t=cf79e1af-511a-5af7-3dca-9986ee785f38&l=98063

### Testing

- [x] `bitbake packagegroup-ni-desirable`
