### PR TITLE
docker-moby: disable iptables on PREEMPT_RT kernels

### DIFF
--- a/recipes-containers/docker/docker-moby_%.bbappend
+++ b/recipes-containers/docker/docker-moby_%.bbappend
@@ -6,3 +6,14 @@ PV = "${DOCKER_VERSION}+git${SRCREV_moby_short}"
 # Remove cgroup-lite dependency so that docker can work on systems with cgroup v2 paths.
 RDEPENDS:${PN}:remove = "cgroup-lite"
 RDEPENDS:${PN}:append = " ni-cgroups"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://daemon.json"
+
+do_install:append() {
+    install -d ${D}${sysconfdir}/docker
+    install -m 0644 ${WORKDIR}/daemon.json \
+        ${D}${sysconfdir}/docker/daemon.json
+}
+
+CONFFILES:${PN} += "${sysconfdir}/docker/daemon.json"

--- a/recipes-containers/docker/files/daemon.json
+++ b/recipes-containers/docker/files/daemon.json
@@ -1,0 +1,3 @@
+{
+    "iptables": false
+}


### PR DESCRIPTION
[AB#3902287](https://dev.azure.com/ni/DevCentral/_workitems/edit/3902287)

### Summary of Changes

This change installs a Docker daemon configuration file (/etc/docker/daemon.json) with "iptables": false enabled by default. The configuration is packaged through a docker-moby bbappend to ensure it is automatically deployed on target systems.

### Justification

On 6.18 PREEMPT_RT kernels, legacy ip_tables support is unavailable due to upstream kernel configuration changes. As a result, Docker may encounter issues when attempting to use legacy iptables functionality. Configuring Docker with "iptables": false avoids this dependency and allows Docker to operate successfully on affected kernels.

### Testing

Validation was performed on a target running 6.18.36-rt5-next-gb75e8f33877c. Verified that ip_tables is unavailable (modprobe ip_tables fails) and that the installed daemon.json is present on the target. After reboot, Docker started successfully, docker info and docker ps executed successfully, and docker run hello-world completed without errors.

* [ ] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)

### Procedure

Built the updated docker-moby package and verified that /etc/docker/daemon.json was included in the package contents. Deployed and booted a 6.18 NEXT kernel on the target, installed the workaround configuration, rebooted the system, and confirmed Docker functionality using docker info and docker run hello-world. The workaround was validated to function across reboot and normal Docker startup scenarios.

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
