### PR TITLE
ni-firewalld-servicedefs: add port-opening helper for NI services

### DIFF
--- a/recipes-ni/ni-firewalld-servicedefs/files/ni-firewall-open
+++ b/recipes-ni/ni-firewalld-servicedefs/files/ni-firewall-open
@@ -1,0 +1,147 @@
+#!/bin/sh
+# ni-firewall-open / ni-firewall-close
+#
+# Open or close a firewalld service in the default zone. The same script backs
+# both commands; the action is chosen from the name it is invoked as
+# (ni-firewall-close is a symlink to ni-firewall-open).
+#
+# It works in two situations:
+#   * offline - firewalld is not running (e.g. early first boot). Changes are
+#     written with firewall-offline-cmd and take effect when firewalld starts.
+#   * live    - firewalld is running. Changes are applied to the running config
+#     (immediate) and the permanent config (persisted), without a full
+#     'firewall-cmd --reload', so other runtime rules are left undisturbed.
+#
+# Usage: ni-firewall-open  <service> [<service> ...]
+#        ni-firewall-close <service> [<service> ...]
+#
+# Re-running is idempotent. An unknown service name causes a non-zero exit.
+
+set -u
+
+# Strip the directory prefix with shell parameter expansion instead of spawning
+# basename; keeps the helper self-contained in minimal/early-boot environments.
+prog=${0##*/}
+case "$prog" in
+	ni-firewall-open)  action=add;    state=open   ;;
+	ni-firewall-close) action=remove; state=closed ;;
+	*)
+		echo "$prog: must be invoked as ni-firewall-open or ni-firewall-close" >&2
+		exit 2
+		;;
+esac
+
+if [ $# -lt 1 ]; then
+	echo "Usage: $prog <service> [<service> ...]" >&2
+	exit 2
+fi
+
+# Ask firewalld itself which service definitions exist instead of scanning a
+# hard-coded path: XMLs may live under /etc/firewalld/services or the platform
+# ${libdir} (/usr/lib or /usr/lib64), alongside firewalld's own built-ins. The
+# permanent/offline views read straight from disk, so a freshly installed
+# service file is visible without a daemon reload.
+service_exists() {
+	for s in ${available_services:-}; do
+		[ "$s" = "$1" ] && return 0
+	done
+	return 1
+}
+
+# Decide once whether firewalld is running (live) or not (offline).
+#
+# The default zone is a single global setting (DefaultZone in firewalld.conf),
+# not a per-view one: firewalld has no '--permanent --get-default-zone', and
+# --set-default-zone always updates runtime and permanent together. So the
+# runtime default zone reported here is also the permanent default zone, and it
+# is safe to target for the permanent changes below.
+if firewall-cmd --state >/dev/null 2>&1; then
+	live=1
+	zone=$(firewall-cmd --get-default-zone 2>/dev/null)
+	available_services=$(firewall-cmd --permanent --get-services 2>/dev/null) || available_services=
+else
+	live=0
+	zone=$(firewall-offline-cmd --get-default-zone 2>/dev/null)
+	available_services=$(firewall-offline-cmd --get-services 2>/dev/null) || available_services=
+fi
+
+if [ -z "${zone:-}" ]; then
+	echo "$prog: could not determine the default firewalld zone" >&2
+	exit 1
+fi
+
+# firewalld always ships built-in service definitions, so an empty list means the
+# query failed (tool missing, D-Bus error, ...). Fail clearly rather than letting
+# every service fall through and be misreported as "unknown".
+if [ -z "${available_services:-}" ]; then
+	echo "$prog: could not retrieve the list of available firewalld services" >&2
+	exit 1
+fi
+
+# Run a permanent/offline query or change with the right tool for the mode.
+fw_perm() {
+	if [ "$live" = 1 ]; then
+		firewall-cmd --permanent --zone="$zone" "$@"
+	else
+		firewall-offline-cmd --zone="$zone" "$@"
+	fi
+}
+
+rc=0
+for svc in "$@"; do
+	if ! service_exists "$svc"; then
+		echo "$prog: unknown firewalld service '$svc'" >&2
+		rc=1
+		continue
+	fi
+
+	enabled=0
+	fw_perm --query-service="$svc" >/dev/null 2>&1 && enabled=1
+
+	if [ "$action" = add ] && [ "$enabled" = 0 ]; then
+		if ! fw_perm --add-service="$svc" >/dev/null 2>&1; then
+			echo "$prog: failed to open service '$svc' in zone '$zone'" >&2
+			rc=1
+			continue
+		fi
+	elif [ "$action" = remove ] && [ "$enabled" = 1 ]; then
+		if ! fw_perm --remove-service="$svc" >/dev/null 2>&1; then
+			echo "$prog: failed to close service '$svc' in zone '$zone'" >&2
+			rc=1
+			continue
+		fi
+	fi
+
+	# On a live system also reflect the change in the running config so it
+	# takes effect immediately, without a full reload (which would drop other
+	# runtime-only rules). Only touch the running config when it is not already
+	# in the desired state. The permanent config was already updated above, so if
+	# this runtime step fails the running and permanent configs can stay out of
+	# sync until the next firewalld reload/restart; surface that as a non-zero
+	# exit rather than hiding it.
+	if [ "$live" = 1 ]; then
+		runtime_enabled=0
+		firewall-cmd --zone="$zone" --query-service="$svc" >/dev/null 2>&1 &&
+			runtime_enabled=1
+
+		if [ "$action" = add ] && [ "$runtime_enabled" = 0 ]; then
+			if ! firewall-cmd --zone="$zone" --add-service="$svc" >/dev/null 2>&1; then
+				echo "$prog: '$svc' was saved to the permanent config but could not be applied to the running zone '$zone'" >&2
+				rc=1
+				continue
+			fi
+		elif [ "$action" = remove ] && [ "$runtime_enabled" = 1 ]; then
+			if ! firewall-cmd --zone="$zone" --remove-service="$svc" >/dev/null 2>&1; then
+				echo "$prog: '$svc' was removed from the permanent config but could not be removed from the running zone '$zone'" >&2
+				rc=1
+				continue
+			fi
+		fi
+	fi
+
+	# The desired state is now ensured whether or not a change was needed, so
+	# word the message as a state rather than an action.
+	echo "$prog: service '$svc' is $state in zone '$zone'"
+done
+
+exit $rc

--- a/recipes-ni/ni-firewalld-servicedefs/ni-firewalld-servicedefs.bb
+++ b/recipes-ni/ni-firewalld-servicedefs/ni-firewalld-servicedefs.bb
@@ -30,9 +30,16 @@ SRC_URI = "\
 	file://services/ni-visa-server.xml \
 	file://services/ni-xnet-bus-monitor.xml \
 	file://services/opcua.xml \
+	file://ni-firewall-open \
 "
 
 FILES:${PN} += "/"
+
+# Always-on NI services opened by this package on install and closed on removal.
+# http/https are firewalld built-ins for the NI System Web Server (ports 80/443),
+# which hosts Web-Based Configuration and the nisysapi/System Configuration channel
+# used by NI MAX and Hardware Manager; they must stay reachable by default.
+CORE_NI_SERVICES = "ni-service-locator ni-mxs ni-rpc-server ni-logos-xt ni-sync-remote http https"
 
 do_install () {
 	for f in ${SRC_URI}; do
@@ -41,6 +48,27 @@ do_install () {
 			-m 0644 "${UNPACKDIR}/${f##file://}" ;;
 		esac
 	done
+
+	# Shared open/close helper; ni-firewall-close is a symlink to ni-firewall-open.
+	install -D -m 0755 ${UNPACKDIR}/ni-firewall-open ${D}${bindir}/ni-firewall-open
+	ln -sf ni-firewall-open ${D}${bindir}/ni-firewall-close
 }
 
-RDEPENDS:${PN} += "firewalld"
+RDEPENDS:${PN} += "firewalld firewalld-offline-cmd"
+
+# Open the always-on NI services once the package is on the target. Deferred to
+# first boot (never runs against $D) so firewalld's tools operate natively.
+pkg_postinst_ontarget:${PN} () {
+	# Best effort: never let a firewall hiccup block package configuration.
+	ni-firewall-open ${CORE_NI_SERVICES} || true
+}
+
+# Close them again on package removal, leaving no stale rules. Skip during any
+# offline (image-build) removal.
+pkg_prerm:${PN} () {
+	if [ -n "$D" ]; then
+		exit 0
+	fi
+	# Best effort: never let a firewall hiccup block package removal.
+	ni-firewall-close ${CORE_NI_SERVICES} || true
+}


### PR DESCRIPTION
### Summary of Changes
Adds a firewalld port-opening mechanism to `ni-firewalld-servicedefs` so NI services can be opened/closed in the default zone and wires the package to open the always-on core NI services (including the NI System Web Server) automatically.

- **New helper:** `ni-firewall-open` (POSIX sh) with `ni-firewall-close` as a symlink; the action is chosen from the invoked name.
- **Dual-mode:** works **offline** (`firewall-offline-cmd`, during image build) and **live** (`firewall-cmd --permanent` + a matching runtime change, no `--reload`, so other runtime rules are preserved).
- **Idempotent:** re-running is a no-op; an unknown/missing service name exits non-zero.
- **Default-open services** — opened by `pkg_postinst_ontarget`, closed by `pkg_prerm` on removal (guarded against offline `$D` removal): `ni-service-locator, ni-mxs, ni-rpc-server, ni-logos-xt, ni-sync-remote, http, https`. The `http/https` built-ins (ports 80/443) cover the NI System Web Server, which hosts Web-Based Configuration and the nisysapi/System Configuration channel used by NI MAX and Hardware Manager, so it stays reachable with firewalld active (matching legacy firewall behavior). `RDEPENDS` now includes `firewalld-offline-cmd`.

### Testing
- **Build:** `bitbake ni-firewalld-servicedefs` and full `bitbake nilrt-base-system-image` (x64). Verified `/usr/bin/ni-firewall-open` (0755) + `ni-firewall-close` symlink + `firewall-offline-cmd` land in the runmode rootfs; manifest shows `firewalld-offline-cmd` and `ni-firewalld-servicedefs`.
- **On-hardware (cRIO-9045, x64, run mode):**
  - `postinst` opened all core NI services in both runtime and permanent config (`INSTALL_RC=0`).
  - `prerm` closed them on removal with no stale rules; zone returned to baseline (`REMOVE_RC=0`).
  - `firewalld-offline-cmd` pulled automatically via RDEPENDS.
  - Functional suite: open, idempotent re-open, close, idempotent re-close, unknown service → rc 1, no-args → rc 2, multi-service open/close.

- NI System Web Server (http/https) auto-enable after fresh image install:
  - On a freshly flashed runmode image (firewalld active) with no manual firewall config, the default zone lists http and https alongside the core NI services — opened automatically by postinst, no first-login/manual step.
  - External reachability from a separate host with firewalld active: TCP 80 and 443 OPEN (verified together with 22 and 3580/RPC).
  - Persists across reboot (written to firewalld's permanent config, not runtime-only).
  - Removed on package removal via prerm (returns zone to baseline, no stale rules).

### Justification
[AB#3964859](https://dev.azure.com/ni/DevCentral/_workitems/edit/3964859)

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
