### PR TITLE
libpam: Add a patch to allow null passwords

### DIFF
--- a/recipes-extended/pam/libpam/0001-pam_unix_passwd-allow-blank-passwords.patch
+++ b/recipes-extended/pam/libpam/0001-pam_unix_passwd-allow-blank-passwords.patch
@@ -1,0 +1,78 @@
+From b89a989805646c3951afd16394f890bb74300683 Mon Sep 17 00:00:00 2001
+From: Erick Shepherd <erick.shepherd@ni.com>
+Date: Tue, 4 Aug 2026 15:08:18 -0500
+Subject: [PATCH] pam_unix_passwd: Allow empty password to be set
+
+Upstream-Status: Inappropriate [NI specific]
+
+Allow users to set a blank password using linux-pam by no longer
+setting blank passwords to NULL and making their shadow file entry
+blank. This is toggled by the nullok option.
+
+Signed-off-by: Erick Shepherd <erick.shepherd@ni.com>
+---
+ modules/pam_unix/pam_unix.8.xml    |  3 ++-
+ modules/pam_unix/pam_unix_passwd.c | 12 ++++++++++--
+ 2 files changed, 12 insertions(+), 3 deletions(-)
+
+diff --git a/modules/pam_unix/pam_unix.8.xml b/modules/pam_unix/pam_unix.8.xml
+index dfc04274..4e3395cf 100644
+--- a/modules/pam_unix/pam_unix.8.xml
++++ b/modules/pam_unix/pam_unix.8.xml
+@@ -155,7 +155,8 @@
+         <listitem>
+           <para>
+             The default action of this module is to not permit the
+-            user access to a service if their official password is blank.
++            user access to a service if their official password is blank
++            or allow blank passwords to be set during password changes.
+             The <option>nullok</option> argument overrides this default.
+           </para>
+         </listitem>
+diff --git a/modules/pam_unix/pam_unix_passwd.c b/modules/pam_unix/pam_unix_passwd.c
+index c3417413..cda7234f 100644
+--- a/modules/pam_unix/pam_unix_passwd.c
++++ b/modules/pam_unix/pam_unix_passwd.c
+@@ -600,6 +600,7 @@ pam_sm_chauthtok(pam_handle_t *pamh, int flags, int argc, const char **argv)
+ 	int remember = -1;
+ 	int rounds = 0;
+ 	int pass_min_len = 0;
++	int nullok_enabled = 0;
+ 
+ 	/* <DO NOT free() THESE> */
+ 	const char *user;
+@@ -611,6 +612,7 @@ pam_sm_chauthtok(pam_handle_t *pamh, int flags, int argc, const char **argv)
+ 
+ 	ctrl = _set_ctrl(pamh, flags, &remember, &rounds, &pass_min_len,
+ 	                 argc, argv);
++	nullok_enabled = off(UNIX__NONULL, ctrl);
+ 
+ 	/*
+ 	 * First get the name of a user
+@@ -779,7 +781,8 @@ pam_sm_chauthtok(pam_handle_t *pamh, int flags, int argc, const char **argv)
+ 			 * password is acceptable.
+ 			 */
+ 
+-			if (*(const char *)pass_new == '\0') {	/* "\0" password = NULL */
++			/* Convert empty string to NULL unless nullok is set */
++			if (!nullok_enabled && *(const char *)pass_new == '\0') {	/* "\0" password = NULL */
+ 				pass_new = NULL;
+ 			}
+ 			retval = _pam_unix_approve_pass(pamh, ctrl, pass_old,
+@@ -835,7 +838,12 @@ pam_sm_chauthtok(pam_handle_t *pamh, int flags, int argc, const char **argv)
+ 		 * First we encrypt the new password.
+ 		 */
+ 
+-		tpass = create_password_hash(pamh, pass_new, ctrl, rounds);
++		if (pass_new != NULL && *pass_new == '\0') {
++			/* For blank password, store as empty */
++			tpass = strdup("");
++		} else {
++			tpass = create_password_hash(pamh, pass_new, ctrl, rounds);
++		}
+ 		if (tpass == NULL) {
+ 			pam_syslog(pamh, LOG_CRIT,
+ 				"crypt() failure or out of memory for password");
+-- 
+2.51.0
+

--- a/recipes-extended/pam/libpam_1.%.bbappend
+++ b/recipes-extended/pam/libpam_1.%.bbappend
@@ -1,11 +1,13 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
 SRC_URI += "\
+	file://0001-pam_unix_passwd-allow-blank-passwords.patch \
 	file://security/faillock.conf \
 "
 
 do_install:append() {
 	install -m 644 ${WORKDIR}/security/faillock.conf ${D}${sysconfdir}/security/faillock.conf
+	sed -i 's/pam_unix\.so sha512/pam_unix.so sha512 nullok/' ${D}${sysconfdir}/pam.d/common-password
 }
 
 pkg_postinst:pam-plugin-faillock:append() {


### PR DESCRIPTION
### Summary of Changes

Add a patch to linux-pam that allows users to set a blank password when using the passwd command and when updating an expired password. This is done by not setting "\0" passwords to NULL and setting the password hash to be blank for "\0" passwords.

[AB#3962858](https://dev.azure.com/ni/DevCentral/_workitems/edit/3962858)

### Justification

This change will help our internal teams and customers adapt to the Set on First Use strategy of shipping with expired passwords by allowing them to set the new password to be blank.


### Testing
- On a machine with ni-auth removed:
  - Ran "passwd root" and set the password to be non-blank
    - Confirmed that the usual password change workflow still works
    - Was able to log in with the new non-blank password
  - Ran "passwd root" and set the password to be blank
    - Confirmed that the root entry in /etc/shadow had an empty password
    - Was able to connect via SSH with a blank password
  -  Ran "password -e root" to set the password to expired
     - Was able to set the password to blank when making a new password on the next SSH connection
     - Confirmed that the root entry in /etc/shadow had an empty password
     - Started a new SSH session using the blank password

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
