### PR TITLE
nilrt-safemode: Update recipes to enable secure-boot

### DIFF
--- a/recipes-core/images/nilrt-safemode-initramfs-efi-secure-boot.inc
+++ b/recipes-core/images/nilrt-safemode-initramfs-efi-secure-boot.inc
@@ -1,0 +1,30 @@
+DEPENDS += "openssl-native"
+
+inherit user-key-store
+
+fakeroot python do_sign_secure_boot() {
+    import os
+
+    if d.getVar('UEFI_SB') != '1':
+        return
+
+    deploy_dir = d.getVar('DEPLOY_DIR_IMAGE')
+    image_link = d.getVar('IMAGE_LINK_NAME')
+
+    for image_fstype in d.getVar('IMAGE_FSTYPES').split():
+        artifact = os.path.join(deploy_dir, image_link + '.' + image_fstype)
+        if os.path.exists(artifact):
+            uks_bl_sign(artifact, d)
+}
+
+addtask sign_secure_boot after do_image_complete before do_build
+
+do_sign_secure_boot[prefuncs] += "check_deploy_keys"
+do_sign_secure_boot[prefuncs] += "${@'check_boot_public_key' if d.getVar('GRUB_SIGN_VERIFY') == '1' else ''}"
+do_sign_secure_boot[depends] += " \
+    openssl-native:do_populate_sysroot \
+    sbsigntool-native:do_populate_sysroot \
+    libsign-native:do_populate_sysroot \
+    efitools-native:do_populate_sysroot \
+    gnupg-native:do_populate_sysroot \
+"

--- a/recipes-core/images/nilrt-safemode-initramfs.bbappend
+++ b/recipes-core/images/nilrt-safemode-initramfs.bbappend
@@ -1,0 +1,1 @@
+require ${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', 'nilrt-safemode-initramfs-efi-secure-boot.inc', '', d)}

--- a/recipes-core/images/nilrt-safemode-rootfs.bb
+++ b/recipes-core/images/nilrt-safemode-rootfs.bb
@@ -7,6 +7,8 @@ IMAGE_NAME_SUFFIX = ""
 
 DEPENDS += "${PREFERRED_PROVIDER_virtual/kernel}"
 
+SECURE_BOOT_ENABLED = "${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', '1', '0', d)}"
+
 PV = "${DISTRO_VERSION}"
 
 SRC_URI += "\
@@ -25,9 +27,18 @@ IMAGE_INSTALL:append:x64 = "\
 
 RAMDISK_IMAGE = "nilrt-safemode-initramfs"
 do_rootfs[depends] += "${RAMDISK_IMAGE}:do_image_complete"
+do_rootfs[depends] += "${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', ' ${RAMDISK_IMAGE}:do_sign_secure_boot', '', d)}"
 
 bootimg_fixup() {
+	install -d "${IMAGE_ROOTFS}/boot"
+
 	install -m 0644 "${DEPLOY_DIR_IMAGE}/${RAMDISK_IMAGE}-${MACHINE}.cpio.xz" "${IMAGE_ROOTFS}/boot/ramdisk.xz"
+
+	if [ "${SECURE_BOOT_ENABLED}" = "1" ] && [ -n "${SB_FILE_EXT}" ]; then
+		if [ -f "${DEPLOY_DIR_IMAGE}/${RAMDISK_IMAGE}-${MACHINE}.cpio.xz${SB_FILE_EXT}" ]; then
+			install -m 0644 "${DEPLOY_DIR_IMAGE}/${RAMDISK_IMAGE}-${MACHINE}.cpio.xz${SB_FILE_EXT}" "${IMAGE_ROOTFS}/boot/ramdisk.xz${SB_FILE_EXT}"
+		fi
+	fi
 
 	install -m 0755 "${THISDIR}/files/${BPN}.preinst" "${IMAGE_ROOTFS}/boot/preinst"
 
@@ -46,6 +57,24 @@ bootimg_fixup() {
 	mv "$(realpath ${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/bzImage)" "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/bzImage.real"
 	rm -f "${IMAGE_ROOTFS}/boot/bzImage"
 	mv "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/bzImage.real" "${IMAGE_ROOTFS}/boot/bzImage"
+	if [ "${SECURE_BOOT_ENABLED}" = "1" ] && [ -n "${SB_FILE_EXT}" ]; then
+		if [ -e "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/bzImage${SB_FILE_EXT}" ]; then
+			kernel_sig_src="${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/bzImage${SB_FILE_EXT}"
+			if [ -L "${kernel_sig_src}" ]; then
+				# Preserve signature contents rather than a potentially dangling symlink.
+				install -m 0644 "$(realpath "${kernel_sig_src}")" "${IMAGE_ROOTFS}/boot/bzImage${SB_FILE_EXT}"
+			else
+				mv "${kernel_sig_src}" "${IMAGE_ROOTFS}/boot/bzImage${SB_FILE_EXT}"
+			fi
+		else
+			# Some package managers may not preserve the stable signature symlink.
+			# Fall back to a versioned kernel sidecar and normalize its final name.
+			versioned_sig="$(ls -1 "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/bzImage-"*"${SB_FILE_EXT}" 2>/dev/null | sort | tail -n 1)"
+			if [ -n "${versioned_sig}" ] && [ -e "${versioned_sig}" ]; then
+				install -m 0644 "${versioned_sig}" "${IMAGE_ROOTFS}/boot/bzImage${SB_FILE_EXT}"
+			fi
+		fi
+	fi
 	rm -rf "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}"
 
 	install -m 0644 "${THISDIR}/files/bootimage.ini" "${IMAGE_ROOTFS}/boot/bootimage.ini"
@@ -85,6 +114,20 @@ ensure_expected_files() {
 	done
 }
 
-IMAGE_PREPROCESS_COMMAND += " bootimg_fixup; ensure_expected_files; "
+ensure_secure_boot_files() {
+	if [ "${SECURE_BOOT_ENABLED}" != "1" ] || [ -z "${SB_FILE_EXT}" ]; then
+		return
+	fi
+
+	for f in "bzImage${SB_FILE_EXT}" "ramdisk.xz${SB_FILE_EXT}"; do
+		if [ -e "${IMAGE_ROOTFS}/boot/${f}" ] || [ -e "${IMAGE_ROOTFS}/${f}" ]; then
+			continue
+		fi
+
+		bbfatal "${f} is required in secure-boot safemode image. Checked ${IMAGE_ROOTFS}/boot/${f} and ${IMAGE_ROOTFS}/${f}."
+	done
+}
+
+IMAGE_PREPROCESS_COMMAND += " bootimg_fixup; ensure_expected_files; ensure_secure_boot_files; "
 
 inherit image

--- a/recipes-kernel/linux/linux-nilrt-efi-secure-boot.inc
+++ b/recipes-kernel/linux/linux-nilrt-efi-secure-boot.inc
@@ -1,0 +1,109 @@
+DEPENDS += "openssl-native"
+
+inherit user-key-store
+
+fakeroot python do_sign() {
+    import glob
+    import os
+    import re
+    import shutil
+
+    if (d.expand('${TARGET_ARCH}') != 'x86_64') and (not re.match('i.86', d.expand('${TARGET_ARCH}'))):
+        return
+
+    if d.expand('${UEFI_SB}') != '1':
+        return
+
+    kdest = d.expand('${D}/${KERNEL_IMAGEDEST}')
+    sig_ext = d.expand('${SB_FILE_EXT}')
+
+    if not sig_ext:
+        bb.warn('SB_FILE_EXT is empty; skipping kernel secure-boot sidecar handling to avoid unsafe file operations.')
+        return
+
+    # Clean up stale artifacts produced by previous buggy runs so they
+    # do not leak into packaging QA as installed-but-not-shipped files.
+    for stale in glob.glob(os.path.join(kdest, '*' + sig_ext + sig_ext)):
+        try:
+            os.unlink(stale)
+        except FileNotFoundError:
+            pass
+
+    for image_type in d.expand('${KERNEL_IMAGETYPES}').split():
+        image_path = os.path.join(kdest, image_type)
+
+        if os.path.exists(image_path):
+            resolved_image = os.path.realpath(image_path)
+        else:
+            # NILRT kernels may be staged only as versioned files
+            # (for example bzImage-<version>) before a stable symlink exists.
+            # Fall back to that versioned file and still create image sidecars.
+            candidates = sorted(
+                c for c in glob.glob(os.path.join(kdest, image_type + '-*'))
+                if not c.endswith(sig_ext)
+            )
+            if not candidates:
+                continue
+            resolved_image = candidates[-1]
+
+        # Keep an unsigned copy for manual verification/debugging.
+        shutil.copyfile(resolved_image, os.path.join(d.expand('${B}'), image_type + '.unsigned'))
+
+        if d.expand('${GRUB_SIGN_VERIFY}') == '1':
+            sb_sign(resolved_image, resolved_image, d)
+
+        # SELoader signature is always based on the unsigned kernel image,
+        # disallowing chainloader to kernel efi-stub.
+        uks_bl_sign(resolved_image, d)
+
+        resolved_sig = resolved_image + sig_ext
+        image_sig = image_path + sig_ext
+
+        if os.path.exists(resolved_sig):
+            versioned_sig = os.path.join(kdest, image_type + '-' + d.expand('${KERNEL_RELEASE}') + sig_ext)
+
+            # If signing already emitted the signature with the expected
+            # versioned filename, avoid copying a file onto itself.
+            if os.path.abspath(resolved_sig) != os.path.abspath(versioned_sig):
+                shutil.copyfile(resolved_sig, versioned_sig)
+
+            if os.path.lexists(image_sig):
+                os.unlink(image_sig)
+            os.symlink(os.path.basename(versioned_sig), image_sig)
+}
+
+# Make sure the kernel image has been signed before kernel_do_deploy()
+# which prepares kernel artifacts consumed by provisioning flows.
+addtask sign after do_install before do_package do_populate_sysroot do_deploy
+
+do_sign[prefuncs] += "check_deploy_keys"
+do_sign[prefuncs] += "${@'check_boot_public_key' if d.getVar('GRUB_SIGN_VERIFY') == '1' else ''}"
+
+do_deploy:append() {
+    install -d "${DEPLOYDIR}/efi-unsigned"
+
+    for imageType in ${KERNEL_IMAGETYPES}; do
+        if [ -f "${B}/${imageType}.unsigned" ]; then
+            install -m 0644 "${B}/${imageType}.unsigned" "${DEPLOYDIR}/efi-unsigned/${imageType}"
+        fi
+
+        if [ -n "${SB_FILE_EXT}" ] && [ -f "${D}/${KERNEL_IMAGEDEST}/${imageType}${SB_FILE_EXT}" ]; then
+            install -m 0644 "${D}/${KERNEL_IMAGEDEST}/${imageType}${SB_FILE_EXT}" "${DEPLOYDIR}"
+        fi
+    done
+}
+
+# Ship *.p7b or *.sig files in the kernel image package.
+python do_package:prepend() {
+    sig_ext = d.expand('${SB_FILE_EXT}')
+    if not sig_ext:
+        bb.warn('SB_FILE_EXT is empty; skipping kernel-image sidecar FILES entries.')
+        return
+
+    for image_type in d.expand('${KERNEL_IMAGETYPES}').split():
+        image_lower = image_type.lower()
+        d.appendVar('FILES:kernel-image-' + image_lower,
+                    ' /' + d.expand('${KERNEL_IMAGEDEST}/') + image_type + d.expand('-${KERNEL_RELEASE}${SB_FILE_EXT}'))
+        d.appendVar('FILES:kernel-image-' + image_lower,
+                    ' /' + d.expand('${KERNEL_IMAGEDEST}/') + image_type + d.expand('${SB_FILE_EXT}'))
+}

--- a/recipes-kernel/linux/linux-nilrt_%.bbappend
+++ b/recipes-kernel/linux/linux-nilrt_%.bbappend
@@ -1,0 +1,1 @@
+require ${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', 'linux-nilrt-efi-secure-boot.inc', '', d)}


### PR DESCRIPTION
### Summary of Changes

Implementing secure-boot signing of bzImage and ramdisk in nilrt-safemode-rootfs


### Justification

[AB#3781428](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3781428)


### Testing

* [X] I have built the nilrt-safemode-rootfs recipe with this PR in place and `efi-secure-boot` enabled in DISTRO_FEATURES
   * [X] I have verified the contents of nilrt-safemode-rootfs have been signed
* [X] I have built the nilrt-safemode-rootfs recipe with this PR in place
   * [X] Deployed the nilrt-safemode-rootfs onto x64 target


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
