### PR TITLE
nilrt-safemode: Update recipes to enable secure-boot

### DIFF
--- a/recipes-bsp/grub/grub-efi-nilrt-secure-boot.inc
+++ b/recipes-bsp/grub/grub-efi-nilrt-secure-boot.inc
@@ -1,0 +1,17 @@
+# Secure-boot handling for the NI-prefixed GRUB image installed under
+# ${NILRT_EFI_DIR}. meta-efi-secure-boot only signs the image it installs to
+# ${EFI_BOOT_PATH}, so the NI variant has to be signed here with the same key.
+
+inherit user-key-store
+
+NILRT_EFI_DIR = "/boot/efi/nilrt"
+
+python do_sign:append:class-target() {
+    if d.getVar('UEFI_SB') != '1':
+        return
+
+    nilrt_dir = d.getVar('D') + d.getVar('NILRT_EFI_DIR') + '/'
+    grub_image = nilrt_dir + d.getVar('GRUB_IMAGE')
+
+    sb_sign(grub_image, grub_image, d)
+}

--- a/recipes-bsp/grub/grub-efi_2.%.bbappend
+++ b/recipes-bsp/grub/grub-efi_2.%.bbappend
@@ -1,4 +1,11 @@
 require grub-nilrt.inc
+require ${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', 'grub-efi-nilrt-secure-boot.inc', '', d)}
+
+# UEFI_SELOADER is set by the meta-signing-key layer.conf whether or not
+# efi-secure-boot is enabled, so the mok2verify patches are only actually in
+# SRC_URI when both conditions hold.
+GRUB_NILRT_MOK2VERIFY = "${@'1' if bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', True, False, d) and d.getVar('UEFI_SELOADER') == '1' else '0'}"
+GRUB_NILRT_ADVERTISE_PATCH = "${@'file://grub-advertise-NI-NILRT-over-GNU-GRUB-mok2verify.patch' if d.getVar('GRUB_NILRT_MOK2VERIFY') == '1' else 'file://grub-advertise-NI-NILRT-over-GNU-GRUB.patch'}"
 
 GRUB_BUILDIN:append = " \
     ata \
@@ -41,6 +48,8 @@ do_install:append:class-target() {
     # the default \EFI\BOOT. We keep the upstream grub image
     # unchanged so that we may use it with USB provisioning tool
     # and other removable storage.
+    # GRUB_SECURE_BUILDIN is empty unless efi-secure-boot is enabled; it carries
+    # mok2verify/efivar and the SBAT section the signed chain requires.
     (
         cd "${B}"
         grub-mkimage \
@@ -48,7 +57,7 @@ do_install:append:class-target() {
             --directory=./grub-core/ \
             --format=${GRUB_TARGET}-efi \
             --output=./${GRUB_IMAGE_PREFIX}nilrt-${GRUB_IMAGE} \
-            ${GRUB_BUILDIN}
+            ${GRUB_BUILDIN} ${GRUB_SECURE_BUILDIN}
     )
 
     # Install NILRT grub image

--- a/recipes-bsp/grub/grub-nilrt.inc
+++ b/recipes-bsp/grub/grub-nilrt.inc
@@ -1,13 +1,19 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/grub:"
 
+# The meta-efi-secure-boot mok2verify patches rewrite the same GRUB banner and
+# menu message sites, so a variant of the NI branding patch is needed there. It
+# is added via :append so that it is always applied after the secure-boot ones.
+GRUB_NILRT_ADVERTISE_PATCH ?= "file://grub-advertise-NI-NILRT-over-GNU-GRUB.patch"
+
 SRC_URI += "\
-	file://cmd-test-Add-bitwise-AND-document-the-feature.patch \
-	file://grub-advertise-NI-NILRT-over-GNU-GRUB.patch \
-	file://add-inbit-command-to-io-module.patch \
-	file://grub.cfg \
-	file://cfg \
-	file://grub.d \
+        file://cmd-test-Add-bitwise-AND-document-the-feature.patch \
+        file://add-inbit-command-to-io-module.patch \
+        file://grub.cfg \
+        file://cfg \
+        file://grub.d \
 "
+
+SRC_URI:append = " ${GRUB_NILRT_ADVERTISE_PATCH}"
 
 # Grub always try to force soft float in recent grub versions, even on x64, and this
 # conflicts with how the x64 OE toolchain is set up. The only solution is to cache

--- a/recipes-bsp/grub/grub/grub-advertise-NI-NILRT-over-GNU-GRUB-mok2verify.patch
+++ b/recipes-bsp/grub/grub/grub-advertise-NI-NILRT-over-GNU-GRUB-mok2verify.patch
@@ -1,0 +1,64 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ioan-Adrian Ratiu <adrian.ratiu@ni.com>
+Date: Thu, 15 Dec 2016 14:04:40 +0200
+Subject: [PATCH] grub: advertise NI NILRT over GNU GRUB
+
+Also don't prompt the more advanced commands to the user, even though
+they can be entered anyway. Presumably advanced users already know about
+them and can use them without being told and this discourages behaviour
+like "uu what does this button do?" from unknowledgeable users.
+
+This is the variant applied on top of the meta-efi-secure-boot
+mok2verify patch set, which rewrites the same message sites.
+
+Upstream-Status: Inappropriate [NI specific]
+
+Signed-off-by: Ioan-Adrian Ratiu <adrian.ratiu@ni.com>
+---
+--- a/grub-core/normal/main.c
++++ b/grub-core/normal/main.c
+@@ -208,7 +208,7 @@
+ {
+   grub_ssize_t msg_len;
+   int posx;
+-  const char *msg = _("GNU GRUB  version %s");
++  const char *msg = _("NI Linux Real-Time Boot Options");
+   char *msg_formatted;
+   grub_uint32_t *unicode_msg;
+   grub_uint32_t *last_position;
+@@ -219,9 +219,9 @@
+   if (grub_is_secured () == 1)
+     {
+       if (grub_is_unlockable () == 1)
+-        msg = _("GNU GRUB  version %s (UNLOCKABLE)");
++        msg = _("NI Linux Real-Time Boot Options (UNLOCKABLE)");
+       else
+-        msg = _("GNU GRUB  version %s (LOCKED)");
++        msg = _("NI Linux Real-Time Boot Options (LOCKED)");
+     }
+ #endif
+ 
+--- a/grub-core/normal/menu_text.c
++++ b/grub-core/normal/menu_text.c
+@@ -190,9 +190,7 @@
+ 		    "ESC to return previous menu.");
+ 	  else
+ #endif
+-	    msg = _("Press enter to boot the selected OS, "
+-		    "`e' to edit the commands before booting "
+-		    "or `c' for a command-line. ESC to return previous menu.");
++	    msg = _("Press enter to boot the selected OS. ");
+ 
+ 	  ret += grub_print_message_indented_real
+ 	    (msg, STANDARD_MARGIN, STANDARD_MARGIN, term, dry_run);
+@@ -204,9 +202,7 @@
+ 	    msg = _("Press enter to boot the selected OS.");
+ 	  else
+ #endif
+-	    msg = _("Press enter to boot the selected OS, "
+-		    "`e' to edit the commands before booting "
+-		    "or `c' for a command-line.");
++	    msg = _("Press enter to boot the selected OS. ");
+ 
+ 	  ret += grub_print_message_indented_real
+ 	    (msg, STANDARD_MARGIN, STANDARD_MARGIN, term, dry_run);

--- a/recipes-bsp/grub/grub/grub-safemode-secure-boot.cfg
+++ b/recipes-bsp/grub/grub/grub-safemode-secure-boot.cfg
@@ -1,0 +1,274 @@
+# NI Linux RT grub boot configuration script
+
+# default env
+set default=0
+set BOOT_MODE=recovery
+set root='(hd0,gpt2)' // Emergency fallback if searching fails
+set CPLD_PROC_MODE_OFFSET=530 //Offset 0x0212
+set CPLD_MODE_SAFE=0
+set CPLD_MODE_RECOVERY=3
+set CPLD_CONSOLE_OUT=2
+set CPLD_TEST_OFFSET=512 //Offset 0x0200
+set CPLD_STATUS_HIGH=545 //Offset 0x0221
+set CPLD_STATUS_LOW=546 //Offset 0x0222
+set RECOVERY_STATUS=0xAA
+set SMBIOS_NILRT_TTYPE=160 // per NI SMBIOS spec 0.4x
+set SMBIOS_NILRT_BMREG=6 // per NI SMBIOS spec 0.4x
+set SMBIOS_NILRT_BMREG_SAFEMODE=0x02 // per NI SMBIOS spec 0.4x
+set SMBIOS_SYSTEM_TTYPE=1
+set SMBIOS_SYSTEM_VENDOR=4
+set GRUB_SERIAL_CONSOLE=serial
+set GRUB_SERIAL_SPEED=115200
+set GRUB_SERIAL_BASE_CLOCK=1843200
+set force_safemode=0;
+set force_recovery=0;
+set safemode_files="bzImage ramdisk.gz bootimage.ini bootimage.cfg"
+set runmode_files="bzImage bootimage.ini bootimage.cfg"
+set valid_runmode=1
+set valid_safemode=1
+set fail_state=0
+set runmode_menu='Runmode'
+set safemode_menu='Safemode'
+set runmode_action=boot_runmode
+set safemode_action=boot_safemode
+set consoleoutenable=False
+set safemodeenabled=False
+set cpld_consoleoutenable=0
+set serial_port=0
+set kernellogparam=quiet
+set video_term=console
+set sys_reset=false
+set system_manufacturer=""
+set smbios_bootmode=0
+set smbios_tablelen=0
+set measure_on=true
+
+# Set the root variable to NI's bootfs partition
+search --set root --label nibootfs
+
+function load_vars {
+	if [ -f $grubenv_file ];then
+		load_env -f $grubenv_file
+
+		if [ $? -ne 0 ]; then
+			load_env -f $grubenv_file_bak
+		fi
+
+		# Setting bootdelay in grubenv draws grub menu and enables
+		# kernel debug messages. Overrides quietbootdelay.
+		if [ ! -z $bootdelay ]; then
+			set quietbootdelay=$bootdelay
+			set kernellogparam=debug ignore_runlevel
+		fi
+
+		# Setting quietbootdelay in grubenv only draws grub menu,
+		# does not change kernel cmdline.
+		if [ ! -z $quietbootdelay ]; then
+			set timeout=$quietbootdelay
+		fi
+	else
+		load_env -f $grubenv_file_bak
+		set sys_reset=true
+	fi
+}
+
+function read_processor_mode {
+	inb $CPLD_TEST_OFFSET -v cpld_test
+	if [ $cpld_test = e5 ]; then
+		inbit $CPLD_PROC_MODE_OFFSET $CPLD_MODE_RECOVERY -v force_recovery
+		inbit $CPLD_PROC_MODE_OFFSET $CPLD_MODE_SAFE -v force_safemode
+		inbit $CPLD_PROC_MODE_OFFSET $CPLD_CONSOLE_OUT -v cpld_consoleoutenable
+	else
+# Also check for newer, no-CPLD NI targets
+# Insert the smbios module here to prevent issues with older grub builds
+		insmod smbios
+		smbios -t $SMBIOS_SYSTEM_TTYPE -s $SMBIOS_SYSTEM_VENDOR --set system_manufacturer
+		if [ "$system_manufacturer" == "National Instruments" ]; then
+			smbios -t $SMBIOS_NILRT_TTYPE -b 1 --set smbios_tablelen
+			if [ $smbios_tablelen -gt $SMBIOS_NILRT_BMREG ]; then
+				smbios -t $SMBIOS_NILRT_TTYPE -b $SMBIOS_NILRT_BMREG --set smbios_bootmode
+				if [ $smbios_bootmode -bwa $SMBIOS_NILRT_BMREG_SAFEMODE ]; then
+					force_safemode=1
+				fi
+			fi
+		fi
+	fi
+	if [ $force_recovery = 1 ]; then
+		set sys_reset=true
+	fi
+}
+
+function setconsoleparam {
+	if [ $consoleoutenable = False ] -a [ $cpld_consoleoutenable = 0 ]; then
+		set consoleparam="console= "
+	fi
+}
+
+function setusbgadgetparam {
+	if [ -z $usbgadgetethaddr ]; then
+		unset usb_gadget_args
+	fi
+}
+
+function setterminal {
+	if [ ! $consoleoutenable = False ] -o [ $cpld_consoleoutenable = 1 ]; then
+		if [ $serial_port -ne 0 ]; then
+			serial --port=$serial_port --speed=$GRUB_SERIAL_SPEED --base-clock=$GRUB_SERIAL_BASE_CLOCK
+			set serial_term=$GRUB_SERIAL_CONSOLE
+		fi
+	fi
+
+	terminal_output $video_term $serial_term
+
+	if [ ! -z $serial_term ]; then
+		terminal_input console $serial_term
+	fi
+}
+
+function check_valid_os {
+	#safemode
+	for file in $safemode_files
+	do
+		if [ ! -f /.safe/$file ]; then
+			set valid_safemode=0
+			break
+		fi
+	done
+
+	#runmode
+	for file in $runmode_files
+	do
+		if [ ! -f /runmode/$file ]; then
+			set valid_runmode=0
+			break
+		fi
+	done
+
+	if [ $valid_safemode = 0 -a $valid_runmode = 0 ]; then
+		set fail_state=1
+	fi
+
+}
+
+function boot_runmode {
+	source /runmode/bootimage.cfg
+
+	for cfg_d_file in /runmode/bootimage.cfg.d/*.cfg; do
+		if [ -f "$cfg_d_file" ]; then
+			source "$cfg_d_file"
+		fi
+	done
+
+	setconsoleparam
+	setusbgadgetparam
+
+	linux $kernel_path root=LABEL=nirootfs $otherbootargs $usb_gadget_args $kernellogparam $consoleparam $othbootargs sys_reset=$sys_reset
+}
+
+function boot_safemode {
+	source /.safe/bootimage.cfg
+
+	for cfg_d_file in /.safe/bootimage.cfg.d/*.cfg; do
+		if [ -f "$cfg_d_file" ]; then
+			source "$cfg_d_file"
+		fi
+	done
+
+	setconsoleparam
+	setusbgadgetparam
+
+	linux $kernel_path $rootfs_path $otherbootargs $usb_gadget_args $kernellogparam $consoleparam $othbootargs sys_reset=$sys_reset
+	initrd $ramdisk_path
+}
+
+function attempt_USB_recovery {
+	search --set=root --label NIRECOVERY --hint hd0,msdos1
+
+	if [ -f /efi/boot/bootx64.efi ]; then
+		chainloader /efi/boot/bootx64.efi
+		boot
+	fi
+}
+
+function set_menu_and_default {
+	if [ $BOOT_MODE = safemode -o $safemodeenabled = True -o $force_safemode = 1 ] ; then
+		set default=1
+	fi
+
+	if [ $valid_runmode = 0 ]; then
+		set default=1
+		set runmode_menu="Runmode not installed"
+		set runmode_action=boot_safemode
+	elif [ $valid_safemode = 0 ]; then
+		set default=0
+		set safemode_menu="Safemode missing"
+		set timeout=10
+		set safemode_action=boot_runmode
+	fi
+}
+
+function normal_boot {
+	set_menu_and_default
+	if [ -z $timeout ]; then
+		if [ $default = 1 ]; then
+			$safemode_action
+		else
+			$runmode_action
+		fi
+		boot
+	else
+		menuentry "$runmode_menu" {
+			$runmode_action
+		}
+
+		menuentry "$safemode_menu" {
+			$safemode_action
+		}
+	fi
+}
+
+insmod regexp
+insmod iorw
+insmod loadenv
+
+search --set=envpath --label nibootfs
+set grubenv_file=($envpath)/grub/grubenv
+set grubenv_file_bak=($envpath)/grub/grubenv.bak
+
+search --set=grubpath --label nigrub
+search --set=rootfs --label nirootfs
+
+if [ $grub_platform = efi ] ; then
+	insmod efi_gop
+	insmod efi_uga
+	insmod font
+	set gfxpayload=keep
+else
+	insmod vbe
+	insmod vga
+	set gfxpayload=text
+fi
+
+# Load grubenv file, including the provisioning-selected boot mode.
+load_vars
+
+read_processor_mode
+setterminal
+check_valid_os
+if [ $fail_state = 0 ]; then
+	if [ $force_recovery = 1 ]; then
+		attempt_USB_recovery
+	fi
+	normal_boot
+else
+	#set led status recovery blink
+	outb $CPLD_STATUS_HIGH $RECOVERY_STATUS
+	outb $CPLD_STATUS_LOW $RECOVERY_STATUS
+
+	set timeout=10
+
+	attempt_USB_recovery
+	menuentry 'No valid OS. Insert NI Recovery key and reboot' {
+		reboot
+	}
+fi

--- a/recipes-bsp/grub/nilrt-grub-safemode-secure-boot.inc
+++ b/recipes-bsp/grub/nilrt-grub-safemode-secure-boot.inc
@@ -1,0 +1,23 @@
+# SELoader verifies every config grub loads, so the safemode configs need
+# detached signatures alongside them on the ESP and bootfs partitions.
+
+inherit user-key-store
+
+SAFEMODE_SIGNED_CFGS = "/boot/grub.cfg /boot/bootimage.cfg"
+
+fakeroot python do_sign() {
+    if d.getVar('UEFI_SB') != '1':
+        return
+
+    image_dir = d.getVar('D')
+
+    for cfg in d.getVar('SAFEMODE_SIGNED_CFGS').split():
+        uks_bl_sign(image_dir + cfg, d)
+}
+do_sign[prefuncs] += "check_deploy_keys"
+addtask sign after do_install before do_package
+
+FILES:${PN} += " \
+    /boot/bootimage.cfg${SB_FILE_EXT} \
+    /boot/grub.cfg${SB_FILE_EXT} \
+"

--- a/recipes-bsp/grub/nilrt-grub-safemode.bb
+++ b/recipes-bsp/grub/nilrt-grub-safemode.bb
@@ -6,6 +6,8 @@ SECTION = "base"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/grub:"
 
+require ${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', 'nilrt-grub-safemode-secure-boot.inc', '', d)}
+
 SRC_URI += " \
     file://grubenv \
     file://grub-safemode.cfg \

--- a/recipes-bsp/grub/nilrt-grub-safemode.bb
+++ b/recipes-bsp/grub/nilrt-grub-safemode.bb
@@ -8,9 +8,11 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/grub:"
 
 require ${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', 'nilrt-grub-safemode-secure-boot.inc', '', d)}
 
+SAFEMODE_GRUB_CFG = "${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', 'grub-safemode-secure-boot.cfg', 'grub-safemode.cfg', d)}"
+
 SRC_URI += " \
     file://grubenv \
-    file://grub-safemode.cfg \
+    file://${SAFEMODE_GRUB_CFG} \
     file://grub-safemode-bootimage.cfg \
 "
 
@@ -29,6 +31,6 @@ CONFFILES:${PN} += " \
 do_install () {
 	install -d ${D}/boot
 	install -m 0644 ${WORKDIR}/grub-safemode-bootimage.cfg ${D}/boot/bootimage.cfg
-	install -m 0644 ${WORKDIR}/grub-safemode.cfg ${D}/boot/grub.cfg
+    install -m 0644 ${WORKDIR}/${SAFEMODE_GRUB_CFG} ${D}/boot/grub.cfg
 	install -m 0644 ${WORKDIR}/grubenv ${D}/boot/grubenv
 }

--- a/recipes-core/images/files/nilrt-base-system-image.postinst
+++ b/recipes-core/images/files/nilrt-base-system-image.postinst
@@ -77,11 +77,22 @@ if [ "$arch" = "armv7l" ]; then
 	rmdir "$mount_point/runmode" 2>/dev/null || true
 elif [ "$arch" = "x86_64" ]; then
 	kernel="/mnt/userfs/boot/tmp/runmode"
+	kernel_sig_ext=""
+	for ext in .p7b .sig; do
+		if [ -e "${kernel}/bzImage${ext}" ]; then
+			kernel_sig_ext="${ext}"
+			break
+		fi
+	done
 	# install the kernel
 	rm -rf /boot/runmode
 	if mv "$kernel" "$mount_point"; then
 		# Remove the tmp path from the rootfs
 		rmdir "`dirname "$kernel"`"
+		if [ -n "${kernel_sig_ext}" ] && [ ! -e "${mount_point}/runmode/bzImage${kernel_sig_ext}" ]; then
+			echo "ERROR: runmode kernel signature sidecar was not preserved." 1>&2
+			exit 1
+		fi
 	else
 		exit 1
 	fi

--- a/recipes-core/images/nilrt-base-system-image.bb
+++ b/recipes-core/images/nilrt-base-system-image.bb
@@ -12,6 +12,8 @@ SRC_URI += " \
 
 PV = "${DISTRO_VERSION}"
 
+SECURE_BOOT_ENABLED = "${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', '1', '0', d)}"
+
 CDFGUID:x64 = "4C0005F7-54D1-492B-A7E7-C1E58BD9B972"
 CDFGUID:xilinx-zynq = "8E3EACD0-B36E-462B-A500-88AE644AB3B0"
 
@@ -37,6 +39,26 @@ bootimg_fixup() {
 		-delete
 }
 
+ensure_secure_boot_payload() {
+	if [ "${SECURE_BOOT_ENABLED}" != "1" ] || [ "${TARGET_ARCH}" != "x86_64" ]; then
+		return
+	fi
+
+	if [ -z "${SB_FILE_EXT}" ]; then
+		echo "ERROR: SB_FILE_EXT is not set while secure boot is enabled." 1>&2
+		exit 1
+	fi
+
+	payload="${IMAGE_ROOTFS}/data.${NILRT_BSI_FSTYPE}"
+	required_file="boot/tmp/runmode/bzImage${SB_FILE_EXT}"
+
+	if ! tar -tf "${payload}" | grep -Fxq "${required_file}" && \
+	   ! tar -tf "${payload}" | grep -Fxq "./${required_file}"; then
+		echo "ERROR: ${required_file} is required in secure-boot base-system-image payload." 1>&2
+		exit 1
+	fi
+}
+
 create_cdf() {
 	CDFOUT="${DEPLOY_DIR_IMAGE}/${IMAGE_BASENAME}-${MACHINE}${IMAGE_NAME_SUFFIX}.cdf"
 	install -m 0644 "${THISDIR}/files/${BPN}.cdf" $CDFOUT
@@ -48,7 +70,7 @@ create_cdf() {
 	sed -i "s/%guid%/$GUID/g; s/%version%/$SHORTVER/g; s/%osvalue%/${OSVALUE}/g; s/%osversion%/${OSVERSION}/g; s/%filename%/$TARFILE/g;" $CDFOUT
 }
 
-IMAGE_PREPROCESS_COMMAND += "bootimg_fixup;"
+IMAGE_PREPROCESS_COMMAND += "bootimg_fixup; ensure_secure_boot_payload;"
 IMAGE_POSTPROCESS_COMMAND += "create_cdf;"
 
 inherit image

--- a/recipes-core/images/nilrt-runmode-rootfs.bb
+++ b/recipes-core/images/nilrt-runmode-rootfs.bb
@@ -1,5 +1,7 @@
 DESCRIPTION = "NI Linux RT runmode rootfs archive"
 
+SECURE_BOOT_ENABLED = "${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', '1', '0', d)}"
+
 SRC_URI += "\
 	file://bootimage.ini \
 "
@@ -12,6 +14,7 @@ IMAGE_INSTALL = "\
 
 IMAGE_INSTALL:append:x64 = "\
 	nilrt-grub-runmode \
+	${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', 'packagegroup-efi-secure-boot', '', d)} \
 	"
 
 require includes/nilrt-image-base.inc
@@ -39,6 +42,22 @@ bootimg_fixup_x64() {
 	mv "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}" "${IMAGE_ROOTFS}/${CUSTOM_KERNEL_PATH}"
 }
 
+ensure_secure_boot_kernel_sidecar_x64() {
+	if [ "${SECURE_BOOT_ENABLED}" != "1" ]; then
+		return
+	fi
+
+	if [ -z "${SB_FILE_EXT}" ]; then
+		echo "ERROR: SB_FILE_EXT is not set while secure boot is enabled." 1>&2
+		exit 1
+	fi
+
+	if [ ! -e "${IMAGE_ROOTFS}/${CUSTOM_KERNEL_PATH}/bzImage${SB_FILE_EXT}" ]; then
+		echo "ERROR: ${CUSTOM_KERNEL_PATH}/bzImage${SB_FILE_EXT} is required in secure-boot runmode rootfs image." 1>&2
+		exit 1
+	fi
+}
+
 bootimg_fixup_arm() {
 	# Stage the ITB under boot/runmode/ rather than directly in boot/.
 	# This prevents u-boot from attempting to boot a partially-extracted
@@ -52,7 +71,7 @@ bootimg_fixup_arm() {
         -exec rm -f {} +
 }
 
-IMAGE_PREPROCESS_COMMAND:append:x64 = " bootimg_fixup_x64; "
+IMAGE_PREPROCESS_COMMAND:append:x64 = " bootimg_fixup_x64; ensure_secure_boot_kernel_sidecar_x64; "
 IMAGE_PREPROCESS_COMMAND:append:xilinx-zynq = " bootimg_fixup_arm; "
 
 IMAGE_FSTYPES += "squashfs ${NILRT_BSI_FSTYPE}"

--- a/recipes-core/images/nilrt-safemode-initramfs-efi-secure-boot.inc
+++ b/recipes-core/images/nilrt-safemode-initramfs-efi-secure-boot.inc
@@ -1,0 +1,35 @@
+DEPENDS += "openssl-native"
+
+inherit user-key-store
+
+fakeroot python do_sign_secure_boot() {
+    import os
+
+    if d.getVar('UEFI_SB') != '1':
+        return
+
+    sig_ext = d.getVar('SB_FILE_EXT') or ''
+    if not sig_ext:
+        bb.warn('SB_FILE_EXT is empty; skipping initramfs secure-boot sidecar handling to avoid unsafe file operations.')
+        return
+
+    deploy_dir = d.getVar('DEPLOY_DIR_IMAGE')
+    image_link = d.getVar('IMAGE_LINK_NAME')
+
+    for image_fstype in d.getVar('IMAGE_FSTYPES').split():
+        artifact = os.path.join(deploy_dir, image_link + '.' + image_fstype)
+        if os.path.exists(artifact):
+            uks_bl_sign(artifact, d)
+}
+
+addtask sign_secure_boot after do_image_complete before do_build
+
+do_sign_secure_boot[prefuncs] += "check_deploy_keys"
+do_sign_secure_boot[prefuncs] += "${@'check_boot_public_key' if d.getVar('GRUB_SIGN_VERIFY') == '1' else ''}"
+do_sign_secure_boot[depends] += " \
+    openssl-native:do_populate_sysroot \
+    sbsigntool-native:do_populate_sysroot \
+    libsign-native:do_populate_sysroot \
+    efitools-native:do_populate_sysroot \
+    gnupg-native:do_populate_sysroot \
+"

--- a/recipes-core/images/nilrt-safemode-initramfs.bbappend
+++ b/recipes-core/images/nilrt-safemode-initramfs.bbappend
@@ -1,0 +1,1 @@
+require ${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', 'nilrt-safemode-initramfs-efi-secure-boot.inc', '', d)}

--- a/recipes-core/images/nilrt-safemode-rootfs.bb
+++ b/recipes-core/images/nilrt-safemode-rootfs.bb
@@ -7,6 +7,9 @@ IMAGE_NAME_SUFFIX = ""
 
 DEPENDS += "${PREFERRED_PROVIDER_virtual/kernel}"
 
+# UEFI_SB is only defined for recipes inheriting user-key-store, which this is not.
+SECURE_BOOT_ENABLED = "${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', '1', '0', d)}"
+
 PV = "${DISTRO_VERSION}"
 
 SRC_URI += "\
@@ -21,13 +24,23 @@ IMAGE_INSTALL = "\
 IMAGE_INSTALL:append:x64 = "\
 	kernel-image-bzimage \
 	nilrt-grub-safemode \
+	${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', 'packagegroup-efi-secure-boot', '', d)} \
 "
 
 RAMDISK_IMAGE = "nilrt-safemode-initramfs"
 do_rootfs[depends] += "${RAMDISK_IMAGE}:do_image_complete"
+do_rootfs[depends] += "${@' ${RAMDISK_IMAGE}:do_sign_secure_boot' if d.getVar('SECURE_BOOT_ENABLED') == '1' else ''}"
 
 bootimg_fixup() {
+	install -d "${IMAGE_ROOTFS}/boot"
+
 	install -m 0644 "${DEPLOY_DIR_IMAGE}/${RAMDISK_IMAGE}-${MACHINE}.cpio.xz" "${IMAGE_ROOTFS}/boot/ramdisk.xz"
+
+	if [ "${SECURE_BOOT_ENABLED}" = "1" ] && [ -n "${SB_FILE_EXT}" ]; then
+		if [ -f "${DEPLOY_DIR_IMAGE}/${RAMDISK_IMAGE}-${MACHINE}.cpio.xz${SB_FILE_EXT}" ]; then
+			install -m 0644 "${DEPLOY_DIR_IMAGE}/${RAMDISK_IMAGE}-${MACHINE}.cpio.xz${SB_FILE_EXT}" "${IMAGE_ROOTFS}/boot/ramdisk.xz${SB_FILE_EXT}"
+		fi
+	fi
 
 	install -m 0755 "${THISDIR}/files/${BPN}.preinst" "${IMAGE_ROOTFS}/boot/preinst"
 
@@ -46,6 +59,24 @@ bootimg_fixup() {
 	mv "$(realpath ${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/bzImage)" "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/bzImage.real"
 	rm -f "${IMAGE_ROOTFS}/boot/bzImage"
 	mv "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/bzImage.real" "${IMAGE_ROOTFS}/boot/bzImage"
+	if [ "${SECURE_BOOT_ENABLED}" = "1" ] && [ -n "${SB_FILE_EXT}" ]; then
+		if [ -e "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/bzImage${SB_FILE_EXT}" ]; then
+			kernel_sig_src="${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/bzImage${SB_FILE_EXT}"
+			if [ -L "${kernel_sig_src}" ]; then
+				# Preserve signature contents rather than a potentially dangling symlink.
+				install -m 0644 "$(realpath "${kernel_sig_src}")" "${IMAGE_ROOTFS}/boot/bzImage${SB_FILE_EXT}"
+			else
+				mv "${kernel_sig_src}" "${IMAGE_ROOTFS}/boot/bzImage${SB_FILE_EXT}"
+			fi
+		else
+			# Some package managers may not preserve the stable signature symlink.
+			# Fall back to a versioned kernel sidecar and normalize its final name.
+			versioned_sig="$(ls -1 "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}/bzImage-"*"${SB_FILE_EXT}" 2>/dev/null | sort | tail -n 1)"
+			if [ -n "${versioned_sig}" ] && [ -e "${versioned_sig}" ]; then
+				install -m 0644 "${versioned_sig}" "${IMAGE_ROOTFS}/boot/bzImage${SB_FILE_EXT}"
+			fi
+		fi
+	fi
 	rm -rf "${IMAGE_ROOTFS}/${KERNEL_IMAGEDEST}"
 
 	install -m 0644 "${THISDIR}/files/bootimage.ini" "${IMAGE_ROOTFS}/boot/bootimage.ini"
@@ -85,6 +116,20 @@ ensure_expected_files() {
 	done
 }
 
-IMAGE_PREPROCESS_COMMAND += " bootimg_fixup; ensure_expected_files; "
+ensure_secure_boot_files() {
+	if [ "${SECURE_BOOT_ENABLED}" != "1" ] || [ -z "${SB_FILE_EXT}" ]; then
+		return
+	fi
+
+	for f in "bzImage${SB_FILE_EXT}" "ramdisk.xz${SB_FILE_EXT}"; do
+		if [ -e "${IMAGE_ROOTFS}/boot/${f}" ] || [ -e "${IMAGE_ROOTFS}/${f}" ]; then
+			continue
+		fi
+
+		bbfatal "${f} is required in secure-boot safemode image. Checked ${IMAGE_ROOTFS}/boot/${f} and ${IMAGE_ROOTFS}/${f}."
+	done
+}
+
+IMAGE_PREPROCESS_COMMAND += " bootimg_fixup; ensure_expected_files; ensure_secure_boot_files; "
 
 inherit image

--- a/recipes-core/images/nilrt-safemode-rootfs.bb
+++ b/recipes-core/images/nilrt-safemode-rootfs.bb
@@ -7,7 +7,7 @@ IMAGE_NAME_SUFFIX = ""
 
 DEPENDS += "${PREFERRED_PROVIDER_virtual/kernel}"
 
-# UEFI_SB is only defined for recipes inheriting user-key-store, which this is not.
+# Derive the image secure-boot state from DISTRO_FEATURES.
 SECURE_BOOT_ENABLED = "${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', '1', '0', d)}"
 
 PV = "${DISTRO_VERSION}"
@@ -33,7 +33,13 @@ do_rootfs[depends] += "${@' ${RAMDISK_IMAGE}:do_sign_secure_boot' if d.getVar('S
 
 bootimg_fixup() {
 	install -d "${IMAGE_ROOTFS}/boot"
-
+	if [ "${SECURE_BOOT_ENABLED}" = "1" ]; then
+		install -d "${IMAGE_ROOTFS}/boot/lib" "${IMAGE_ROOTFS}/boot/usr/lib"
+		cp -a "${IMAGE_ROOTFS}/lib/." "${IMAGE_ROOTFS}/boot/lib/"
+		cp -a "${IMAGE_ROOTFS}/usr/lib/." "${IMAGE_ROOTFS}/boot/usr/lib/"
+		install -d "${IMAGE_ROOTFS}/boot/etc/ld.so.conf.d"
+		cp -a "${IMAGE_ROOTFS}/etc/ld.so.conf.d/." "${IMAGE_ROOTFS}/boot/etc/ld.so.conf.d/" 2>/dev/null || true
+	fi
 	install -m 0644 "${DEPLOY_DIR_IMAGE}/${RAMDISK_IMAGE}-${MACHINE}.cpio.xz" "${IMAGE_ROOTFS}/boot/ramdisk.xz"
 
 	if [ "${SECURE_BOOT_ENABLED}" = "1" ] && [ -n "${SB_FILE_EXT}" ]; then

--- a/recipes-core/images/rauc/nilrt-dkms-bundle-image.bb
+++ b/recipes-core/images/rauc/nilrt-dkms-bundle-image.bb
@@ -4,6 +4,10 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 IMAGE_FSTYPES = "tar.bz2"
 
+SECURE_BOOT_ENABLED = "${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', '1', '0', d)}"
+
+inherit ${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', 'user-key-store', '', d)}
+
 DEPENDS = "grub-efi grub-bootconf ${PREFERRED_PROVIDER_virtual/kernel}"
 
 IMAGE_INSTALL = " \
@@ -11,6 +15,9 @@ IMAGE_INSTALL = " \
 	grub-bootconf-nilrt \
 	kernel-image-bzimage \
 "
+
+# shim is the first stage; SELoader and the NI grub image are its siblings.
+IMAGE_INSTALL:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', 'shim seloader', '', d)}"
 
 INITRAMFS_IMAGE = "nilrt-initramfs"
 do_rootfs[depends] += "${INITRAMFS_IMAGE}:do_image_complete"
@@ -30,7 +37,15 @@ bootimg_fixup() {
 
 	# Generate readme.txt file to describe image contents
 	echo  >"${IMAGE_ROOTFS}/boot/readme.txt" "${PN} ${PV} ${PR} system partition image:"
-	echo >>"${IMAGE_ROOTFS}/boot/readme.txt" " - bootx64.efi: Grub EFI binary"
+	if [ "${SECURE_BOOT_ENABLED}" = "1" ]; then
+		echo >>"${IMAGE_ROOTFS}/boot/readme.txt" " - efi/nilrt/bootx64.efi: shim EFI binary (first stage)"
+		echo >>"${IMAGE_ROOTFS}/boot/readme.txt" " - efi/nilrt/SELoaderx64.efi: SELoader EFI binary (second stage)"
+		echo >>"${IMAGE_ROOTFS}/boot/readme.txt" " - efi/nilrt/mmx64.efi: MokManager EFI binary"
+		echo >>"${IMAGE_ROOTFS}/boot/readme.txt" " - efi/nilrt/${GRUB_IMAGE}: Grub EFI binary"
+		echo >>"${IMAGE_ROOTFS}/boot/readme.txt" " - ${SB_FILE_EXT} files: detached signatures for the files Grub loads"
+	else
+		echo >>"${IMAGE_ROOTFS}/boot/readme.txt" " - bootx64.efi: Grub EFI binary"
+	fi
 	echo >>"${IMAGE_ROOTFS}/boot/readme.txt" " - grub.cfg: Grub configuration"
 	echo >>"${IMAGE_ROOTFS}/boot/readme.txt" " - bzImage: $(readlink "${IMAGE_ROOTFS}/boot/bzImage") kernel image"
 	echo >>"${IMAGE_ROOTFS}/boot/readme.txt" " - initrd.cpio.gz: ${INITRAMFS_IMAGE}-${MACHINE}.cpio.gz ramdisk image"
@@ -66,6 +81,43 @@ bootimg_fixup() {
 	rmdir "${IMAGE_ROOTFS}/boot"
 }
 
-IMAGE_PREPROCESS_COMMAND += " bootimg_fixup; "
+# shim looks for its next stage next to itself, so the whole chain has to live
+# in the same directory as the NI-prefixed grub image.
+secure_boot_esp_fixup() {
+	if [ "${SECURE_BOOT_ENABLED}" != "1" ]; then
+		return
+	fi
+
+	for f in bootx64.efi mmx64.efi SELoaderx64.efi; do
+		if [ ! -e "${IMAGE_ROOTFS}/efi/EFI/BOOT/$f" ]; then
+			bbfatal "$f is required in the secure-boot ESP image but was not installed."
+		fi
+		mv "${IMAGE_ROOTFS}/efi/EFI/BOOT/$f" "${IMAGE_ROOTFS}/efi/nilrt/$f"
+	done
+
+	rm -rf "${IMAGE_ROOTFS}/efi/EFI"
+}
+
+python secure_boot_esp_sign() {
+    import glob
+
+    if d.getVar('SECURE_BOOT_ENABLED') != '1':
+        return
+
+    rootfs = d.getVar('IMAGE_ROOTFS')
+    targets = [rootfs + '/efi/nilrt/grub.cfg',
+               rootfs + '/bzImage',
+               rootfs + '/initrd.cpio.gz']
+    targets += sorted(glob.glob(rootfs + '/bootimage.cfg.d/*.cfg'))
+
+    for target in targets:
+        if not os.path.exists(target):
+            bb.fatal('%s is required in the secure-boot ESP image but is missing.'
+                     % target[len(rootfs):])
+        uks_bl_sign(target, d)
+}
+secure_boot_esp_sign[prefuncs] += "check_deploy_keys"
+
+IMAGE_PREPROCESS_COMMAND += " bootimg_fixup; secure_boot_esp_fixup; secure_boot_esp_sign; "
 
 inherit image

--- a/recipes-core/initrdscripts/files/ni_provisioning.common
+++ b/recipes-core/initrdscripts/files/ni_provisioning.common
@@ -426,9 +426,20 @@ elif [ "$ARCH" = "x86_64" ]; then
 				die "Failed to find an image file in bundle"
 			fi
 
-			# Move boot loader image to auto-discoverable /efi/boot/
-			mkdir /mnt/efi-auto/niboota/efi/boot
-			mv /mnt/efi-auto/niboota/efi/nilrt/bootx64.efi /mnt/efi-auto/niboota/efi/boot/bootx64.efi
+			local nilrt_efi_dir=/mnt/efi-auto/niboota/efi/nilrt
+			local auto_efi_dir=/mnt/efi-auto/niboota/efi/boot
+			mkdir -p "$auto_efi_dir"
+
+			if [ -e "$nilrt_efi_dir/grubx64.efi" ]; then
+				local secure_boot_stage
+				for secure_boot_stage in bootx64.efi SELoaderx64.efi mmx64.efi grubx64.efi; do
+					[ -f "$nilrt_efi_dir/$secure_boot_stage" ] || die "Secure Boot bundle is missing $secure_boot_stage"
+				done
+				cp -a "$nilrt_efi_dir"/. "$auto_efi_dir"/
+			else
+				[ -f "$nilrt_efi_dir/bootx64.efi" ] || die "Bundle is missing bootx64.efi"
+				cp "$nilrt_efi_dir/bootx64.efi" "$auto_efi_dir/bootx64.efi"
+			fi
 
 			umount /mnt/efi-auto/niboota
 			umount /mnt/efi-auto/bundle

--- a/recipes-core/initrdscripts/files/ni_provisioning.safemode
+++ b/recipes-core/initrdscripts/files/ni_provisioning.safemode
@@ -20,7 +20,6 @@ prune_efi_crash_vars
 install_grub
 
 install_safemode
-install_bootmode_file
 install_grubenv
 set_versions
 

--- a/recipes-core/initrdscripts/files/ni_provisioning.safemode.common
+++ b/recipes-core/initrdscripts/files/ni_provisioning.safemode.common
@@ -222,12 +222,15 @@ mount_grub_partition()
 
 # Signed EFI binaries installed by packagegroup-efi-secure-boot. The unsigned
 # oe-core images under /boot/EFI/BOOT are only usable without Secure Boot.
-SECURE_BOOT_EFI_DIR=/boot/efi/EFI/BOOT
-SECURE_BOOT_CHAIN="bootx64.efi SELoaderx64.efi mmx64.efi grubx64.efi"
+# SELoaderx64.efi is renamed to bootx64.efi when MOK signing is disabled.
+SECURE_BOOT_REQUIRED_FILES="bootx64.efi mmx64.efi grubx64.efi"
+SECURE_BOOT_OPTIONAL_FILES="SELoaderx64.efi"
+SECURE_BOOT_CHAIN="$SECURE_BOOT_REQUIRED_FILES $SECURE_BOOT_OPTIONAL_FILES"
+SECURE_BOOT_EFI_FILES="$SECURE_BOOT_CHAIN Hash2DxeCrypto.efi Pkcs7VerifyDxe.efi LockDown.efi"
 
 secure_boot_chain_available()
 {
-	for STAGE in $SECURE_BOOT_CHAIN ; do
+	for STAGE in $SECURE_BOOT_REQUIRED_FILES ; do
 		[ -f "$SECURE_BOOT_EFI_DIR/$STAGE" ] || return 1
 	done
 	return 0
@@ -245,23 +248,42 @@ install_grub()
 	if secure_boot_chain_available ; then
 		# bootx64.efi is shim here; it loads its next stage from its own
 		# directory, so the whole chain has to be installed together.
-		for STAGE in $SECURE_BOOT_CHAIN ; do
-			cp "$SECURE_BOOT_EFI_DIR/$STAGE" $GRUB_TARGET_DIR
+		for STAGE in $SECURE_BOOT_EFI_FILES ; do
+			if [ -f "$SECURE_BOOT_EFI_DIR/$STAGE" ] ; then
+				cp "$SECURE_BOOT_EFI_DIR/$STAGE" $GRUB_TARGET_DIR
+			fi
 		done
 	else
-		cp /boot/EFI/BOOT/bootx64.efi $GRUB_TARGET_DIR
+		cp "$SOURCE_DIR/efi/EFI/BOOT/bootx64.efi" $GRUB_TARGET_DIR
 	fi
 
 	set_efiboot_entry
 
 	print_info "Installing grub.cfg..."
 
-	cp $SOURCE_DIR/grub.cfg $GRUB_TARGET_DIR/grub.cfg
-	if [ -f "$SOURCE_DIR/grub.cfg.p7b" ] ; then
-		cp $SOURCE_DIR/grub.cfg.p7b $GRUB_TARGET_DIR/grub.cfg.p7b
+	if [ -f "$GRUB_TARGET_DIR/grub.cfg" ] ; then
+		print_info "Preserving existing grub.cfg on ESP..."
+	else
+		cp $SOURCE_DIR/grub.cfg $GRUB_TARGET_DIR/grub.cfg
 	fi
-	mkdir -p $GRUB_TARGET_DIR/fonts
-	cp $SOURCE_DIR/fonts/unicode.pf2 $GRUB_TARGET_DIR/fonts/
+	if [ -f "$SOURCE_DIR/grub.cfg.p7b" ] ; then
+		if [ -f "$GRUB_TARGET_DIR/grub.cfg.p7b" ] ; then
+			print_info "Preserving existing grub.cfg.p7b on ESP..."
+		else
+			cp $SOURCE_DIR/grub.cfg.p7b $GRUB_TARGET_DIR/grub.cfg.p7b
+		fi
+	fi
+
+	# In Secure Boot mode, the font is embedded in the signed grubx64.efi and
+	# an external unicode.pf2 is not trusted. Skip copying the unsigned font so
+	# GRUB does not try to load an unrelated mismatched file.
+	if secure_boot_chain_available ; then
+		# Ensure no stale external font is left behind from an older install.
+		rm -rf "$GRUB_TARGET_DIR/fonts"
+	else
+		mkdir -p $GRUB_TARGET_DIR/fonts
+		cp $SOURCE_DIR/fonts/unicode.pf2 $GRUB_TARGET_DIR/fonts/
+	fi
 	print_done
 }
 
@@ -287,14 +309,6 @@ install_safemode()
 	if [ -f "$SOURCE_DIR/bzImage.p7b" ] ; then
 		cp "$SOURCE_DIR"/*Image.p7b "$BOOTFS_MOUNTPOINT/.safe/"
 	fi
-	print_done
-}
-
-install_bootmode_file()
-{
-	# write initial bootmode file
-	print_info "Installing bootmode file..."
-	echo "set BOOT_MODE=safemode" >$BOOTFS_MOUNTPOINT/bootmode
 	print_done
 }
 
@@ -329,6 +343,7 @@ install_grubenv()
 
 	grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv set "BIOSBootMode=efi"
 	grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv set "NITarget=$NI_TARGET"
+	grub-editenv $BOOTFS_MOUNTPOINT/grub/grubenv set "BOOT_MODE=safemode"
 
 	# Mark aforementioned grub vars read-only
 	for varname in "BIOSBootMode" "NITarget" ; do
@@ -476,3 +491,4 @@ sanity_check()
 }
 
 SOURCE_DIR=/payload
+SECURE_BOOT_EFI_DIR=$SOURCE_DIR/efi/EFI/BOOT

--- a/recipes-core/initrdscripts/files/ni_provisioning.safemode.common
+++ b/recipes-core/initrdscripts/files/ni_provisioning.safemode.common
@@ -220,6 +220,19 @@ mount_grub_partition()
 	MOUNT_ERROR=`mount -L $PART1_LABEL $GRUB_MOUNTPOINT 2>&1` || die "$MOUNT_ERROR"
 }
 
+# Signed EFI binaries installed by packagegroup-efi-secure-boot. The unsigned
+# oe-core images under /boot/EFI/BOOT are only usable without Secure Boot.
+SECURE_BOOT_EFI_DIR=/boot/efi/EFI/BOOT
+SECURE_BOOT_CHAIN="bootx64.efi SELoaderx64.efi mmx64.efi grubx64.efi"
+
+secure_boot_chain_available()
+{
+	for STAGE in $SECURE_BOOT_CHAIN ; do
+		[ -f "$SECURE_BOOT_EFI_DIR/$STAGE" ] || return 1
+	done
+	return 0
+}
+
 install_grub()
 {
 	mount_grub_partition
@@ -228,13 +241,25 @@ install_grub()
 	GRUB_TARGET_DIR=$GRUB_MOUNTPOINT/efi/boot
 	mkdir -p $GRUB_TARGET_DIR
 	GRUB_TARGET=$(uname -m)
-	cp /boot/EFI/BOOT/bootx64.efi $GRUB_TARGET_DIR
+
+	if secure_boot_chain_available ; then
+		# bootx64.efi is shim here; it loads its next stage from its own
+		# directory, so the whole chain has to be installed together.
+		for STAGE in $SECURE_BOOT_CHAIN ; do
+			cp "$SECURE_BOOT_EFI_DIR/$STAGE" $GRUB_TARGET_DIR
+		done
+	else
+		cp /boot/EFI/BOOT/bootx64.efi $GRUB_TARGET_DIR
+	fi
 
 	set_efiboot_entry
 
 	print_info "Installing grub.cfg..."
 
 	cp $SOURCE_DIR/grub.cfg $GRUB_TARGET_DIR/grub.cfg
+	if [ -f "$SOURCE_DIR/grub.cfg.p7b" ] ; then
+		cp $SOURCE_DIR/grub.cfg.p7b $GRUB_TARGET_DIR/grub.cfg.p7b
+	fi
 	mkdir -p $GRUB_TARGET_DIR/fonts
 	cp $SOURCE_DIR/fonts/unicode.pf2 $GRUB_TARGET_DIR/fonts/
 	print_done
@@ -257,7 +282,11 @@ install_safemode()
 	cp "$SOURCE_DIR"/*Image		"$BOOTFS_MOUNTPOINT/.safe/"
 	cp "$SOURCE_DIR"/ramdisk.*	"$BOOTFS_MOUNTPOINT/.safe/"
 	cp "$SOURCE_DIR"/bootimage.*  "$BOOTFS_MOUNTPOINT/.safe/"
-
+	# Detached kernel signature; the ramdisk and bootimage globs above
+	# already pick theirs up.
+	if [ -f "$SOURCE_DIR/bzImage.p7b" ] ; then
+		cp "$SOURCE_DIR"/*Image.p7b "$BOOTFS_MOUNTPOINT/.safe/"
+	fi
 	print_done
 }
 

--- a/recipes-kernel/linux/linux-nilrt-efi-secure-boot.inc
+++ b/recipes-kernel/linux/linux-nilrt-efi-secure-boot.inc
@@ -1,0 +1,115 @@
+DEPENDS += "openssl-native"
+
+inherit user-key-store
+
+fakeroot python do_sign() {
+    import glob
+    import os
+    import re
+    import shutil
+
+    if (d.expand('${TARGET_ARCH}') != 'x86_64') and (not re.match('i.86', d.expand('${TARGET_ARCH}'))):
+        return
+
+    if d.expand('${UEFI_SB}') != '1':
+        return
+
+    kdest = d.expand('${D}/${KERNEL_IMAGEDEST}')
+    sig_ext = d.expand('${SB_FILE_EXT}')
+
+    if not sig_ext:
+        bb.warn('SB_FILE_EXT is empty; skipping kernel secure-boot sidecar handling to avoid unsafe file operations.')
+        return
+
+    # Clean up stale artifacts produced by previous buggy runs so they
+    # do not leak into packaging QA as installed-but-not-shipped files.
+    for stale in glob.glob(os.path.join(kdest, '*' + sig_ext + sig_ext)):
+        try:
+            os.unlink(stale)
+        except FileNotFoundError:
+            pass
+
+    for image_type in d.expand('${KERNEL_IMAGETYPES}').split():
+        image_path = os.path.join(kdest, image_type)
+
+        if os.path.exists(image_path):
+            resolved_image = os.path.realpath(image_path)
+        else:
+            expected_image = os.path.join(kdest, image_type + '-' + d.expand('${KERNEL_RELEASE}'))
+            if os.path.exists(expected_image):
+                resolved_image = expected_image
+            else:
+                # NILRT kernels may be staged only as versioned files
+                # (for example bzImage-<version>) before a stable symlink exists.
+                # Fall back to a deterministic choice and still create image sidecars.
+                candidates = [
+                    c for c in glob.glob(os.path.join(kdest, image_type + '-*'))
+                    if not c.endswith(sig_ext)
+                ]
+                if not candidates:
+                    continue
+                resolved_image = max(candidates, key=lambda p: (os.path.getmtime(p), p))
+
+        # Keep an unsigned copy for manual verification/debugging and for
+        # SELoader sidecar signing.
+        unsigned_image = os.path.join(d.expand('${B}'), image_type + '.unsigned')
+        shutil.copyfile(resolved_image, unsigned_image)
+
+        if d.expand('${GRUB_SIGN_VERIFY}') == '1':
+            sb_sign(resolved_image, resolved_image, d)
+
+        # SELoader signature is always based on the unsigned kernel image,
+        # disallowing chainloader to kernel efi-stub.
+        uks_bl_sign(unsigned_image, d)
+
+        resolved_sig = unsigned_image + sig_ext
+        image_sig = image_path + sig_ext
+
+        if os.path.exists(resolved_sig):
+            versioned_sig = os.path.join(kdest, image_type + '-' + d.expand('${KERNEL_RELEASE}') + sig_ext)
+
+            # If signing already emitted the signature with the expected
+            # versioned filename, avoid copying a file onto itself.
+            if os.path.abspath(resolved_sig) != os.path.abspath(versioned_sig):
+                shutil.copyfile(resolved_sig, versioned_sig)
+
+            if os.path.lexists(image_sig):
+                os.unlink(image_sig)
+            os.symlink(os.path.basename(versioned_sig), image_sig)
+}
+
+# Make sure the kernel image has been signed before kernel_do_deploy()
+# which prepares kernel artifacts consumed by provisioning flows.
+addtask sign after do_install before do_package do_populate_sysroot do_deploy
+
+do_sign[prefuncs] += "check_deploy_keys"
+do_sign[prefuncs] += "${@'check_boot_public_key' if d.getVar('GRUB_SIGN_VERIFY') == '1' else ''}"
+
+do_deploy:append() {
+    install -d "${DEPLOYDIR}/efi-unsigned"
+
+    for imageType in ${KERNEL_IMAGETYPES}; do
+        if [ -f "${B}/${imageType}.unsigned" ]; then
+            install -m 0644 "${B}/${imageType}.unsigned" "${DEPLOYDIR}/efi-unsigned/${imageType}"
+        fi
+
+        if [ -n "${SB_FILE_EXT}" ] && [ -f "${D}/${KERNEL_IMAGEDEST}/${imageType}${SB_FILE_EXT}" ]; then
+            install -m 0644 "${D}/${KERNEL_IMAGEDEST}/${imageType}${SB_FILE_EXT}" "${DEPLOYDIR}"
+        fi
+    done
+}
+
+# Ship *.p7b or *.sig files in the kernel image package.
+python do_package:prepend() {
+    sig_ext = d.expand('${SB_FILE_EXT}')
+    if not sig_ext:
+        bb.warn('SB_FILE_EXT is empty; skipping kernel-image sidecar FILES entries.')
+        return
+
+    for image_type in d.expand('${KERNEL_IMAGETYPES}').split():
+        image_lower = image_type.lower()
+        d.appendVar('FILES:kernel-image-' + image_lower,
+                    ' ' + d.expand('${KERNEL_IMAGEDEST}/') + image_type + d.expand('-${KERNEL_RELEASE}${SB_FILE_EXT}'))
+        d.appendVar('FILES:kernel-image-' + image_lower,
+                    ' ' + d.expand('${KERNEL_IMAGEDEST}/') + image_type + d.expand('${SB_FILE_EXT}'))
+}

--- a/recipes-kernel/linux/linux-nilrt_%.bbappend
+++ b/recipes-kernel/linux/linux-nilrt_%.bbappend
@@ -1,0 +1,1 @@
+require ${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', 'linux-nilrt-efi-secure-boot.inc', '', d)}


### PR DESCRIPTION
### Summary of Changes

Implementing secure-boot signing of bzImage and ramdisk in nilrt-safemode-rootfs


### Justification

[AB#3781428](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3781428)


### Testing

* [X] I have built the nilrt-safemode-rootfs recipe with this PR in place and `efi-secure-boot` enabled in DISTRO_FEATURES
   * [X] I have verified the contents of nilrt-safemode-rootfs have been signed
* [X] I have built the nilrt-safemode-rootfs recipe with this PR in place
   * [X] Deployed the nilrt-safemode-rootfs onto x64 target


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
