### PR TITLE
Switch ARM kernel to 6.18

### DIFF
--- a/conf/machine/xilinx-zynq.conf
+++ b/conf/machine/xilinx-zynq.conf
@@ -42,4 +42,4 @@ NILRT_ARM_DEVICE_CODES = "\
         793C \
 "
 
-KERNEL_DEVICETREE = "${@' '.join(["ni-%s.dtb" % x for x in "${NILRT_ARM_DEVICE_CODES}".split()])}"
+KERNEL_DEVICETREE = "${@' '.join(["xilinx/ni-%s.dtb" % x for x in "${NILRT_ARM_DEVICE_CODES}".split()])}"

--- a/recipes-kernel/linux/linux-nilrt-arm-safemode_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-arm-safemode_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NILRT safemode itb for ARM targets"
 NI_RELEASE_VERSION = "master"
-LINUX_VERSION:xilinx-zynq = "4.14"
+LINUX_VERSION:xilinx-zynq = "6.18"
 COMPATIBLE_MACHINE = "xilinx-zynq"
 
 require linux-nilrt-alternate.inc

--- a/recipes-kernel/linux/linux-nilrt-debug_git.bb
+++ b/recipes-kernel/linux/linux-nilrt-debug_git.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "NILRT linux kernel debug build"
 NI_RELEASE_VERSION = "master"
 LINUX_VERSION = "6.18"
-LINUX_VERSION:xilinx-zynq = "4.14"
+LINUX_VERSION:xilinx-zynq = "6.18"
 LINUX_KERNEL_TYPE = "debug"
 
 require linux-nilrt-alternate.inc

--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -13,9 +13,6 @@ KBUILD_FRAGMENTS_LOCATION ?= "nilrt"
 
 LINUX_VERSION_EXTENSION = "$([ "${LINUX_KERNEL_TYPE}" != "standard" ] && echo '-${LINUX_KERNEL_TYPE}')"
 
-# Only required for 4.14 kernels
-EXTRA_OEMAKE:append:xilinx-zynq = ' CFLAGS="${TOOLCHAIN_OPTIONS} -Wno-array-bounds" '
-
 # Kbuild intenionally clobbers CFLAGS/LDFLAGS for some binaries we ship in nilrt,
 # particularly in the tools/ dir (fixdep, genksyms etc), and OE has this insanity check
 # to see if binaries were built using the OE-supplied *FLAGS, so skip this sanity check to
@@ -45,7 +42,6 @@ PV = "${LINUX_VERSION}+git${SRCPV}"
 CVE_VERSION = "${KERNEL_VERSION}+git${SRCPV}"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
-LIC_FILES_CHKSUM:xilinx-zynq = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 
 # This checks ${PV} == version from kernel sources which our PV/AUTOREV breaks, so skip it.
 KERNEL_VERSION_SANITY_SKIP="1"

--- a/recipes-kernel/linux/linux-nilrt.inc
+++ b/recipes-kernel/linux/linux-nilrt.inc
@@ -13,7 +13,7 @@ KBUILD_FRAGMENTS_LOCATION ?= "nilrt"
 
 LINUX_VERSION_EXTENSION = "$([ "${LINUX_KERNEL_TYPE}" != "standard" ] && echo '-${LINUX_KERNEL_TYPE}')"
 
-# Kbuild intenionally clobbers CFLAGS/LDFLAGS for some binaries we ship in nilrt,
+# Kbuild intentionally clobbers CFLAGS/LDFLAGS for some binaries we ship in nilrt,
 # particularly in the tools/ dir (fixdep, genksyms etc), and OE has this insanity check
 # to see if binaries were built using the OE-supplied *FLAGS, so skip this sanity check to
 # avoid this OE<>Kernel clash (linux-yocto recipe doesn't have this problem because it does

--- a/recipes-kernel/linux/linux-nilrt_git.bb
+++ b/recipes-kernel/linux/linux-nilrt_git.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Linux kernel based on nilrt branch"
 NI_RELEASE_VERSION = "master"
 LINUX_VERSION = "6.18"
-LINUX_VERSION:xilinx-zynq = "4.14"
+LINUX_VERSION:xilinx-zynq = "6.18"
 
 require linux-nilrt.inc
 


### PR DESCRIPTION
### Summary of Changes

Now that 6.18 kernel supports ARM targets, make 6.18 the default for ARM as well.

### Justification

WI: [AB#3966413](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3966413)

### Testing

* [x] Built core feeds, BSI - `bitbake packagefeed-ni-core && bitbake package-index && bitbake nilrt-base-system-image`
* [x] Built safemode - `bitbake linux-nilrt-arm-safemode`
* [x] Tested BSI on majority of supported ARM targets and verified it works with NIHM. Software can be installed, drivers can load, LV works, FPGA can be programmed.
* [x] Tested safemode on a few targets and it can format, install BSI.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
