### PR TITLE
images: remove ni-sysapi-webservice

### DIFF
--- a/recipes-core/images/includes/nilrt-container.inc
+++ b/recipes-core/images/includes/nilrt-container.inc
@@ -16,17 +16,19 @@ ROOTFS_RO_UNNEEDED = "\
 # /etc/opkg/ni-arch.conf at first boot via run-postinsts.
 IMAGE_INSTALL_NODEPS += "ni-arch-gen"
 
-# ni-sysapi-webservice provides the /nisysapi/server endpoint needed
-# for NI MAX connectivity.
 # ni-auth is required by SystemWebServer (segfaults without niauth_daemon).
 # ni-system-webserver provides the web server for deployment and discovery
 # by NI MAX and VeriStand.
 # ni-webdav-system-webserver-support provides mod_nidav.so for WebDAV file
 # deployment (how VeriStand deploys .rtexe to /c).
-IMAGE_INSTALL_NODEPS += "ni-sysapi-webservice ni-auth ni-system-webserver ni-webdav-system-webserver-support"
+IMAGE_INSTALL_NODEPS += "ni-auth ni-system-webserver ni-webdav-system-webserver-support"
 
 # nirtmdnsd provides NI RT mDNS service for target discovery.
 IMAGE_INSTALL_NODEPS += "nirtmdnsd"
+
+# ni-sysapi-sshcli is required by both container variants; install it
+# explicitly since NODEPS skips dependency resolution.
+IMAGE_INSTALL_NODEPS += "ni-sysapi-sshcli"
 
 # Necessary whenever building a container.
 # Though this appears to do nothing, given how our kernel recipes are constructed.

--- a/recipes-core/images/includes/nilrt-proprietary.inc
+++ b/recipes-core/images/includes/nilrt-proprietary.inc
@@ -19,7 +19,6 @@ NI_PROPRIETARY_COMMON_PACKAGES = "\
         ni-ssl-webserver-support \
         ni-sysapi \
         ni-sysapi-remote \
-        ni-sysapi-webservice \
         ni-sysmgmt-auth-utils \
         ni-system-webserver \
         ni-traceengine \


### PR DESCRIPTION
### Summary of Changes

- `ni-sysapi-webservice` is being EOL'd this cycle. `ni-sysapi-sshcli`(direct dependency of `ni-sysapi-remote`) is already installed as its replacement, so stop installing the package that is going to be deprecated.


### Justification

[AB#3795721](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3795721)

[AB#3975710](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3975710)


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have built the runmode image with this PR in place. (`bitbake nilrt-base-system-image`)
* [x] Verified that on a target that `ni-sysapi-webservice` was not present and `ni-sysapi-remote` was present.
* [x] Working of `lvrt` and `Veristand` on both the `slim` and `runmode` containers were successfully tested using `ni-sysapi-sshcli` in place of `ni-sysapi-webservice`.




### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).

### Note:

- [x] This should be cherry-picked to `-next`.