### PR TITLE
nisystemformat: Preserve .shadow and niauth

### DIFF
--- a/recipes-ni/ni-systemformat/files/nisystemformat
+++ b/recipes-ni/ni-systemformat/files/nisystemformat
@@ -19,9 +19,12 @@ arch=`uname -m`
 
 NETCFG_MODE=bypass
 RESET_OVERLAY=no
+PRESERVE_PASSWORD=no
 
 NETCFG_TMP=/tmp/netconfig.$$
 declare -r BASENAME=${0##*/}
+
+ACCTINFO_TMP=/tmp/acctinfo.$$
 
 NINETCFGUTIL=/usr/local/natinst/bin/ninetcfgutil
 
@@ -242,7 +245,7 @@ usage()
 		EOF
 	elif [ "$OSMODE" != runmode ]; then
 		cat >&2 <<-EOF
-		Usage: $BASENAME [-f -t <type> [-c][-r][-n <mode>][-e]|-s [-c]|-l] [-B <fslabel>] [-P <pcrset>] [-L keep|disable]
+		Usage: $BASENAME [-f -t <type> [-c][-r][-n <mode>][-e][-p]|-s [-c]|-l] [-B <fslabel>] [-P <pcrset>] [-L keep|disable]
 
 		-f	Format the volume
 		-h	Print this help
@@ -252,6 +255,7 @@ usage()
 		-t	Filesystem type
 		-c	Format the config volume (otherwise rootfs + kernel)
 		-r	Relaunch the system webserver after format
+		-p	Preserve the system passwords
 		-n	Preserve network config according to <mode>:
 		        all		Preserve all settings
 		        primary		Preserve primary, reset secondary
@@ -359,6 +363,18 @@ format_rootfs_or_userfs_nosvc()
 {
 	netconfig_pre || return $?
 
+	# Backup shared account information to the tmp dir.
+	if [ "$PRESERVE_PASSWORD" = yes ] &&
+			[ -f "$CONFIG_MOUNT_POINT/.shadow" -o -e "$CONFIG_MOUNT_POINT/niauth" ]; then
+		trap 'rm -rf "$ACCTINFO_TMP"' EXIT HUP INT TERM
+		mkdir -p "$ACCTINFO_TMP" &&
+			{ [ ! -f "$CONFIG_MOUNT_POINT/.shadow" ] ||
+				cp "$CONFIG_MOUNT_POINT/.shadow" "$ACCTINFO_TMP"; } &&
+			{ [ ! -e "$CONFIG_MOUNT_POINT/niauth" ] ||
+				cp -a "$CONFIG_MOUNT_POINT/niauth" "$ACCTINFO_TMP"; } ||
+			return $?
+	fi
+
 	# Backup the restore files to the tmp dir. Do this even if we're only
 	# reformatting the configfs, because under some configurations,
 	# reformatting the configfs may also trigger reformatting the userfs.
@@ -386,6 +402,18 @@ format_rootfs_or_userfs_nosvc()
 		mkdir -p "$ROOTFS_MOUNT_POINT/.restore" &&
 			mv /tmp/restore/* "$ROOTFS_MOUNT_POINT/.restore" &&
 			rmdir /tmp/restore || (( ret )) || ret=$?
+	fi
+
+	# Move shared account information back to the configfs.
+	if [ "$PRESERVE_PASSWORD" = yes ] && mountpoint -q "$CONFIG_MOUNT_POINT"; then
+		if [ -f "$ACCTINFO_TMP/.shadow" -a ! -e "$CONFIG_MOUNT_POINT/.shadow" ]; then
+			mv "$ACCTINFO_TMP/.shadow" "$CONFIG_MOUNT_POINT" ||
+				(( ret )) || ret=$?
+		fi
+		if [ -e "$ACCTINFO_TMP/niauth" -a ! -e "$CONFIG_MOUNT_POINT/niauth" ]; then
+			mv "$ACCTINFO_TMP/niauth" "$CONFIG_MOUNT_POINT" ||
+				(( ret )) || ret=$?
+		fi
 	fi
 
 	netconfig_post || (( ret )) || ret=$?
@@ -490,7 +518,7 @@ if [ $# -eq "0" ]; then
 	die_with_usage INVALID_ARGUMENT "No command-line arguments specified."
 fi
 
-while getopts "fhsl4n:t:coreB:P:L:" Option
+while getopts "fhsl4n:t:pcoreB:P:L:" Option
 do
 	case $Option in
 		h)	usage; exit 0 ;;
@@ -502,6 +530,7 @@ do
 		c)	VOL=config;;
 		o)	RESET_OVERLAY=yes;;
 		r)	RELAUNCH=yes;;
+		p)	PRESERVE_PASSWORD=yes;;
 		n)	NETCFG_MODE="$OPTARG";;
 		*)	usage;;
 	esac


### PR DESCRIPTION
### Summary of Changes

Update the nisystemformat script to include a new -p argument that preserves the niauth database and the shared .shadow file when the configfs is formatted.


### Justification

This change is required for the RTOS set on first use plan because removing the .shadow file when formatting would reset the device back to the initial expired password state and users should be able to choose if they want this to happen. For consistency this behavior should be extended to apply to the niauth database as well.


### Testing

On a cRIO-9033:
- Manually ran nisystemformat without the -p argument and confirmed that the niauth database and .shadow file were removed when formatting the configfs partition
- Manually ran the nisystemformat script with the -p argument and confirmed that the niauth database and .shadow file were preserved when formatting the configfs partition
- Ran the format script from NI MAX and confirmed that the default behavior is to wipe the niauth database and .shadow file
- Manually modified the script on the target to default to using -p, ran the format script from NI MAX, and confirmed that the niauth database and .shadow file were preserved

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [ ] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
