### PR TITLE
Revert "sshd_config: Enable KbdInteractiveAuth"

### DIFF
--- a/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/recipes-connectivity/openssh/openssh_%.bbappend
@@ -27,8 +27,7 @@ do_install:append () {
 	# customize sshd_config
 	sed -e 's|^[#[:space:]]*Banner .*|Banner /etc/issue.net|' \
 		-e 's|^[#[:space:]]*UseDNS .*|UseDNS no|' \
-		-e 's|^[#[:space:]]*KbdInteractiveAuthentication .*|KbdInteractiveAuthentication yes|' \
-		-e 's|^[#[:space:]]*PasswordAuthentication .*|PasswordAuthentication no|' \
+		-e 's|^[#[:space:]]*PasswordAuthentication .*|PasswordAuthentication yes|' \
 		-e 's|^[#[:space:]]*PermitEmptyPasswords .*|PermitEmptyPasswords yes|' \
 		-e 's|^[#[:space:]]*PermitRootLogin .*|PermitRootLogin yes|' \
 		-e 's|^[#[:space:]]*ChallengeResponseAuthentication .*|ChallengeResponseAuthentication no|' \


### PR DESCRIPTION

### Summary of Changes

This reverts commit e4c51c26117cf29ef2933abe593ef8c8430e7eb7.


### Justification

Reverting until [AB#4020964](https://dev.azure.com/ni/DevCentral/_workitems/edit/4020964) is resolved.


### Testing
* [ ] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
