### PR TITLE
libpam: Add a patch to allow null passwords

### DIFF
--- a/recipes-extended/pam/libpam/0001-pam_unix_passwd-allow-blank-passwords.patch
+++ b/recipes-extended/pam/libpam/0001-pam_unix_passwd-allow-blank-passwords.patch
@@ -1,0 +1,77 @@
+From f285df521f3a63515615d6e7ad39a3cd5e18d88f Mon Sep 17 00:00:00 2001
+From: Erick Shepherd <erick.shepherd@ni.com>
+Date: Mon, 17 Aug 2026 11:36:50 -0500
+Subject: [PATCH] pam_unix_passwd: Allow empty password to be set
+
+Upstream-Status: Inappropriate [NI specific]
+
+Allow users to set a blank password using linux-pam by no longer
+setting blank passwords to NULL and making their shadow file entry
+blank. This is toggled by the nullok option.
+
+Signed-off-by: Erick Shepherd <erick.shepherd@ni.com>
+---
+ modules/pam_unix/pam_unix.8.xml    |  4 ++--
+ modules/pam_unix/pam_unix_passwd.c | 10 ++++++++--
+ 2 files changed, 10 insertions(+), 4 deletions(-)
+
+diff --git a/modules/pam_unix/pam_unix.8.xml b/modules/pam_unix/pam_unix.8.xml
+index d2cd198f..7f95beeb 100644
+--- a/modules/pam_unix/pam_unix.8.xml
++++ b/modules/pam_unix/pam_unix.8.xml
+@@ -155,8 +155,8 @@
+         <listitem>
+           <para>
+             The default action of this module is to not permit the
+-            user access to a service if their official password is blank.
+-            The <option>nullok</option> argument overrides this default.
++            user access to a service if their official password is blank
++            or allow blank passwords to be set during password changes.
+           </para>
+         </listitem>
+       </varlistentry>
+diff --git a/modules/pam_unix/pam_unix_passwd.c b/modules/pam_unix/pam_unix_passwd.c
+index c01fd56b..b8ac9688 100644
+--- a/modules/pam_unix/pam_unix_passwd.c
++++ b/modules/pam_unix/pam_unix_passwd.c
+@@ -593,6 +593,7 @@ pam_sm_chauthtok(pam_handle_t *pamh, int flags, int argc, const char **argv)
+ 	int remember = -1;
+ 	int rounds = 0;
+ 	int pass_min_len = 0;
++	int nullok_enabled = 0;
+ 	struct passwd *pwd;
+ 
+ 	/* <DO NOT free() THESE> */
+@@ -605,6 +606,7 @@ pam_sm_chauthtok(pam_handle_t *pamh, int flags, int argc, const char **argv)
+ 
+ 	ctrl = _set_ctrl(pamh, flags, &remember, &rounds, &pass_min_len,
+ 	                 argc, argv);
++	nullok_enabled = off(UNIX__NONULL, ctrl);
+ 
+ 	/*
+ 	 * First get the name of a user
+@@ -772,7 +774,7 @@ pam_sm_chauthtok(pam_handle_t *pamh, int flags, int argc, const char **argv)
+ 			 * password is acceptable.
+ 			 */
+ 
+-			if (*pass_new == '\0') {	/* "\0" password = NULL */
++			if (!nullok_enabled && pass_new != NULL && *pass_new == '\0') {
+ 				pass_new = NULL;
+ 			}
+ 			retval = _pam_unix_approve_pass(pamh, ctrl, pass_old,
+@@ -828,7 +830,11 @@ pam_sm_chauthtok(pam_handle_t *pamh, int flags, int argc, const char **argv)
+ 		 * First we encrypt the new password.
+ 		 */
+ 
+-		tpass = create_password_hash(pamh, pass_new, ctrl, rounds);
++		if (pass_new != NULL && *pass_new == '\0') {
++			tpass = strdup("");
++		} else {
++			tpass = create_password_hash(pamh, pass_new, ctrl, rounds);
++		}
+ 		if (tpass == NULL) {
+ 			pam_syslog(pamh, LOG_CRIT,
+ 				"crypt() failure or out of memory for password");
+-- 
+2.51.0
+

--- a/recipes-extended/pam/libpam_1.%.bbappend
+++ b/recipes-extended/pam/libpam_1.%.bbappend
@@ -3,6 +3,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 RDEPENDS:${PN} += "ni-acctsync pam-plugin-exec"
 
 SRC_URI += "\
+	file://0001-pam_unix_passwd-allow-blank-passwords.patch \
 	file://security/faillock.conf \
 	file://scripts/ni-acctsync-pam \
 "
@@ -10,6 +11,8 @@ SRC_URI += "\
 do_install:append() {
 	install -m 644 ${UNPACKDIR}/security/faillock.conf ${D}${sysconfdir}/security/faillock.conf
 	install -m 700 ${UNPACKDIR}/scripts/ni-acctsync-pam ${D}${sbindir}/ni-acctsync-pam
+	grep -qE 'pam_unix\.so.*[[:space:]]nullok([[:space:]]|$)' "${D}${sysconfdir}/pam.d/common-password" || \
+		sed -i -E '/pam_unix\.so/ s/(pam_unix\.so)([[:space:]]+)/\1\2nullok /' "${D}${sysconfdir}/pam.d/common-password"
 	sed -E -i '/^password[[:space:]]+requisite[[:space:]]+pam_deny\.so$/a password\toptional\t\t\tpam_exec.so /usr/sbin/ni-acctsync-pam' "${D}${sysconfdir}/pam.d/common-password"
 }
 


### PR DESCRIPTION
### Summary of Changes

Add a patch to linux-pam that allows users to set a blank password when using the passwd command and when updating an expired password. This is done by not setting "\0" passwords to NULL and setting the password hash to be blank for "\0" passwords.

[AB#3962858](https://dev.azure.com/ni/DevCentral/_workitems/edit/3962858)

### Justification

This change will help our internal teams and customers adapt to the Set on First Use strategy of shipping with expired passwords by allowing them to set the new password to be blank.


### Testing
- On a machine with ni-auth removed:
  - Ran "passwd root" and set the password to be non-blank
    - Confirmed that the usual password change workflow still works
    - Was able to log in with the new non-blank password
  - Ran "passwd root" and set the password to be blank
    - Confirmed that the root entry in /etc/shadow had an empty password
    - Was able to connect via SSH with a blank password
  -  Ran "password -e root" to set the password to expired
     - Was able to set the password to blank when making a new password on the next SSH connection
     - Confirmed that the root entry in /etc/shadow had an empty password
     - Started a new SSH session using the blank password

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
