### PR TITLE
Revert "[scarthgap] Always enable ssh"

### DIFF
--- a/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/recipes-connectivity/openssh/openssh_%.bbappend
@@ -16,9 +16,13 @@ do_patch_oe_source () {
 addtask patch_oe_source after do_patch before do_configure
 
 do_install:append () {
-	sed -i '/check_for_no_start() {/a \
-	# Ignore sshd.enabled in /etc/natinst/share/ni.rt.ini\
-	enable="true"' ${D}${sysconfdir}/init.d/sshd
+	sed 's|check_for_no_start() {|&\
+	# if sshd is not enabled in ni-rt.ini, do not start sshd\
+	enable=`/usr/local/natinst/bin/nirtcfg --get section=SystemSettings,token=sshd.enabled,value="false" \|tr "[:upper:]" "[:lower:]"`\
+	if [ "$enable" != "true" ]; then\
+		[ "${VERBOSE}" != "no" ] \&\& echo "SSHD not enabled in ni-rt.ini"\
+		exit 0\
+	fi|' -i ${D}${sysconfdir}/init.d/sshd
 
 	# customize sshd_config
 	sed -e 's|^[#[:space:]]*Banner .*|Banner /etc/issue.net|' \

--- a/recipes-core/images/includes/nilrt-proprietary.inc
+++ b/recipes-core/images/includes/nilrt-proprietary.inc
@@ -18,7 +18,6 @@ NI_PROPRIETARY_COMMON_PACKAGES = "\
         ni-software-installation-websvc \
         ni-ssl-webserver-support \
         ni-sysapi \
-        ni-sysapi-sshcli \
         ni-sysapi-remote \
         ni-sysmgmt-auth-utils \
         ni-system-webserver \

--- a/recipes-core/packagegroups/packagegroup-ni-safemode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-safemode.bb
@@ -18,6 +18,7 @@ RDEPENDS:${PN} = " \
 	ni-netcfgutil \
 	ni-shutdown-guard-safemode \
 	ni-systemimage \
+	sysconfig-settings-ssh \
 "
 
 # GPU firmware, included as split packages to conserve space

--- a/recipes-ni/sysconfig-settings/files/systemsettings/target_common.ini
+++ b/recipes-ni/sysconfig-settings/files/systemsettings/target_common.ini
@@ -15,6 +15,9 @@ DefaultValue=FALSE
 
 [sshdEnable]
 Attr=335544320
-ReadOnly=TRUE
+ChangeRequiresReboot=TRUE
+RedirectFile="/etc/natinst/share/ni-rt.ini"
+RedirectSection="SYSTEMSETTINGS"
+RedirectValue="sshd.enabled"
 Type=bool
-Value=TRUE
+DefaultValue=FALSE

--- a/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.binding.xml
+++ b/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.binding.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<binding>
+	<!-- sysattr=SecureShellServerEnabled -->
+	<has sysattr="335544320" />
+</binding>

--- a/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.const.de.xml
+++ b/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.const.de.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<uistrings>
+	<str name="sshd">Secure Shell Server (SSHD) aktivieren</str>
+</uistrings>

--- a/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.const.fr.xml
+++ b/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.const.fr.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<uistrings>
+	<str name="sshd">Activer le serveur Secure Shell (sshd)</str>
+</uistrings>

--- a/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.const.ja.xml
+++ b/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.const.ja.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<uistrings>
+	<str name="sshd">Secure Shellサーバ (sshd) を有効化</str>
+</uistrings>

--- a/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.const.ko.xml
+++ b/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.const.ko.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<uistrings>
+	<str name="sshd">SSH Server (sshd) 활성화</str>
+</uistrings>

--- a/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.const.xml
+++ b/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.const.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<uistrings>
+	<str name="sshd">Enable Secure Shell Server (sshd)</str>
+</uistrings>

--- a/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.const.zh-CN.xml
+++ b/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.const.zh-CN.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<uistrings>
+	<str name="sshd">启用SSH服务器(sshd)</str>
+</uistrings>

--- a/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.def.xml
+++ b/recipes-ni/sysconfig-settings/files/uixml/nilinuxrt.sshd_enable.def.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<item>
+	<group id="startupsettings" caption="{startupsettings}" weight="100" order="0">
+		<!-- sysattr=SecureShellServerEnabled -->
+		<property id="sshd" caption="{sshd}" sysattr="335544320" writable="true" order="600" />
+	</group>
+</item>

--- a/recipes-ni/sysconfig-settings/sysconfig-settings.bb
+++ b/recipes-ni/sysconfig-settings/sysconfig-settings.bb
@@ -146,6 +146,26 @@ pkg_prerm_ontarget:${PN}-console () {
 	rm -f ${systemsettingsdir}/consoleout.ini
 }
 
+
+# sysconfig-settings-ssh package
+PACKAGES += "${PN}-ssh"
+SUMMARY:${PN}-ssh = "System configuration files for ssh"
+DESCRIPTION:${PN}-ssh = "SSH configuration files for the National Instruments System Configuration subsystem."
+
+SRC_URI:append = "\
+	file://uixml/nilinuxrt.sshd_enable.binding.xml \
+	file://uixml/nilinuxrt.sshd_enable.const.de.xml \
+	file://uixml/nilinuxrt.sshd_enable.const.fr.xml \
+	file://uixml/nilinuxrt.sshd_enable.const.ja.xml \
+	file://uixml/nilinuxrt.sshd_enable.const.ko.xml \
+	file://uixml/nilinuxrt.sshd_enable.const.xml \
+	file://uixml/nilinuxrt.sshd_enable.const.zh-CN.xml \
+	file://uixml/nilinuxrt.sshd_enable.def.xml \
+"
+
+FILES:${PN}-ssh = "${uixmldir}/nilinuxrt.sshd_enable.*"
+
+
 # sysconfig-settings-ui package
 PACKAGES += "${PN}-ui"
 SUMMARY:${PN}-ui = "System configuration files to enable UI"


### PR DESCRIPTION
### Summary of Changes

Revert changes to always enable ssh i.e., https://github.com/ni/meta-nilrt/pull/1067 as this causes build failures due to rtos-nifeed not containing `ni-sysapi-sshcli` pacakge (due to update-depslock failures).

WI: [AB#4009943](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/4009943)

### Testing

None. Simple revert.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
