### PR TITLE
sshd_config: Enable KbdInteractiveAuthentication

### DIFF
--- a/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/recipes-connectivity/openssh/openssh_%.bbappend
@@ -27,6 +27,7 @@ do_install:append () {
 	# customize sshd_config
 	sed -e 's|^[#[:space:]]*Banner .*|Banner /etc/issue.net|' \
 		-e 's|^[#[:space:]]*UseDNS .*|UseDNS no|' \
+		-e 's|^[#[:space:]]*KbdInteractiveAuthentication .*|KbdInteractiveAuthentication yes|' \
 		-e 's|^[#[:space:]]*PasswordAuthentication .*|PasswordAuthentication yes|' \
 		-e 's|^[#[:space:]]*PermitEmptyPasswords .*|PermitEmptyPasswords yes|' \
 		-e 's|^[#[:space:]]*PermitRootLogin .*|PermitRootLogin yes|' \


### PR DESCRIPTION
### Summary of Changes

Updates the OpenSSH bbappend to modify the NILRT sshd_config file to enable KbdInteractiveAuth.

[AB#3918226](https://dev.azure.com/ni/DevCentral/_workitems/edit/3918226)

### Justification

This will allow users to detect an expired password in non-interactive scenarios while keeping SSH and login behaviors the same. The change is required in the scarthgap branch to support the changes already being made in Hardware Manager for our set on first use plan. Dan's PR that relies on this is here: https://dev.azure.com/ni/DevCentral/_git/ni-central/pullrequest/1279679. 

Unlike in the previous iteration of this change that was reverted (0447f76), this change will keep PasswordAuthentication enabled. This will allow automated workflows to SSH into devices using a blank password without being prompted to enter that password and should not disrupt the ability to use KbdInteractiveAuth.


### Testing

- On a cRIO-9033 with ni-auth installed:
  - Confirmed that the sshd_config file has KbdInteractiveAuthentication set to 'yes'
  - Confirmed that users are still able to log in with admin/blank
  - Confirmed that there is no password prompt when the password is blank

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
