### PR TITLE
ni-acctsync: De-expire password during sync

### DIFF
--- a/recipes-ni/ni-acctsync/files/ni-acctsync
+++ b/recipes-ni/ni-acctsync/files/ni-acctsync
@@ -17,6 +17,18 @@ get_root_line() {
     grep "^root:" "$1"
 }
 
+check_expired()
+{
+    ROOT_LINE=$(get_root_line "$1")
+    LAST_CHANGED=$(echo "$ROOT_LINE" | cut -d':' -f3)
+
+    if [ "$LAST_CHANGED" = "0" ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
 check_hash_equality()
 {
     SHARED_HASH_PATH="$1"
@@ -96,6 +108,11 @@ insert_root_hash()
             chown --reference="$DEST" "$TMP_SHADOW"
             awk -F: -v OFS=":" -v shadow_hash="$SHADOW_HASH" '$1 == "root" { $2 = shadow_hash } { print }' "$DEST" > "$TMP_SHADOW"
             mv "$TMP_SHADOW" "$DEST"
+            chage --lastday "$(date +%F)" root
+        fi
+    else
+        if check_expired "$DEST"; then
+            chage --lastday "$(date +%F)" root
         fi
     fi
 }
@@ -130,14 +147,18 @@ case "$1" in
         ;;
 
     stop)
-        log "Syncing root info to shared shadow file..."
+        if ! check_expired "$SYS_SHADOW"; then
+            log "Syncing root info to shared shadow file..."
 
-        if [ ! -f "$SHARED_SHADOW" ]; then
-            log "Creating shared shadow file..."
-            touch "$SHARED_SHADOW"
-            chmod 400 "$SHARED_SHADOW"
+            if [ ! -f "$SHARED_SHADOW" ]; then
+                log "Creating shared shadow file..."
+                touch "$SHARED_SHADOW"
+                chmod 400 "$SHARED_SHADOW"
+            fi
+            extract_root_hash "$SYS_SHADOW" "$SHARED_SHADOW"
+        else
+            log "Password is expired. Stopping sync."
         fi
-        extract_root_hash "$SYS_SHADOW" "$SHARED_SHADOW"
         ;;
 
     restart|force-reload)


### PR DESCRIPTION
### Summary of Changes

Update the ni-acctsync init script to clear the expired state on the system shadow file when syncing from the shared shadow file. This is required so the safemode does not get stuck in an expired state when the shared shadow file exists.

This commit also updates ni-acctsync to avoid creating the shared shadow file and syncing to it when the system root password is expired. This is required for the system to stay in the expired password state until a password is explicitly set.


### Justification

- When inserting the shared hash into the system shadow file, set the last changed date field in the shadow file.
    - This clears the expired state
- Check if the system shadow file has an expired root entry before syncing to the shared shadow file
    - If the system root entry is expired do not create the shared shadow file and do not sync to it


### Testing

- On a cRIO-9033 with ni-auth removed:
    - Confirmed that if the shared .shadow file doesn't exist and the root password is expired "ni-acctsync stop" does not create the shadow file
    - Confirmed that if the shared .shadow file doesn't exist and the root password is not expired "ni-acctsync stop" creates the shadow file and syncs to it
    - Confirmed that if the root password is expired "ni-acctsync start" makes it no longer expired if the shared shadow file exists
    - Confirmed that if the root password is expired "ni-acctsync start" leaves it expired if the shared shadow file does not exist
    - Confirmed that if the root password is expired "ni-acctsync start" leaves it expired if the shared shadow file contains an invalid hash 

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
