### PR TITLE
sshd_config: Enable KbdInteractiveAuthentication

### DIFF
--- a/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/recipes-connectivity/openssh/openssh_%.bbappend
@@ -23,7 +23,8 @@ do_install:append () {
 	# customize sshd_config
 	sed -e 's|^[#[:space:]]*Banner .*|Banner /etc/issue.net|' \
 		-e 's|^[#[:space:]]*UseDNS .*|UseDNS no|' \
-		-e 's|^[#[:space:]]*PasswordAuthentication .*|PasswordAuthentication yes|' \
+		-e 's|^[#[:space:]]*KbdInteractiveAuthentication .*|KbdInteractiveAuthentication yes|' \
+		-e 's|^[#[:space:]]*PasswordAuthentication .*|PasswordAuthentication no|' \
 		-e 's|^[#[:space:]]*PermitEmptyPasswords .*|PermitEmptyPasswords yes|' \
 		-e 's|^[#[:space:]]*PermitRootLogin .*|PermitRootLogin yes|' \
 		-e 's|^[#[:space:]]*ChallengeResponseAuthentication .*|ChallengeResponseAuthentication no|' \


### PR DESCRIPTION
### Summary of Changes

Updates the OpenSSH bbappend to modify the NILRT sshd_config file to enable KbdInteractiveAuth and disable PasswordAuthentication.

[AB#3918226](https://dev.azure.com/ni/DevCentral/_workitems/edit/3918226)

### Justification

This will allow users to detect an expired password in non-interactive scenarios while keeping SSH and login behaviors the same.


### Testing

- On a cRIO-9033 with ni-auth installed:
  - Confirmed that users are still able to log in with admin/<blank password>
    - One difference is that you are prompted for the blank password. This may need a change in ni-auth.
  - Confirmed that users can set a non-blank password and log in.
- On a cRIO-9033 without ni-auth
  - Confirmed that users are able to log in with root/<blank password>
  - Confirmed that users are able to change the root password with passwd and then log in with it
  - Confirmed that users are able to update an expired root password and log in

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
