### PR TITLE
perf: remove obsolete Zynq source exclusions

### DIFF
--- a/recipes-kernel/perf/perf.bbappend
+++ b/recipes-kernel/perf/perf.bbappend
@@ -1,9 +1,0 @@
-
-# NILRT ARM images use linux kernel 4.14 - which does not support perf
-# scripting using python3. Disable `scripting` PACKAGECONFIG in that case, to
-# keep python3 out of the perf config.
-PACKAGECONFIG:remove:xilinx-zynq = "scripting"
-
-# Older xilinx-zynq kernels do not ship the arm64-only perf source fragments
-# listed by the upstream recipe, so avoid probing for them during configure.
-PERF_SRC:remove:xilinx-zynq = "arch/arm64/tools include/uapi/asm-generic/Kbuild"


### PR DESCRIPTION
Fix for failing `bitbake packagegroup-ni-desirable` that I forgot to build for https://github.com/ni/meta-nilrt/pull/1060

### Justification

WI: [AB#3966413](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3966413)

### Testing

* [x] `bitbake packagegroup-ni-desirable`

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
