### PR TITLE
populateconfig: setgid /etc/natinst/share/certstore/server_certs

### DIFF
--- a/recipes-ni/initscripts-nilrt/files/populateconfig
+++ b/recipes-ni/initscripts-nilrt/files/populateconfig
@@ -65,7 +65,7 @@ then
 	chmod 700 "/etc/natinst/share/certstore/open_csrs"
 
 	chown webserv:niwscerts "/etc/natinst/share/certstore/server_certs"
-	chmod 750 "/etc/natinst/share/certstore/server_certs"
+	chmod 2750 "/etc/natinst/share/certstore/server_certs"
 
 	chown webserv:root "/etc/natinst/share/certstore/temp"
 	chmod 700 "/etc/natinst/share/certstore/temp"


### PR DESCRIPTION
Certain utilities run as the superuser may manipulate keys/certificates in /etc/natinst/share/certstore/server_certs, whose contents must be readable by the webserver (user webserv). To ensure that files created by the superuser are readable here, mark the directory setgid, so that group niwscerts (of which webserv is a member) can read them.

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
