### PR TITLE
ni-factory-reset: Create a recipe for the ni-factory-reset tool

### DIFF
--- a/recipes-core/packagegroups/packagegroup-ni-base.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-base.bb
@@ -62,6 +62,7 @@ RDEPENDS:${PN} += "\
 	modutils-initscripts \
 	netbase \
 	ni-acctsync \
+	ni-factory-reset \
 	ni-hw-scripts \
 	ni-rtfeatures \
 	ni-safemode-utils \

--- a/recipes-ni/ni-factory-reset/files/ni-factory-reset
+++ b/recipes-ni/ni-factory-reset/files/ni-factory-reset
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -euo pipefail
+
+quiet=false
+
+while getopts ":q" opt; do
+    case "$opt" in
+        q) quiet=true ;;
+        \?)
+            echo "Usage: ${0##*/} [-q]" >&2
+            exit 2
+            ;;
+    esac
+done
+
+shift $((OPTIND - 1))
+if (( $# != 0 )); then
+    echo "Usage: ${0##*/} [-q]" >&2
+    exit 2
+fi
+
+if [[ "$EUID" -ne 0 ]]; then
+    echo "This utility must be run as root." >&2
+    exit 1
+fi
+
+if [[ "$quiet" == false ]]; then
+    echo "This will reset the root password to its out-of-box state. You will be required to set a new root password the next time you connect to this machine."
+
+    if ! read -r -p "Do you wish to continue? [y/N] " response; then
+        echo
+        response=""
+    fi
+
+    case "$response" in
+        [yY]|[yY][eE][sS]) ;;
+        *)
+            echo "Password reset canceled."
+            exit 0
+            ;;
+    esac
+fi
+
+passwd -d root >/dev/null
+passwd -e root >/dev/null
+rm -f /etc/natinst/share/.shadow
+
+if [[ "$quiet" == false ]]; then
+    echo "The root password was successfully reset."
+fi

--- a/recipes-ni/ni-factory-reset/ni-factory-reset.bb
+++ b/recipes-ni/ni-factory-reset/ni-factory-reset.bb
@@ -1,0 +1,16 @@
+SUMMARY = "NI Linux Real-Time factory reset utility"
+DESCRIPTION = "Installs the ni-factory-reset administrative utility"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+SECTION = "base"
+
+SRC_URI = "file://ni-factory-reset"
+
+S = "${UNPACKDIR}"
+
+RDEPENDS:${PN} += "bash shadow"
+
+do_install () {
+	install -d ${D}${sbindir}
+	install -m 0700 ${S}/ni-factory-reset ${D}${sbindir}/ni-factory-reset
+}


### PR DESCRIPTION
### Summary of Changes

Create a new ni-factory-reset utility in the /usr/sbin directory that allows users to reset a NILRT device to a state where the root password is blank, expired, and no shared shadow file exists. This will force a new password to be set.


### Justification

Users need an easy way to reset NILRT devices to a set on first use state. Setting the root password to be both blank and expired while deleting the shared .shadow file accomplishes this.

[AB#3926996](https://dev.azure.com/ni/DevCentral/_workitems/edit/3926996)


### Testing

On a cRIO-9033
- Confirmed that the ni-factory-reset exists in /usr/sbin on runmode and safemode
- Confirmed that running ni-factory-reset prompts the user for confirmation before setting the root password to be blank and expired
- Confirmed that running ni-factory-reset deletes /etc/natinst/share/.shadow if it exists
- Confirmed that ni-factory-reset does not throw an error if /etc/natinst/share/.shadow does not exist
- Confirmed that running "ni-factory-reset -q" runs the script without any console input or output

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
