### PR TITLE
nilrt-image-base: Make password expired by default

### DIFF
--- a/recipes-core/images/includes/nilrt-image-base.inc
+++ b/recipes-core/images/includes/nilrt-image-base.inc
@@ -1,5 +1,7 @@
 # This image is bootable to a console with package management support
 
+inherit extrausers
+
 # useradd and groupadd need to be on sysroot
 do_rootfs[depends] += "shadow-native:do_populate_sysroot"
 
@@ -13,6 +15,8 @@ IMAGE_INSTALL += "\
 	packagegroup-ni-base \
 	packagegroup-ni-tzdata \
 "
+
+EXTRA_USERS_PARAMS += "passwd-expire root;"
 
 addtask image_build_test before do_rootfs
 


### PR DESCRIPTION
### Summary of Changes

Update nilrt-image-base.inc to have the root password by expired by default.


### Justification

Update the NILRT images to have expired passwords by default. This is a requirement for our set on first use policy.

[AB#3918293](https://dev.azure.com/ni/DevCentral/_workitems/edit/3918293)

### Testing

On a cRIO-9033

- Confirmed that the runmode image had an expired password after installation
- Confirmed that the safemode image had an expired password after installation

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
