### PR TITLE
format.sh: Preserve password with network settings

### DIFF
--- a/recipes-ni/ni-systemformat/ni-systemformat.bb
+++ b/recipes-ni/ni-systemformat/ni-systemformat.bb
@@ -70,6 +70,7 @@ RDEPENDS:${PN} += "\
 	pkgconfig \
 	ni-netcfgutil \
 	niacctbase \
+	shadow \
 	util-linux-lsblk \
 	util-linux-logger \
 "

--- a/recipes-ni/ni-systemformat/ni-systemformat/src/lib/format.sh
+++ b/recipes-ni/ni-systemformat/ni-systemformat/src/lib/format.sh
@@ -295,12 +295,20 @@ function format_rootfs_or_userfs_nomount()
 # restores system configuration, if necessary.
 function format_rootfs_or_userfs_nosvc()
 {
-	# Backup the shared .shadow file to the tmp dir.
-	if [ -f "$CONFIG_MOUNT_POINT/.shadow" ]; then
-		mkdir -p "$ACCTINFO_TMP" &&
-			cp "$CONFIG_MOUNT_POINT/.shadow" "$ACCTINFO_TMP" ||
-			return $?
-	fi
+	# Backup the shared .shadow file when preserving network configuration.
+	local expire_root_password=no
+	case "$NETCFG_MODE" in
+		all|primary|bypass)
+			if [ -f "$CONFIG_MOUNT_POINT/.shadow" ]; then
+				mkdir -p "$ACCTINFO_TMP" &&
+					cp "$CONFIG_MOUNT_POINT/.shadow" "$ACCTINFO_TMP" ||
+					return $?
+			fi
+			;;
+		none)
+			expire_root_password=yes
+			;;
+	esac
 
 	# Backup the restore files to the tmp dir. Do this even if we're only
 	# reformatting the configfs, because under some configurations,
@@ -338,6 +346,18 @@ function format_rootfs_or_userfs_nosvc()
 		mv -f "$ACCTINFO_TMP/.shadow" "$CONFIG_MOUNT_POINT" &&
 			rmdir "$ACCTINFO_TMP"	|| { local rc=$?; (( ret )) || ret=$rc; }
 	fi
+
+	# Expire the root password without invoking PAM or ni-acctsync, then remove
+	# the shared shadow file so it is not recreated on reboot.
+	if [ "$expire_root_password" = yes ]; then
+		chage --lastday 0 root ||
+			{ local rc=$?; (( ret )) || ret=$rc; }
+		if mountpoint -q "$CONFIG_MOUNT_POINT"; then
+			rm -f "$CONFIG_MOUNT_POINT/.shadow" ||
+				{ local rc=$?; (( ret )) || ret=$rc; }
+		fi
+	fi
+
 	return $ret
 }
 


### PR DESCRIPTION
### Summary of Changes

Add a case structure in the format script that only preserves the shared .shadow file when network settings are preserved.


### Justification

We should allow users to have some way of deleting the shared .shadow file during a format, similar to how the ni-auth database was handled. Coupling it with the option to preserve network settings makes sense and should work for now.

[AB#3918230](https://dev.azure.com/ni/DevCentral/_workitems/edit/3918230)


### Testing
On a cRIO-9033:
- Ran the format script through HWM, selected not to preserve network settings and confirmed that the .shadow file was deleted
- Ran the format script through HWM, selected to preserve some network settings and confirmed that the .shadow file was preserved
- Ran the format script through HWM, selected to preserve all network settings and confirmed that the .shadow file was preserved

* [X] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [X] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
