### PR TITLE
Fix wifi on ARM

### DIFF
--- a/recipes-bsp/u-boot/files/bootscript.txt
+++ b/recipes-bsp/u-boot/files/bootscript.txt
@@ -10,15 +10,15 @@ if fdt addr ${loadaddr} && fdt get value rd_desc /images/ramdisk-1 description; 
   # usb host or device mode switching
   if test -n ${otg_usb_en} && test ${otg_usb_en} -eq 1; then
     fdt addr ${loadaddr} && fdt get value fdtname /configurations/conf-ni-${DeviceCode}.dtb fdt && fdt get addr fdtaddr /images/${fdtname} data && fdt addr ${fdtaddr} && if itest.l ${usb_otgsc_id:-ffffffff} == 0; then
-      fdt set /amba@0/usb@${otg_usb_base_addr} dr_mode host;
+      fdt set /axi/usb@${otg_usb_base_addr} dr_mode host;
     elif itest.l ${usb_otgsc_id:-ffffffff} == 100; then
-      fdt set /amba@0/usb@${otg_usb_base_addr} dr_mode peripheral;
+      fdt set /axi/usb@${otg_usb_base_addr} dr_mode peripheral;
     fi;
   fi
 
   # wireless region switching
   if test -n ${wirelessRegionFactory} && test -n ${wireless_board_id} && test -n ${wlan_sdio_base_addr}; then
-    fdt addr ${loadaddr} && fdt get value fdtname /configurations/conf-ni-${DeviceCode}.dtb fdt && fdt get addr fdtaddr /images/${fdtname} data && fdt addr ${fdtaddr} && fdt set /amba@0/sdhci@${wlan_sdio_base_addr}/wlan@0 atheros,board-id ${wireless_board_id} && fdt set /amba@0/sdhci@${wlan_sdio_base_addr}/wlan@0 atheros,region-code ${wirelessRegionFactory};
+    fdt addr ${loadaddr} && fdt get value fdtname /configurations/conf-ni-${DeviceCode}.dtb fdt && fdt get addr fdtaddr /images/${fdtname} data && fdt addr ${fdtaddr} && fdt set /axi/mmc@${wlan_sdio_base_addr}/wlan@0 atheros,board-id ${wireless_board_id} && fdt set /axi/mmc@${wlan_sdio_base_addr}/wlan@0 atheros,region-code ${wirelessRegionFactory};
   fi
 
   # cRIO-9068 doesn't have USB gadget, so skip it on that device
@@ -54,15 +54,15 @@ else
   # usb host or device mode switching
   if test -n ${otg_usb_en} && test ${otg_usb_en} -eq 1; then
     fdt addr ${loadaddr} && fdt get value fdtname /configurations/conf-ni-${DeviceCode}.dtb fdt && fdt get addr fdtaddr /images/${fdtname} data && fdt addr ${fdtaddr} && if itest.l ${usb_otgsc_id:-ffffffff} == 0; then
-      fdt set /amba@0/usb@${otg_usb_base_addr} dr_mode host;
+      fdt set /axi/usb@${otg_usb_base_addr} dr_mode host;
     elif itest.l ${usb_otgsc_id:-ffffffff} == 100; then
-      fdt set /amba@0/usb@${otg_usb_base_addr} dr_mode peripheral;
+      fdt set /axi/usb@${otg_usb_base_addr} dr_mode peripheral;
     fi;
   fi
 
   # wireless region switching
   if test -n ${wirelessRegionFactory} && test -n ${wireless_board_id} && test -n ${wlan_sdio_base_addr}; then
-    fdt addr ${loadaddr} && fdt get value fdtname /configurations/conf-ni-${DeviceCode}.dtb fdt && fdt get addr fdtaddr /images/${fdtname} data && fdt addr ${fdtaddr} && fdt set /amba@0/sdhci@${wlan_sdio_base_addr}/wlan@0 atheros,board-id ${wireless_board_id} && fdt set /amba@0/sdhci@${wlan_sdio_base_addr}/wlan@0 atheros,region-code ${wirelessRegionFactory};
+    fdt addr ${loadaddr} && fdt get value fdtname /configurations/conf-ni-${DeviceCode}.dtb fdt && fdt get addr fdtaddr /images/${fdtname} data && fdt addr ${fdtaddr} && fdt set /axi/mmc@${wlan_sdio_base_addr}/wlan@0 atheros,board-id ${wireless_board_id} && fdt set /axi/mmc@${wlan_sdio_base_addr}/wlan@0 atheros,region-code ${wirelessRegionFactory};
   fi
 
   # cRIO-9068 doesn't have USB gadget, so skip it on that device

--- a/recipes-core/packagegroups/packagegroup-base.bbappend
+++ b/recipes-core/packagegroups/packagegroup-base.bbappend
@@ -1,7 +1,0 @@
-
-# The `wireless-regdb-static` subpackage installs static databases for wireless
-# regulatory negotiation. NILRT uses CRDA for run-time negotiation, so these
-# databse files are superfluous. They also CONFLICT with `wireless-regdb` and
-# so need to be removed.
-RDEPENDS:packagegroup-base-wifi:remove = "wireless-regdb-static"
-RDEPENDS:packagegroup-base-wifi += "wireless-regdb"

--- a/recipes-core/packagegroups/packagegroup-ni-wifi.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-wifi.bb
@@ -10,14 +10,13 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 inherit packagegroup
 
 RDEPENDS:${PN} = "\
-	crda \
 	iw \
 	libnl \
 	ni-wireless-ath6kl-fw \
 	openssl \
 	rfkill \
 	wpa-supplicant \
-	wireless-regdb \
+	wireless-regdb-static \
 "
 
 RDEPENDS:${PN}:append:xilinx-zynq = " \


### PR DESCRIPTION
### Summary of Changes

Fix wifi on ARM for targets using atheros chip.
Replace legacy CRDA and wireless-regdb with wireless-regdb-static.

Related: WI: [AB#3990501](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3990501)

### Testing

* [x] Built ARM BSI, x64 BSI
* [x] Installed BSI on Elvis III and cRIO-9037.
* [x] Verified wifi works on Elvis III and cRIO-9037.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
