### PR TITLE
[Linux RT] Increase ESP size for systems with disks larger than 32GB .

### DIFF
--- a/recipes-core/initrdscripts/files/ni_provisioning.safemode.common
+++ b/recipes-core/initrdscripts/files/ni_provisioning.safemode.common
@@ -164,13 +164,24 @@ set_serial_port()
 
 partitioning_disk()
 {
+	DISK_SIZE_BYTES=$(lsblk -bnd -o SIZE "$TARGET_DISK")
+	DISK_SIZE_GB=$((DISK_SIZE_BYTES / 1024 / 1024 / 1024))
+	if [ "$DISK_SIZE_GB" -ge 32 ]; then
+    	PART1_END=100
+		PART2_END=284
+		PART3_END=348
+	else
+    	PART1_END=16
+    	PART2_END=200
+    	PART3_END=216
+	fi
 	umount "$TARGET_DISK"? 2>/dev/null || true
 	print_info "Partitioning TARGET_DISK=$TARGET_DISK (PART_STYLE=$PART_STYLE)..."
 	PARTED_ERROR=`parted -s $TARGET_DISK mklabel $PART_STYLE 2>&1` || die "$PARTED_ERROR"
-	PARTED_ERROR=`parted -s --align optimal $TARGET_DISK mkpart $PART1_NAME 1MB 16MB 2>&1` || die "$PARTED_ERROR"
-	PARTED_ERROR=`parted -s --align optimal $TARGET_DISK mkpart $PART2_NAME 16MB 200MB 2>&1` || die "$PARTED_ERROR"
-	PARTED_ERROR=`parted -s --align optimal $TARGET_DISK mkpart $PART3_NAME 200MB 216MB 2>&1` || die "$PARTED_ERROR"
-	PARTED_ERROR=`parted -s --align optimal $TARGET_DISK mkpart $PART4_NAME 216MB 100% 2>&1` || die "$PARTED_ERROR"
+	PARTED_ERROR=`parted -s --align optimal $TARGET_DISK mkpart $PART1_NAME 1MB ${PART1_END}MB 2>&1` || die "$PARTED_ERROR"
+	PARTED_ERROR=`parted -s --align optimal $TARGET_DISK mkpart $PART2_NAME ${PART1_END}MB ${PART2_END}MB 2>&1` || die "$PARTED_ERROR"
+	PARTED_ERROR=`parted -s --align optimal $TARGET_DISK mkpart $PART3_NAME ${PART2_END}MB ${PART3_END}MB 2>&1` || die "$PARTED_ERROR"
+	PARTED_ERROR=`parted -s --align optimal $TARGET_DISK mkpart $PART4_NAME ${PART3_END}MB 100% 2>&1` || die "$PARTED_ERROR"
 	print_done
 
 	print_info "Assigning EFI System Partition..."


### PR DESCRIPTION
### Summary of Changes
[AB#4011590](https://dev.azure.com/ni/DevCentral/_workitems/edit/4011590)

- Added disk size detection during provisioning using lsblk.
- Increased ESP size to ~100MB and niconfig to ~64MB for targets with storage equal or larger than 32GB.
- Preserved existing partition layout for devices with less than 32GB storage
- Reduced available rootfs space only on large-capacity systems where the impact is negligible.

### Justification

Upcoming platforms that rely on capsule-based firmware updates
require additional EFI System Partition space to stage capsule
files before reboot.

The existing ESP is approximately 15MB, which is insufficient
for larger firmware capsules.

Instead of maintaining a product-specific allowlist, partition
sizing is based on total disk capacity. This automatically
supports future controllers with sufficient storage while
preserving the current layout on storage-constrained devices.

### Testing
Validation performed using the updated recovery media.
Large-capacity system:
Target: PXIe-8881
Disk size: ~477GB

Verified that the larger ESP layout was applied. FYI, 
<img width="775" height="238" alt="Screenshot 2026-09-03 145941" src="https://github.com/user-attachments/assets/8f61585f-b036-485f-927c-e917ba9444fb" />

* [ ] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
