### PR TITLE
fwupd: enable UEFI capsule/PK plugins and conditional udisks2 

### DIFF
--- a/conf/distro/nilrt.conf
+++ b/conf/distro/nilrt.conf
@@ -10,6 +10,7 @@ DISTRO_FEATURES:append:x64 = "\
         x11 \
         opengl \
         create-spdx \
+        polkit \
 "
 
 INHERIT += " create-spdx "

--- a/recipes-bsp/fwupd/fwupd_%.bbappend
+++ b/recipes-bsp/fwupd/fwupd_%.bbappend
@@ -1,0 +1,5 @@
+# Enable UEFI capsule update support for NI Linux RT x64 targets
+PACKAGECONFIG:append:x64 = " plugin_uefi_capsule plugin_uefi_pk"
+
+# ESP mounting support for fwupdtool when polkit is enabled
+RRECOMMENDS:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'polkit', 'udisks2', '', d)}"


### PR DESCRIPTION
### Summary of Changes
-Add a fwupd bbappend in meta-nilrt . 
-Enable plugin_uefi_capsule and plugin_uefi_pk through PACKAGECONFIG so capsule updates are built in.
-Add conditional udisks2 runtime recommendation when polkit is enabled to support ESP discovery in fwupdtool.
-Update distro config to include polkit in DISTRO_FEATURES for ESP discovery

### Justification

 [AB#4011535](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/4011535)


### Testing

* [x] bitbake fwupd
* [x] bitbake nilrt-base-system-image
<img width="1029" height="800" alt="Screenshot 2026-09-07 163532" src="https://github.com/user-attachments/assets/8bd91907-396b-479c-9fe4-492de8adf118" />
<img width="844" height="588" alt="Screenshot 2026-09-07 163540" src="https://github.com/user-attachments/assets/a62d6d8d-6a28-4a01-95d2-b5469dc72212" />


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
