### PR TITLE
Add root NIAuth user to fix web-service auth in run mode

### DIFF
--- a/recipes-core/images/includes/nilrt-proprietary.inc
+++ b/recipes-core/images/includes/nilrt-proprietary.inc
@@ -37,6 +37,7 @@ NI_PROPRIETARY_COMMON_PACKAGES:append:x64 = "\
 
 NI_PROPRIETARY_RUNMODE_PACKAGES = "\
         ni-arch-gen \
+        ni-niauth-root-user \
 "
 
 # SystemLink dependencies

--- a/recipes-ni/ni-niauth-root-user/files/ni-niauth-root-user
+++ b/recipes-ni/ni-niauth-root-user/files/ni-niauth-root-user
@@ -1,0 +1,85 @@
+#! /bin/sh
+#
+# Seed a 'root' user into the NIAuth database on first boot.
+#
+# The NI System Web Server authenticates WebDAV/SIWS requests via mod_niauth
+# against the NIAuth DB (registry.bin), keyed by the NIAuth *user name*. The DB
+# ships with only the built-in 'admin' user, so web-service calls presenting the
+# name 'root' cannot authenticate. This adds a 'root' NIAuth account (blank
+# password, administrators group) once; it does not touch the local /etc/shadow
+# root account.
+
+log() { logger -p auth.info "[niauth-root-seed] $1"; }
+
+find_util() {
+    for c in niauthutil /usr/local/natinst/bin/niauthutil /usr/bin/niauthutil; do
+        if command -v "$c" >/dev/null 2>&1; then
+            echo "$c"
+            return 0
+        fi
+    done
+    return 1
+}
+
+seed_root() {
+    UTIL="$(find_util)" || { log "niauthutil not found; skipping"; return 0; }
+
+    # No wait loop: init order is S05 niauth -> S25 systemWebServer -> S99 (this),
+    # so the daemon is long up and admin's permissions are already seeded by the
+    # time we run. If the daemon somehow isn't answering, skip and let the next
+    # boot reconcile, rather than adding boot latency.
+    if ! "$UTIL" list-users >/dev/null 2>&1; then
+        log "niauth daemon not responding; will reconcile next boot"
+        return 0
+    fi
+
+    # Create the account once. We never recreate/repassword an existing 'root'
+    # (avoids clobbering a password an operator may set later). list-users prints
+    # names space-separated.
+    if ! "$UTIL" list-users 2>/dev/null | tr ' ' '\n' | grep -qx "root"; then
+        if ! "$UTIL" create-user -i -u root; then
+            log "create-user root failed"
+            return 0
+        fi
+        # Blank password: non-interactive stdin is read as a single line.
+        echo "" | "$UTIL" set-password-for-user -u root || log "set blank password failed"
+        log "root NIAuth user seeded"
+    fi
+
+    "$UTIL" add-user-to-group -i -u root -g administrators || log "add root to administrators failed"
+
+    # admin's permission set is assembled by the NI web server from many services
+    # (granted directly to the 'admin' name), so we can't enumerate it ourselves;
+    # we mirror whatever admin currently holds. Compare counts as a cheap gate:
+    # equal -> already in sync, or admin not seeded yet (both zero) -> do nothing;
+    # unequal -> grant admin's permissions that root is missing. Effect: copies
+    # once on the first boot after admin is seeded, then no-ops unless the set
+    # changes. Grants persist in the DB (/etc/natinst/share/niauth), so no
+    # per-boot refresh and no timing dependency on service start order.
+    admin_perms="$("$UTIL" list-permissions-for-user -u admin 2>/dev/null)"
+    root_perms="$("$UTIL" list-permissions-for-user -u root 2>/dev/null)"
+    if [ "$(printf '%s' "$admin_perms" | wc -w)" -ne "$(printf '%s' "$root_perms" | wc -w)" ]; then
+        rp=" $root_perms "
+        # Flags: -u <user>, -p <permission>.
+        for p in $admin_perms; do
+            case "$rp" in
+                *" $p "*) ;;
+                *) "$UTIL" grant-permission-to-user -u root -p "$p" || log "grant $p to root failed" ;;
+            esac
+        done
+    fi
+}
+
+case "$1" in
+    start)
+        seed_root
+        ;;
+    stop | restart | force-reload)
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart|force-reload}"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/recipes-ni/ni-niauth-root-user/ni-niauth-root-user.bb
+++ b/recipes-ni/ni-niauth-root-user/ni-niauth-root-user.bb
@@ -1,0 +1,26 @@
+SUMMARY = "Seed a 'root' user into the NIAuth database"
+DESCRIPTION = "First-boot init script that adds a 'root' NIAuth account to the \
+administrators group so the NI System Web Server (WebDAV/SIWS) can authenticate \
+web-service calls as 'root'. NIAuth keys its Digest/SRP credentials on the user \
+name, so a distinct 'root' record is required in addition to the built-in \
+'admin' user."
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+LICENSE = "MIT"
+SECTION = "base"
+
+SRC_URI = "\
+        file://ni-niauth-root-user \
+"
+
+S = "${UNPACKDIR}"
+
+inherit update-rc.d
+
+INITSCRIPT_NAME = "ni-niauth-root-user"
+# Start after the niauth daemon (init.d/niauth is S05) in the multi-user runlevels.
+INITSCRIPT_PARAMS = "start 99 2 3 4 5 ."
+
+do_install () {
+        install -d ${D}${sysconfdir}/init.d/
+        install -m 0700 ${S}/ni-niauth-root-user ${D}${sysconfdir}/init.d/
+}


### PR DESCRIPTION
The NI System Web Server authenticates WebDAV/SIWS requests against the NIAuth database by user name. The database ships with only the built-in admin account, so web-service calls that present the name root cannot authenticate.

Creates the `root` user (idempotent, blank password — does not touch shadow) & mirrors admin's permissions to root.

This should no longer be needed once the web-service calls are migrated over to SSH next cycle; at that point the SSH connection should fulfil these authentication requirements.

### Summary of Changes

Adds a new `ni-niauth-root-user` package that seeds a root user into the NIAuth database on first boot, so NI System Web Server (WebDAV/SIWS) calls presenting the name root can authenticate. The DB ships with only the built-in admin account, so root-named web-service requests currently fail auth.


### Justification
[AB#4038327](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/4038327)

### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)

Before (scarthgap - safemode):
<img width="1884" height="186" alt="image" src="https://github.com/user-attachments/assets/217cea9e-8213-4706-8991-7d141d1e83c0" />

After (dist-next - runmode)
<img width="1891" height="261" alt="image" src="https://github.com/user-attachments/assets/684a358f-044b-4b84-ac81-85da12d78e7f" />


** Also verified ` niauthutil list-groups-containing-user` is same for `admin` and `root`.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
