### PR TITLE
recovery: add network support for provisioning tool

### DIFF
--- a/recipes-core/initrdscripts/files/init-restore-mode.sh
+++ b/recipes-core/initrdscripts/files/init-restore-mode.sh
@@ -53,6 +53,13 @@ disable_x64_cstates() {
 	done
 }
 
+load_x64_network_modules() {
+	# Include common physical and virtual NIC drivers used in recovery scenarios.
+	for mod in e1000 e1000e i40e igb igc ixgbe tg3 virtio_pci virtio_net; do
+		modprobe "$mod" 2> /dev/null
+	done
+}
+
 show_console() {
 	while true; do
 		echo ""
@@ -101,6 +108,7 @@ if [[ $ARCH == "x86_64" ]]; then
 	# support VMWare image keyboard
 	modprobe atkbd 2> /dev/null
 	modprobe i8042 2> /dev/null
+	load_x64_network_modules
 	modprobe hv_vmbus 2> /dev/null
 	modprobe hv_balloon 2> /dev/null
 	modprobe hv_storvsc 2> /dev/null

--- a/recipes-core/initrdscripts/files/ni_provisioning
+++ b/recipes-core/initrdscripts/files/ni_provisioning
@@ -24,6 +24,9 @@ early_setup "$@"
 # Source default answer file to prompt user for all questions
 source_default_answer_file
 
+# Enable recovery networking and SSH access for all provisioning flows.
+setup_recovery_network_and_ssh
+
 if in_recovery_mode; then
 	echo "Automatic provision and reboot in recovery mode"
 	PROVISION_REPARTITION_TARGET="y"

--- a/recipes-core/initrdscripts/files/ni_provisioning.common
+++ b/recipes-core/initrdscripts/files/ni_provisioning.common
@@ -717,6 +717,183 @@ source_answer_file()
 	print_verbose "No answer file found; using default configuration"
 }
 
+get_recovery_iface_ipv4()
+{
+	local iface="$1"
+	ifconfig "$iface" 2>/dev/null | awk '/inet addr:/{sub("addr:","",$2); print $2; exit} /inet /{print $2; exit}'
+}
+
+ensure_recovery_udhcpc_script()
+{
+	local script_path="/run/recovery-udhcpc.script"
+
+	if [[ -x "$script_path" ]]; then
+		echo "$script_path"
+		return 0
+	fi
+
+	cat >"$script_path" <<'EOF'
+#!/bin/sh
+
+case "$1" in
+	deconfig)
+		ifconfig "$interface" 0.0.0.0 up
+		;;
+	renew|bound)
+		if [ -n "$subnet" ]; then
+			ifconfig "$interface" "$ip" netmask "$subnet" up
+		else
+			ifconfig "$interface" "$ip" up
+		fi
+		if command -v route >/dev/null 2>&1; then
+			for r in $router; do
+				route add default gw "$r" dev "$interface" 2>/dev/null && break
+			done
+		fi
+		;;
+esac
+
+exit 0
+EOF
+
+	chmod 0755 "$script_path"
+	echo "$script_path"
+}
+
+configure_recovery_interface()
+{
+	local iface="$1"
+	local ip_addr=""
+	local mac=""
+	local byte5=""
+	local byte6=""
+	local ll3=""
+	local ll4=""
+	local have_link="unknown"
+	local udhcpc_script=""
+	local tries=0
+
+	if ! ifconfig "$iface" up >/dev/null 2>&1; then
+		print_warning "Failed to bring up ${iface}"
+		return 1
+	fi
+
+	# Give the link state time to settle after bringing up the interface.
+	for tries in 1 2 3; do
+		if [[ -r "/sys/class/net/${iface}/carrier" ]]; then
+			if [[ "$(cat "/sys/class/net/${iface}/carrier" 2>/dev/null)" == "1" ]]; then
+				have_link="yes"
+				break
+			fi
+		fi
+		sleep 1
+	done
+
+	ip_addr=$(get_recovery_iface_ipv4 "$iface")
+	if [[ -n "$ip_addr" ]]; then
+		echo "Network: ${iface} already has IPv4 ${ip_addr}"
+		return 0
+	fi
+
+	if type udhcpc >/dev/null 2>&1; then
+		udhcpc_script=$(ensure_recovery_udhcpc_script)
+		print_verbose "Attempting DHCP on ${iface}"
+		udhcpc -n -q -t 6 -T 2 -i "$iface" -s "$udhcpc_script" >/dev/null 2>&1 || true
+	else
+		print_warning "udhcpc not available in recovery image"
+	fi
+
+	ip_addr=$(get_recovery_iface_ipv4 "$iface")
+	if [[ -n "$ip_addr" ]]; then
+		echo "Network: ${iface} acquired IPv4 ${ip_addr}"
+		return 0
+	fi
+
+	# Fallback to a deterministic link-local address if DHCP is unavailable.
+	mac=$(cat "/sys/class/net/${iface}/address" 2>/dev/null)
+	if [[ "$mac" =~ ^([[:xdigit:]]{2}:){5}[[:xdigit:]]{2}$ ]]; then
+		byte6=${mac##*:}
+		byte5=${mac%:*}
+		byte5=${byte5##*:}
+		ll3=$((16#$byte5 % 254 + 1))
+		ll4=$((16#$byte6 % 254 + 1))
+		if ifconfig "$iface" "169.254.${ll3}.${ll4}" netmask 255.255.0.0 up >/dev/null 2>&1; then
+			echo "Network: ${iface} using fallback IPv4 169.254.${ll3}.${ll4}"
+			return 0
+		fi
+	fi
+
+	print_warning "No IPv4 address acquired on ${iface} (link=${have_link})"
+	return 1
+}
+
+start_recovery_ssh_server()
+{
+	local sshd_bin="/usr/sbin/sshd"
+	local hostkey_base="/etc/natinst/share/ssh"
+
+	if [[ ! -x "$sshd_bin" ]]; then
+		print_warning "OpenSSH server binary not present in recovery image"
+		return 1
+	fi
+
+	if type pidof >/dev/null 2>&1 && pidof sshd >/dev/null 2>&1; then
+		echo "SSH: sshd already running"
+		return 0
+	fi
+
+	mkdir -p /run/sshd /var/run "$hostkey_base"
+
+	if type ssh-keygen >/dev/null 2>&1; then
+		[[ -f "$hostkey_base/ssh_host_rsa_key" ]] || ssh-keygen -q -t rsa -b 3072 -N "" -f "$hostkey_base/ssh_host_rsa_key" >/dev/null 2>&1
+		[[ -f "$hostkey_base/ssh_host_ecdsa_key" ]] || ssh-keygen -q -t ecdsa -b 256 -N "" -f "$hostkey_base/ssh_host_ecdsa_key" >/dev/null 2>&1
+		[[ -f "$hostkey_base/ssh_host_ed25519_key" ]] || ssh-keygen -q -t ed25519 -N "" -f "$hostkey_base/ssh_host_ed25519_key" >/dev/null 2>&1
+	fi
+
+	"$sshd_bin" \
+		-o PidFile=/var/run/sshd.pid \
+		-o PermitRootLogin=yes \
+		-o PasswordAuthentication=yes \
+		-o PermitEmptyPasswords=yes \
+		-o KbdInteractiveAuthentication=yes \
+		-o ChallengeResponseAuthentication=no \
+		-o UseDNS=no \
+		-o HostKey="$hostkey_base/ssh_host_rsa_key" \
+		-o HostKey="$hostkey_base/ssh_host_ecdsa_key" \
+		-o HostKey="$hostkey_base/ssh_host_ed25519_key" \
+		>/dev/null 2>&1 || {
+			print_warning "Failed to start sshd"
+			return 1
+		}
+
+	echo "SSH: sshd started"
+	return 0
+}
+
+setup_recovery_network_and_ssh()
+{
+	local net_ok=1
+	local iface=""
+	local iface_count=0
+
+	for iface in /sys/class/net/*; do
+		iface=${iface##*/}
+		[[ "$iface" == "lo" ]] && continue
+		iface_count=$((iface_count + 1))
+		configure_recovery_interface "$iface" && net_ok=0
+	done
+
+	if [[ $iface_count -eq 0 ]]; then
+		print_warning "No non-loopback network interfaces detected in recovery"
+	fi
+
+	if [[ $net_ok -ne 0 ]]; then
+		print_warning "No recovery interface obtained an IPv4 address"
+	fi
+
+	start_recovery_ssh_server || true
+}
+
 prompt_user()
 {
 	local question="$1"

--- a/recipes-core/packagegroups/packagegroup-ni-restoremode.bb
+++ b/recipes-core/packagegroups/packagegroup-ni-restoremode.bb
@@ -8,6 +8,7 @@ inherit packagegroup
 RDEPENDS:${PN} += "\
 	base-passwd \
 	bash \
+	busybox \
 	bzip2 \
 	coreutils \
 	dosfstools \
@@ -22,6 +23,8 @@ RDEPENDS:${PN} += "\
 	init-restore-mode \
 	kmod \
 	ni-systemreplication \
+	openssh-keygen \
+	openssh-sshd \
 	parted \
 	procps \
 	sed \
@@ -49,6 +52,15 @@ RDEPENDS:${PN}:append:xilinx-zynq = "\
 	"
 
 RRECOMMENDS:${PN}:x64 = "\
+	kernel-module-e1000 \
+	kernel-module-e1000e \
+	kernel-module-i40e \
+	kernel-module-igb \
+	kernel-module-igc \
+	kernel-module-ixgbe \
+	kernel-module-tg3 \
+	kernel-module-virtio-net \
+	kernel-module-virtio-pci \
 	kernel-module-atkbd \
 	kernel-module-hyperv-keyboard \
 	kernel-module-hv-storvsc \


### PR DESCRIPTION
### Summary of Changes

Enable provisioning over SSH in recovery mode as a foundation for future network provisioning workflows.

This change adds ni-restore-provisioning.init and updates init-restore-mode.sh to invoke it after the early recovery setup. The new init script brings up the recovery services needed by provisioning using sysv-style init scripts: udev, networking, and sshd, then hands the console to /ni_provisioning.

Update the init-restore-mode recipe to install the new recovery init script, and adjust the recovery packagegroup so the recovery image explicitly includes the userspace and kernel-support packages required by the direct init-script flow, including initscripts, init-ifupdown, iproute2, ni-hw-scripts, ni-utils, busybox, openssh-keygen, openssh-sshd, udev-extraconf, and packagegroup-kernel-modules-essential. The previous x64 kernel-module recommendations are removed in favor of these explicit recovery dependencies.

Also fix safemode provisioning to unmount existing target-disk partitions before repartitioning. Recovery udev startup can auto-mount target partitions, and the previous cleanup only matched sdX-style partition names. Switch to lsblk-based child partition unmounting so NVMe-backed PXI targets are handled correctly.

### Justification

[AB#4044677](https://dev.azure.com/ni/DevCentral/_workitems/edit/4044677/)


### Testing

* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] `bitbake nilrt-recovery-media`
* [x] Tested the provisioning on both VM and controllers (cRIO-9030 and PXIe 8881) and verified the recovery partition gets an available IPv4 address and has SSH enabled. The system at recovery state was accessible from a remote host.
<img width="800" height="317" alt="image" src="https://github.com/user-attachments/assets/1450ad5f-3351-4c98-924c-fb0adc5f0ad4" />
<img width="2048" height="1536" alt="image" src="https://github.com/user-attachments/assets/649bafcf-a073-4937-aaf4-b9a511066c92" />


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
