### PR TITLE
nilrt-proprietary: update common pkg and remove duplicates

### DIFF
--- a/recipes-core/images/includes/nilrt-proprietary.inc
+++ b/recipes-core/images/includes/nilrt-proprietary.inc
@@ -32,7 +32,6 @@ NI_PROPRIETARY_COMMON_PACKAGES = "\
 
 NI_PROPRIETARY_COMMON_PACKAGES:append:x64 = "\
         ni-sdmon \
-        ni-wifibledd \
 "
 
 NI_PROPRIETARY_RUNMODE_PACKAGES = "\

--- a/recipes-core/images/includes/nilrt-proprietary.inc
+++ b/recipes-core/images/includes/nilrt-proprietary.inc
@@ -27,12 +27,12 @@ NI_PROPRIETARY_COMMON_PACKAGES = "\
         nicurl \
         nirtcfg \
         nirtmdnsd \
+        ni-sysapi-sshcli \
 "
 
 NI_PROPRIETARY_COMMON_PACKAGES:append:x64 = "\
         ni-sdmon \
         ni-wifibledd \
-        ni-sysapi-sshcli \
 "
 
 NI_PROPRIETARY_RUNMODE_PACKAGES = "\


### PR DESCRIPTION
### Summary of Changes

-Include ni-sysapi-sshcli in NI_PROPRIETARY_COMMON_PACKAGES to ensure it is available on both x64 and ARM architectures in NILRT images.
-removed duplicate ni-wifibledd pkg

### Justification

 [AB#4054988](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/4054988)

### Testing

* [x] bitbake nilrt-base-system-image
<img width="681" height="73" alt="image" src="https://github.com/user-attachments/assets/6885ef44-579b-4169-9ccb-09042e2e146e" />


### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
