### PR TITLE
ni-cgroups: select cgroup version based on kernel release

### DIFF
--- a/recipes-ni/ni-cgroups/files/ni-cgroups
+++ b/recipes-ni/ni-cgroups/files/ni-cgroups
@@ -10,14 +10,11 @@
 
 identify_lvrt_cgroup_version()
 {
-	# We only support cgroups v1 on ARM for now
-	local cpu_arch
-	cpu_arch="$(uname -m)"
-	case "$cpu_arch" in
-		arm*|aarch64)
-			echo 1
-			return
-			;;
+	# Linux 4.14 requires cgroups v1
+	local kernel_version
+	kernel_version="$(uname -r)"
+	case "$kernel_version" in
+		4.14.*) echo 1; return ;;
 	esac
 
 	local lvrt_installed


### PR DESCRIPTION
Use cgroups v1 only on Linux 4.14 kernels. Allow newer ARM kernels, to use the existing LabVIEW-version selectio logic instead of forcing cgroups v1 based on CPU architecture.

WI: [AB#4059014](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/4059014)

### Testing

* [x] Verified logic works on 4.14 ARM, 6.18 ARM, 6.18 x64 targets.
* [x] Verified script works on sbRIO-9607 with 6.18 kernel and selects cgroups v2 and that following errors are no longer present in dmesg.

> cp: cannot stat 'cpus': No such file or directory
cp: cannot stat 'mems': No such file or directory
cp: cannot stat 'cpus': No such file or directory
cp: cannot stat 'mems': No such file or directory
cp: cannot stat 'cpus': No such file or directory
cp: cannot stat 'mems': No such file or directory
/etc/init.d/ni-cgroups-v1: line 9: tasks: No such file or directory

* [x] Verified LV 2026 works on 6.18 ARM (tested with a simple add VI).
* [x] Verified script selects cgroups v1 on 6.18 ARM if LV 2025 is installed.

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
